### PR TITLE
Fixed the mgmt_only and proxmox_keep_interface bool logic

### DIFF
--- a/netbox_proxbox/proxbox_api/updates/node.py
+++ b/netbox_proxbox/proxbox_api/updates/node.py
@@ -229,7 +229,7 @@ def interfaces(netbox_node, proxmox_json):
         if iface not in [x.get('name') for x in _pmx_iface]:
             ntb_iface = list(nb.dcim.interfaces.filter(device_id=netbox_node.id, name=iface))
             if len(ntb_iface) == 1:
-                if not ntb_iface[0].mgmt_only or not ntb_iface[0].custom_fields.get('proxmox_keep_interface', False):
+                if not ntb_iface[0].mgmt_only and not ntb_iface[0].custom_fields.get('proxmox_keep_interface', False):
                     ntb_iface[0].delete()
 
     return updated


### PR DESCRIPTION
Fixed the change @MrBE4R made yesterday by adding the proxmox_keep_interface Custom Field.

The `or` in the if statement that compared the mgmt_only value and the proxmox_keep_interface custom field should have been an `and` to keep the interface in both cases and delete it if neither are true.