### PR TITLE
Get Network information from Proxmox

### DIFF
--- a/netbox_proxbox/proxbox_api/update.py
+++ b/netbox_proxbox/proxbox_api/update.py
@@ -17,8 +17,6 @@ from . import (
     remove,
 )
 
-
-
 # Call all functions to update Virtual Machine
 def vm_full_update(netbox_vm, proxmox_vm):
     changes = {}
@@ -34,9 +32,8 @@ def vm_full_update(netbox_vm, proxmox_vm):
 
     # Update 'resources', like CPU, Memory and Disk, if necessary.
     resources_updated = updates.virtual_machine.resources(netbox_vm, proxmox_vm)
-
+    
     interfaces_updated = updates.virtual_machine.interfaces(netbox_vm, proxmox_vm)
-
     ips_updated = updates.virtual_machine.interfaces_ips(netbox_vm, proxmox_vm)
 
     tag_updated = updates.extras.tag(netbox_vm)
@@ -47,9 +44,9 @@ def vm_full_update(netbox_vm, proxmox_vm):
         "custom_fields" : custom_fields_updated,
         "local_context" : local_context_updated,
         "resources" : resources_updated,
+        "tag" : tag_updated,
         "interfaces": interfaces_updated,
-        "ips": ips_updated,
-        "tag" : tag_updated
+        "ips": ips_updated
     }
 
     return changes
@@ -61,7 +58,6 @@ def node_full_update(netbox_node, proxmox_json, proxmox_cluster):
 
     status_updated = updates.node.status(netbox_node, proxmox_json)
     cluster_updated = updates.node.cluster(netbox_node, proxmox_json, proxmox_cluster)
-
     interfaces_updated = updates.node.interfaces(netbox_node, proxmox_json)
 
     changes = {

--- a/netbox_proxbox/proxbox_api/update.py
+++ b/netbox_proxbox/proxbox_api/update.py
@@ -35,6 +35,10 @@ def vm_full_update(netbox_vm, proxmox_vm):
     # Update 'resources', like CPU, Memory and Disk, if necessary.
     resources_updated = updates.virtual_machine.resources(netbox_vm, proxmox_vm)
 
+    interfaces_updated = updates.virtual_machine.interfaces(netbox_vm, proxmox_vm)
+
+    ips_updated = updates.virtual_machine.interfaces_ips(netbox_vm, proxmox_vm)
+
     tag_updated = updates.extras.tag(netbox_vm)
 
     #changes = [custom_fields_updated, status_updated, local_context_updated, resources_updated]
@@ -43,6 +47,8 @@ def vm_full_update(netbox_vm, proxmox_vm):
         "custom_fields" : custom_fields_updated,
         "local_context" : local_context_updated,
         "resources" : resources_updated,
+        "interfaces": interfaces_updated,
+        "ips": ips_updated,
         "tag" : tag_updated
     }
 

--- a/netbox_proxbox/proxbox_api/update.py
+++ b/netbox_proxbox/proxbox_api/update.py
@@ -62,9 +62,12 @@ def node_full_update(netbox_node, proxmox_json, proxmox_cluster):
     status_updated = updates.node.status(netbox_node, proxmox_json)
     cluster_updated = updates.node.cluster(netbox_node, proxmox_json, proxmox_cluster)
 
+    interfaces_updated = updates.node.interfaces(netbox_node, proxmox_json)
+
     changes = {
         "status" : status_updated,
-        "cluster" : cluster_updated
+        "cluster" : cluster_updated,
+        "interfaces": interfaces_updated
     }
 
     return changes

--- a/netbox_proxbox/proxbox_api/updates/node.py
+++ b/netbox_proxbox/proxbox_api/updates/node.py
@@ -10,6 +10,10 @@ from ..plugins_config import (
     NETBOX_SESSION as nb,
 )
 
+from .. import (
+    create,
+)
+
 # Update STATUS field on /dcim/device/{id}
 def status(netbox_node, proxmox_node):
     #
@@ -90,7 +94,6 @@ def cluster(netbox_node, proxmox_node, proxmox_cluster):
         cluster_updated = False
 
     return cluster_updated
-
 
 def interfaces(netbox_node, proxmox_json):
     updated = False

--- a/netbox_proxbox/proxbox_api/updates/node.py
+++ b/netbox_proxbox/proxbox_api/updates/node.py
@@ -1,5 +1,13 @@
-from .. import (
-    create,
+from ..plugins_config import (
+    PROXMOX,
+    PROXMOX_PORT,
+    PROXMOX_USER,
+    PROXMOX_PASSWORD,
+    PROXMOX_SSL,
+    NETBOX,
+    NETBOX_TOKEN,
+    PROXMOX_SESSION as proxmox,
+    NETBOX_SESSION as nb,
 )
 
 # Update STATUS field on /dcim/device/{id}

--- a/netbox_proxbox/proxbox_api/updates/node.py
+++ b/netbox_proxbox/proxbox_api/updates/node.py
@@ -82,3 +82,131 @@ def cluster(netbox_node, proxmox_node, proxmox_cluster):
         cluster_updated = False
 
     return cluster_updated
+
+
+def interfaces(netbox_node, proxmox_json):
+    updated = False
+    _int_port = ['OVSIntPort']
+    _lag_port = ['OVSBond']
+    _brg_port = ['OVSBridge']
+    _pmx_iface = []
+    _ntb_iface = [{'name': iface.name, 'mtu' : int(iface.mtu), 'tagged_vlans': [int(x['vid']) for x in iface.tagged_vlans]} for iface in nb.dcim.interfaces.filter(device_id=netbox_node.id)]
+    _eth =  [iface for iface in proxmox.nodes(proxmox_json['name']).network.get() if iface['type'] == 'eth']
+    _virt = [iface for iface in proxmox.nodes(proxmox_json['name']).network.get() if iface['type'] in _int_port]
+    _bond = [iface for iface in proxmox.nodes(proxmox_json['name']).network.get() if iface['type'] in _lag_port]
+    _bridge = [iface for iface in proxmox.nodes(proxmox_json['name']).network.get() if iface['type'] in _brg_port]
+
+    for iface in _eth:
+        ntb_iface = list(nb.dcim.interfaces.filter(device_id=netbox_node.id, name=iface['iface']))
+        if iface.get('ovs_tag') is not None:
+            _tagged_vlans = [int(iface.get('ovs_tag'))]
+        else:
+            _tagged_vlans = []
+        _pmx_iface.append({'name': iface['iface'], 'mtu' : int(iface.get('mtu', 1500)), 'tagged_vlans': _tagged_vlans})
+        pmx_if = next((_if for _if in _pmx_iface if _if['name'] == iface['iface']), None)
+        if not len(ntb_iface):
+            if len(_tagged_vlans):
+                ntb_iface = nb.dcim.interfaces.create(device=netbox_node.id, name=pmx_if['name'], type='other', mtu=pmx_if['mtu'], mode='tagged', tagged_vlans=[nb.ipam.vlans.get(vid=_tagged_vlans[0]).id])
+            else:
+                ntb_iface = nb.dcim.interfaces.create(device=netbox_node.id, name=pmx_if['name'], type='other', mtu=pmx_if['mtu'])
+            updated = True
+        else:
+            if len(ntb_iface) == 1:
+                ntb_iface = ntb_iface[0]
+                ntb_if = next((_if for _if in _ntb_iface if _if['name'] == iface['iface']), None)
+                if pmx_if != ntb_if:
+                    if len(pmx_if['tagged_vlans']):
+                        nb.dcim.interfaces.update([{'id': ntb_iface.id, 'mtu': pmx_if['mtu'], 'mode': 'tagged', 'tagged_vlans': [nb.ipam.vlans.get(vid=_tagged_vlans[0]).id]}])
+                    else:
+                        nb.dcim.interfaces.update([{'id': ntb_iface.id, 'mtu': pmx_if['mtu']}])
+                    updated = True
+
+    for iface in _bond:
+        ntb_iface = list(nb.dcim.interfaces.filter(device_id=netbox_node.id, name=iface['iface']))
+        if iface.get('ovs_tag') is not None:
+            _tagged_vlans = [int(iface.get('ovs_tag'))]
+        else:
+            _tagged_vlans = []
+        _pmx_iface.append({'name': iface['iface'], 'mtu' : int(iface.get('mtu', 1500)), 'tagged_vlans': _tagged_vlans})
+        if not len(ntb_iface):
+            if len(_tagged_vlans):
+                ntb_iface = nb.dcim.interfaces.create(device=netbox_node.id, name=iface['iface'], type='lag', mtu=int(iface.get('mtu', 1500)), mode='tagged', tagged_vlans=[nb.ipam.vlans.get(vid=_tagged_vlans[0]).id])
+            else:
+                ntb_iface = nb.dcim.interfaces.create(device=netbox_node.id, name=iface['iface'], type='lag', mtu=int(iface.get('mtu', 1500)))
+        else:
+            if len(ntb_iface) == 1:
+                ntb_iface = ntb_iface[0]
+                pmx_if = next((_if for _if in _pmx_iface if _if['name'] == iface['iface']), None)
+                ntb_if = next((_if for _if in _ntb_iface if _if['name'] == iface['iface']), None)
+                if pmx_if != ntb_if:
+                    if len(pmx_if['tagged_vlans']):
+                        nb.dcim.interfaces.update([{'id': ntb_iface.id, 'mtu': pmx_if['mtu'], 'mode': 'tagged', 'tagged_vlans': [nb.ipam.vlans.get(vid=_tagged_vlans[0]).id]}])
+                    else:
+                        nb.dcim.interfaces.update([{'id': ntb_iface.id, 'mtu': pmx_if['mtu']}])
+                    updated = True
+        if 'ovs_bonds' in iface:
+            for _sif in iface['ovs_bonds'].split(' '):
+                _nb_iface = list(nb.dcim.interfaces.filter(device_id=netbox_node.id, name=_sif))
+                if len(_nb_iface) == 1:
+                    nb.dcim.interfaces.update([{'id': _nb_iface[0].id, 'lag': {'id': ntb_iface.id}}])
+
+    for iface in _virt:
+        ntb_iface = list(nb.dcim.interfaces.filter(device_id=netbox_node.id, name=iface['iface']))
+        if iface.get('ovs_tag') is not None:
+            _tagged_vlans = [int(iface.get('ovs_tag'))]
+        else:
+            _tagged_vlans = []
+        _pmx_iface.append({'name': iface['iface'], 'mtu' : int(iface.get('mtu', 1500)), 'tagged_vlans': _tagged_vlans})
+        if not len(ntb_iface):
+            if len(_tagged_vlans):
+                ntb_iface = nb.dcim.interfaces.create(device=netbox_node.id, name=iface['iface'], type='virtual', mtu=int(iface.get('mtu', 1500)), mode='tagged', tagged_vlans=[nb.ipam.vlans.get(vid=_tagged_vlans[0]).id])
+            else:
+                ntb_iface = nb.dcim.interfaces.create(device=netbox_node.id, name=iface['iface'], type='virtual', mtu=int(iface.get('mtu', 1500)))
+        else:
+            if len(ntb_iface) == 1:
+                ntb_iface = ntb_iface[0]
+                pmx_if = next((_if for _if in _pmx_iface if _if['name'] == iface['iface']), None)
+                ntb_if = next((_if for _if in _ntb_iface if _if['name'] == iface['iface']), None)
+                if pmx_if != ntb_if:
+                    if len(pmx_if['tagged_vlans']):
+                        nb.dcim.interfaces.update([{'id': ntb_iface.id, 'mtu': pmx_if['mtu'], 'mode': 'tagged', 'tagged_vlans': [nb.ipam.vlans.get(vid=_tagged_vlans[0]).id]}])
+                    else:
+                        nb.dcim.interfaces.update([{'id': ntb_iface.id, 'mtu': pmx_if['mtu']}])
+                    updated = True
+
+    for iface in _bridge:
+        ntb_iface = list(nb.dcim.interfaces.filter(device_id=netbox_node.id, name=iface['iface']))
+        if iface.get('ovs_tag') is not None:
+            _tagged_vlans = [int(iface.get('ovs_tag'))]
+        else:
+            _tagged_vlans = []
+        _pmx_iface.append({'name': iface['iface'], 'mtu' : int(iface.get('mtu', 1500)), 'tagged_vlans': _tagged_vlans})
+        if not len(ntb_iface):
+            if len(_tagged_vlans):
+                ntb_iface = nb.dcim.interfaces.create(device=netbox_node.id, name=iface['iface'], type='bridge', mtu=int(iface.get('mtu', 1500)), mode='tagged', tagged_vlans=[nb.ipam.vlans.get(vid=_tagged_vlans[0]).id])
+            else:
+                ntb_iface = nb.dcim.interfaces.create(device=netbox_node.id, name=iface['iface'], type='bridge', mtu=int(iface.get('mtu', 1500)))
+        else:
+            if len(ntb_iface) == 1:
+                ntb_iface = ntb_iface[0]
+                pmx_if = next((_if for _if in _pmx_iface if _if['name'] == iface['iface']), None)
+                ntb_if = next((_if for _if in _ntb_iface if _if['name'] == iface['iface']), None)
+                if pmx_if != ntb_if:
+                    if len(pmx_if['tagged_vlans']):
+                        nb.dcim.interfaces.update([{'id': ntb_iface.id, 'mtu': pmx_if['mtu'], 'mode': 'tagged', 'tagged_vlans': [nb.ipam.vlans.get(vid=_tagged_vlans[0]).id]}])
+                    else:
+                        nb.dcim.interfaces.update([{'id': ntb_iface.id, 'mtu': pmx_if['mtu']}])
+                    updated = True
+        if 'ovs_ports' in iface:
+            for _sif in iface['ovs_ports'].split(' '):
+                _nb_iface = list(nb.dcim.interfaces.filter(device_id=netbox_node.id, name=_sif))
+                if len(_nb_iface) == 1:
+                    nb.dcim.interfaces.update([{'id': _nb_iface[0].id, 'bridge': {'id': ntb_iface.id}}])
+
+    for iface in [x.get('name') for x in _ntb_iface]:
+        if iface not in [x.get('name') for x in _pmx_iface]:
+            ntb_iface = list(nb.dcim.interfaces.filter(device_id=netbox_node.id, name=iface['name']))
+            if len(ntb_iface) == 1:
+                ntb_iface[0].delete()
+
+    return updated

--- a/netbox_proxbox/proxbox_api/updates/virtual_machine.py
+++ b/netbox_proxbox/proxbox_api/updates/virtual_machine.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import re
 
 # PLUGIN_CONFIG variables
 from ..plugins_config import (
@@ -17,6 +18,9 @@ from ..plugins_config import (
 from .. import (
     create,
 )
+
+from proxmoxer.core import ResourceException
+
 
 # Update "status" field on Netbox Virtual Machine based on Proxmox information
 def status(netbox_vm, proxmox_vm):
@@ -56,6 +60,7 @@ def status(netbox_vm, proxmox_vm):
         status_updated = False
     
     return status_updated
+
 
 
 def site(**kwargs):
@@ -98,6 +103,7 @@ def http_update_custom_fields(**kwargs):
 
     # Return HTTP Status Code
     return r.status_code
+
 
 
 # Update 'custom_fields' field on Netbox Virtual Machine based on Proxbox
@@ -213,6 +219,11 @@ def local_context_data(netbox_vm, proxmox_vm):
     return False
 
 
+
+
+
+
+
 # Updates following fields based on Proxmox: "vcpus", "memory", "disk", if necessary.
 def resources(netbox_vm, proxmox_vm):
     # Save values from Proxmox
@@ -228,6 +239,8 @@ def resources(netbox_vm, proxmox_vm):
 
     # JSON with new resources info
     new_resources_json = {}
+
+    
     
     # Compare VCPU
     if netbox_vm.vcpus != None:
@@ -240,6 +253,8 @@ def resources(netbox_vm, proxmox_vm):
     elif netbox_vm.vcpus == None:
         new_resources_json["vcpus"] = vcpus
 
+
+
     # Compare Memory
     if netbox_vm.memory != None:
         if netbox_vm.memory != memory_Mb:
@@ -248,6 +263,8 @@ def resources(netbox_vm, proxmox_vm):
     elif netbox_vm.memory == None:
         new_resources_json["memory"] = memory_Mb
 
+
+
     # Compare Disk
     if netbox_vm.disk != None:
         if netbox_vm.disk != disk_Gb:
@@ -255,6 +272,8 @@ def resources(netbox_vm, proxmox_vm):
 
     elif netbox_vm.disk == None:
         new_resources_json["disk"] = disk_Gb
+    
+    
 
     # If new information found, save it to Netbox object.
     if len(new_resources_json) > 0:
@@ -264,7 +283,6 @@ def resources(netbox_vm, proxmox_vm):
             return True
         else:
             return False
-
 
 def interfaces(netbox_vm, proxmox_vm):
     updated = False
@@ -340,7 +358,6 @@ def interfaces(netbox_vm, proxmox_vm):
                 print('[ERROR] something went wrong while getting interface config from netbox')
                 return False
     return updated
-
 
 def interfaces_ips(netbox_vm, proxmox_vm):
     updated = False

--- a/netbox_proxbox/proxbox_api/updates/virtual_machine.py
+++ b/netbox_proxbox/proxbox_api/updates/virtual_machine.py
@@ -283,12 +283,20 @@ def interfaces(netbox_vm, proxmox_vm):
             _mac_addr = ''
             _mtu = 1500
             _vlan = None
+            _bridge = None
             for _conf_str in interface[ifname].split(','):
                 _k_s =_conf_str.split('=')
                 if re.match("[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$", _k_s[1].lower()):
                     _mac_addr =_k_s[1].lower()
+                elif _k_s[0] == 'bridge':
+                    _bridge = _k_s[1].lower()
                 elif _k_s[0] == 'mtu':
-                    if int(_k_s[1]) > 1:
+                    if int(_k_s[1]) == 1:
+                        if _bridge is not None:
+                            node = nb.dcim.devices.get(name=proxmox_vm['node'])
+                            brg = nb.dcim.interfaces.get(device_id=node.id, name=_bridge)
+                            _mtu = brg.mtu
+                    else:
                         _mtu = int(_k_s[1])
                 elif _k_s[0] == 'tag':
                     _vlan = int(_k_s[1])


### PR DESCRIPTION
- sync proxmox's interfaces in netbox (only for openvswitch for now, we don't use linux bridges)
- sync qemu and lxc interfaces in netbox
- if qemu vm is running and have qemu-guest-agent running, we get it's ip and sync it in netbox
- if lxc container is running and have static ips in config, sync it in netbox
- we use netbox ipam and dcim objects

Should be the first step for #51 #52 