### PR TITLE
Closes #37 - Automatically publish the package on PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,32 @@
+name: Upload Python Package
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel build
+
+    - name: Build distributable
+      run: |
+        python -m build
+
+    - name: Publish a Python distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The plugin is available as a Python package in pypi and can be installed with pi
 
 ### 1.1. Install package
 
-#### 1.1.1. Using pip (production use - [not working yet!](https://github.com/netdevopsbr/netbox-proxbox/issues/37))
+#### 1.1.1. Using pip (production use)
 
 Enter Netbox's virtual environment.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "netbox-proxbox"
 version = "0.0.4"
 description = "Netbox Plugin - Integrate Proxmox and Netbox"
+readme = "README.md"
 authors = ["Emerson Felipe <emerson.felipe@nmultifibra.com>"]
 license = "Apache-2.0"
 packages = [

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
     long_description_content_type="text/markdown",
     classifiers=[
         "Programming Language :: Python :: 3",
-	"Framework :: Django",
-	"Operating System :: Unix",
+        "Framework :: Django",
+        "Operating System :: Unix",
         "License :: OSI Approved :: Apache Software License",
     ],
     keywords="netbox netbox-plugin plugin proxmox proxmoxer pynetbox",


### PR DESCRIPTION
After considering installing the plugin and then reading the notice in the readme, and #37 afterwards, I thought that this will make life a little bit easier.

It requires you, @emersonfelipesp, to [create an API token](https://pypi.org/help/#apitoken) on PyPI scoped for the netbox-proxbox project, and [store it as a repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) called `PYPI_API_TOKEN`.

Once the secret is created every time you create a release in GitHub it will automatically build the package and upload it to PyPI.

I'll hope you'll find this useful and it saves you some time and effort.

---
PS: why does this help me? As I run my netbox in Kubernetes, installing plugins a little more involved. But as I'm lazy I'd rather have netbox-proxbox installable from pypi instead of manually building it in my netbox-extension-collecting container.