### PR TITLE
remove numpy and matplotlib - they do not seem to be in use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,6 @@ yamllint = "^1.26.1"
 [build-system]
 requires = [
     "poetry-core>=1.0.0",
-    "numpy",
-    "matplotlib",
     "requests",
     "pynetbox",
     "proxmoxer"

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,6 @@ github = 'https://github.com/N-Multifibra/netbox-proxbox'
 requires = [
     'poetry',
     'invoke',
-    'numpy',
-    'matplotlib',
     'requests>=2',
     'pynetbox>=5',
     'paramiko>=2',


### PR DESCRIPTION
This removes the requirements of numpy and matplotlib. Both libraries are not used directly in this module, and also searching the issues only returns #39, which simply lists the installed packages.

Why remove them? (besides the obvious "keep the dependencies lean")
While no current package is available on PyPI, I started to setup the package in my netbox-docker container the long way, which means installing it from git. But installing in the container [fails at installing matplotlib](https://github.com/klaernie/netbox-docker/runs/6524150783?check_suite_focus=true#step:6:446), as there is no `gcc` available in the base image (which is [the official netbox image](https://github.com/netbox-community/netbox-docker)).
So I wondered, considering the purpose of the project, what numpy and matplotlib could be used for, and I searched for the usage of the libraries.