### PR TITLE
base_path for netbox api requests

### DIFF
--- a/netbox_proxbox/proxbox_api/virtual_machine.py
+++ b/netbox_proxbox/proxbox_api/virtual_machine.py
@@ -14,6 +14,8 @@ from .create.virtualization import (
     cluster
 )
 
+from netbox.settings import BASE_PATH
+
 import logging
 
 #
@@ -142,7 +144,7 @@ class VirtualMachine:
         # HTTP PATCH Request (partially update)
         #
         # URL 
-        url = '{}/api/virtualization/virtual-machines/{}/'.format(domain_with_http, vm_id)
+        url = '{}{}/api/virtualization/virtual-machines/{}/'.format(domain_with_http, BASE_PATH, vm_id)
         
         # HTTP Request Headers
         headers = {


### PR DESCRIPTION
Now proxbox makes requests to netbox api without honour of BASE_URL of netbox. That PR resolves that.