### PR TITLE
docs: fix table of contents link

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The plugin is available as a Python package in pypi and can be installed with pi
 
 ### 1.1. Install package
 
-#### 1.1.1. Using pip (production use)
+#### 1.1.1. Using pip (production use) - not working yet
 
 Enter Netbox's virtual environment.
 ```


### PR DESCRIPTION
The table of contents includes a reference to an anchor that doesn't exist.

This fixes the anchor and has the side effect of making it clear to readers the pip method does not work now.