### PR TITLE
small readme.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <div>
 
-### [New Documentation available!](http://proxbox.netbox.dev.br/)
+### [New Documentation available!](https://proxbox.netbox.dev.br/introduction/)
 </div>
 <br>
 </div>

--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ PLUGINS_CONFIG = {
                 'node_role_id' : 0,
                 'site_id': 0
             }
-      }
- }
+        }
+    }
+}
 ```
 
 


### PR DESCRIPTION
the documentation link resulted in a 404, and the plugin config code example was missing a }, resulting in
```
PLUGINS_CONFIG = {
                     ^
SyntaxError: '{' was never closed
```
when executing `python3 manage.py migrate`