### PR TITLE
fix 

### DIFF
--- a/netbox_proxbox/proxbox_api/updates/virtual_machine.py
+++ b/netbox_proxbox/proxbox_api/updates/virtual_machine.py
@@ -481,3 +481,4 @@ def interfaces_ips(netbox_vm, proxmox_vm):
                         else:
                             print('[ERROR] something went wrong while getting ip object from netbox')
     return updated
+#

--- a/netbox_proxbox/proxbox_api/updates/virtual_machine.py
+++ b/netbox_proxbox/proxbox_api/updates/virtual_machine.py
@@ -324,7 +324,7 @@ def interfaces(netbox_vm, proxmox_vm):
             _pmx_if.append({'name': ifname, 'mac_address': _mac_addr, 'mtu': _mtu})
 
     for interface in nb.virtualization.interfaces.filter(virtual_machine_id=netbox_vm.id):
-        _ntb_if.append({'name': interface.name, 'mac_address': interface.mac_address.lower(), 'mtu': interface.mtu})
+        _ntb_if.append({'name': interface.name, 'mac_address': interface.mac_address, 'mtu': interface.mtu})
 
     for pmx_if_mac in [_if['mac_address'] for _if in _pmx_if]:
         pmx_if = next((_if for _if in _pmx_if if _if['mac_address'] == pmx_if_mac), None)

--- a/netbox_proxbox/proxbox_api/updates/virtual_machine.py
+++ b/netbox_proxbox/proxbox_api/updates/virtual_machine.py
@@ -331,16 +331,16 @@ def interfaces(netbox_vm, proxmox_vm):
         if pmx_if is not None:
             if pmx_if_mac not in [_if['mac_address'] for _if in _ntb_if]:
                 try:
-                    if nb.virtualization.interfaces.get(virtual_machine_id=netbox_vm.id, name=pmx_if['name']):
+                    if nb.virtualization.interfaces.get(virtual_machine_id=netbox_vm.id, virtual_machine=netbox_vm.name, name=pmx_if['name']):
                         print("Interface already exist.")
                     else:
                         # Create interface if does not exist.
-                        netbox_interface = nb.virtualization.interfaces.create(virtual_machine_id=netbox_vm.id, name=pmx_if['name'], mac_address=pmx_if_mac, mtu=pmx_if['mtu'])
+                        netbox_interface = nb.virtualization.interfaces.create(virtual_machine_id=netbox_vm.id, virtual_machine=netbox_vm.name, name=pmx_if['name'], mac_address=pmx_if_mac, mtu=pmx_if['mtu'])
                         updated = True
                 except Exception as error: print(error)
             else:
                 if pmx_if not in _ntb_if:
-                    netbox_interface = list(nb.virtualization.interfaces.filter(virtual_machine_id=netbox_vm.id, mac_address=pmx_if_mac))
+                    netbox_interface = list(nb.virtualization.interfaces.filter(virtual_machine_id=netbox_vm.id, virtual_machine=netbox_vm.name, mac_address=pmx_if_mac))
                     if len(netbox_interface) == 1:
                         netbox_interface = netbox_interface[0]
                         netbox_interface = nb.virtualization.interfaces.update([{'id': netbox_interface.id, 'name': pmx_if['name'], 'mac_address': pmx_if_mac, 'mtu': pmx_if['mtu']}])

--- a/netbox_proxbox/proxbox_api/updates/virtual_machine.py
+++ b/netbox_proxbox/proxbox_api/updates/virtual_machine.py
@@ -331,11 +331,11 @@ def interfaces(netbox_vm, proxmox_vm):
         if pmx_if is not None:
             if pmx_if_mac not in [_if['mac_address'] for _if in _ntb_if]:
                 try:
-                    if nb.virtualization.interfaces.get(virtual_machine=netbox_vm.id, name=pmx_if['name']):
+                    if nb.virtualization.interfaces.get(virtual_machine_id=netbox_vm.id, name=pmx_if['name']):
                         print("Interface already exist.")
                     else:
                         # Create interface if does not exist.
-                        netbox_interface = nb.virtualization.interfaces.create(virtual_machine=netbox_vm.id, name=pmx_if['name'], mac_address=pmx_if_mac, mtu=pmx_if['mtu'])
+                        netbox_interface = nb.virtualization.interfaces.create(virtual_machine_id=netbox_vm.id, name=pmx_if['name'], mac_address=pmx_if_mac, mtu=pmx_if['mtu'])
                         updated = True
                 except Exception as error: print(error)
             else:

--- a/netbox_proxbox/proxbox_api/updates/virtual_machine.py
+++ b/netbox_proxbox/proxbox_api/updates/virtual_machine.py
@@ -335,12 +335,12 @@ def interfaces(netbox_vm, proxmox_vm):
                         print("Interface already exist.")
                     else:
                         # Create interface if does not exist.
-                        netbox_interface = nb.virtualization.interfaces.create(virtual_machine_id=netbox_vm.id, virtual_machine=netbox_vm.name, name=pmx_if['name'], mac_address=pmx_if_mac, mtu=pmx_if['mtu'])
+                        netbox_interface = nb.virtualization.interfaces.create(virtual_machine_id=netbox_vm.id, virtual_machine=netbox_vm.id, name=pmx_if['name'], mac_address=pmx_if_mac, mtu=pmx_if['mtu'])
                         updated = True
                 except Exception as error: print(error)
             else:
                 if pmx_if not in _ntb_if:
-                    netbox_interface = list(nb.virtualization.interfaces.filter(virtual_machine_id=netbox_vm.id, virtual_machine=netbox_vm.name, mac_address=pmx_if_mac))
+                    netbox_interface = list(nb.virtualization.interfaces.filter(virtual_machine_id=netbox_vm.id, virtual_machine=netbox_vm.id, mac_address=pmx_if_mac))
                     if len(netbox_interface) == 1:
                         netbox_interface = netbox_interface[0]
                         netbox_interface = nb.virtualization.interfaces.update([{'id': netbox_interface.id, 'name': pmx_if['name'], 'mac_address': pmx_if_mac, 'mtu': pmx_if['mtu']}])
@@ -481,4 +481,3 @@ def interfaces_ips(netbox_vm, proxmox_vm):
                         else:
                             print('[ERROR] something went wrong while getting ip object from netbox')
     return updated
-#


### PR DESCRIPTION
Hello,
I have corrected these errors:

```
"GET /api/virtualization/interfaces/?virtual_machine=6&name=net0&limit=0 HTTP/1.1" 400 85 "-" "python-requests/2.28.2"
The request failed with code 400 Bad Request: {'virtual_machine': ['Select a valid choice. 6 is not one of the available choices.']}

File "/opt/netbox/venv/lib/python3.10/site-packages/netbox_proxbox/proxbox_api/updates/virtual_machine.py", line 327, in interfaces
    _ntb_if.append({'name': interface.name, 'mac_address': interface.mac_address.lower(), 'mtu': interface.mtu})
AttributeError: 'NoneType' object has no attribute 'lower'
```
for the second error I just deleted the lower.
To improve it would be necessary to see to convert the mac in strings if it is really necessary.
