### PR TITLE
feat: add Backend Logs page to plugin

### DIFF
--- a/netbox_proxbox/navigation.py
+++ b/netbox_proxbox/navigation.py
@@ -60,6 +60,11 @@ sync_jobs_item = PluginMenuItem(
     link_text="Sync Jobs",
 )
 
+backend_logs_item = PluginMenuItem(
+    link="plugins:netbox_proxbox:backend_logs",
+    link_text="Backend Logs",
+)
+
 settings_item = PluginMenuItem(
     link="plugins:netbox_proxbox:settings",
     link_text="Settings",
@@ -173,6 +178,7 @@ menu = PluginMenu(
                 task_history_item,
                 schedule_sync_item,
                 sync_jobs_item,
+                backend_logs_item,
                 settings_item,
             ),
         ),

--- a/netbox_proxbox/static/netbox_proxbox/js/logs.js
+++ b/netbox_proxbox/static/netbox_proxbox/js/logs.js
@@ -1,0 +1,442 @@
+/**
+ * Backend Logs page JavaScript
+ * Handles fetching, filtering, and displaying logs from the proxbox-api backend.
+ */
+
+class LogsPage {
+    constructor() {
+        this.config = window.proxboxLogsConfig || {};
+        this.logsApiUrl = this.config.logsApiUrl || "";
+        this.cachedLogs = [];
+        this.allLogs = [];
+        this.currentLevel = "";
+        this.currentOperationId = "";
+        this.autoRefreshInterval = 5000;
+        this.autoRefreshTimer = null;
+        this.isAutoRefreshEnabled = true;
+        this.currentOffset = 0;
+        this.limit = 200;
+        this.total = 0;
+        this.isLoading = false;
+
+        this.init();
+    }
+
+    init() {
+        this.bindEvents();
+        this.fetchLogs();
+    }
+
+    bindEvents() {
+        const refreshBtn = document.getElementById("refreshBtn");
+        const autoRefreshToggle = document.getElementById("autoRefreshToggle");
+        const levelFilter = document.getElementById("levelFilter");
+        const operationIdFilter = document.getElementById("operationIdFilter");
+        const clearFiltersBtn = document.getElementById("clearFiltersBtn");
+        const loadMoreBtn = document.getElementById("loadMoreBtn");
+
+        if (refreshBtn) {
+            refreshBtn.addEventListener("click", () => this.fetchLogs());
+        }
+
+        if (autoRefreshToggle) {
+            autoRefreshToggle.addEventListener("change", (e) => {
+                this.isAutoRefreshEnabled = e.target.checked;
+                if (this.isAutoRefreshEnabled) {
+                    this.startAutoRefresh();
+                } else {
+                    this.stopAutoRefresh();
+                }
+            });
+        }
+
+        if (levelFilter) {
+            levelFilter.addEventListener("change", (e) => {
+                this.currentLevel = e.target.value;
+                this.applyFilters();
+            });
+        }
+
+        if (operationIdFilter) {
+            operationIdFilter.addEventListener("input", (e) => {
+                this.currentOperationId = e.target.value.trim();
+                this.applyFilters();
+            });
+        }
+
+        if (clearFiltersBtn) {
+            clearFiltersBtn.addEventListener("click", () => this.clearFilters());
+        }
+
+        if (loadMoreBtn) {
+            loadMoreBtn.addEventListener("click", () => this.loadMore());
+        }
+    }
+
+    async fetchLogs() {
+        if (this.isLoading) return;
+        if (!this.logsApiUrl) {
+            this.showError("Logs API URL not configured");
+            return;
+        }
+
+        this.isLoading = true;
+        this.showLoading();
+
+        try {
+            const params = new URLSearchParams();
+            if (this.currentLevel) {
+                params.append("level", this.currentLevel);
+            }
+            params.append("limit", this.limit.toString());
+
+            const url = `${this.logsApiUrl}?${params.toString()}`;
+            const response = await fetch(url, {
+                headers: {
+                    Accept: "application/json",
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+
+            const data = await response.json();
+            this.allLogs = data.logs || [];
+            this.total = data.total || this.allLogs.length;
+            this.currentOffset = this.allLogs.length;
+
+            this.applyFilters();
+
+            this.updateLogCount();
+            this.updateFilterIndicator(data.active_filters);
+
+            if (this.allLogs.length < this.total) {
+                this.showLoadMore();
+            } else {
+                this.hideLoadMore();
+            }
+
+            if (this.isAutoRefreshEnabled) {
+                this.startAutoRefresh();
+            }
+        } catch (error) {
+            console.error("Failed to fetch logs:", error);
+            this.showError(error.message || "Failed to fetch logs");
+        } finally {
+            this.isLoading = false;
+            this.hideLoading();
+        }
+    }
+
+    applyFilters() {
+        this.cachedLogs = this.allLogs.filter((log) => {
+            if (this.currentLevel) {
+                const logLevel = this.getLogLevelPriority(log.level);
+                const filterLevel = this.getLogLevelPriority(this.currentLevel);
+                if (logLevel < filterLevel) return false;
+            }
+
+            if (this.currentOperationId) {
+                if (!log.operation_id || !log.operation_id.includes(this.currentOperationId)) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
+        this.renderLogs();
+        this.updateFilterIndicator();
+    }
+
+    getLogLevelPriority(level) {
+        const priorities = {
+            DEBUG: 0,
+            INFO: 1,
+            WARNING: 2,
+            ERROR: 3,
+            CRITICAL: 4,
+        };
+        return priorities[level] ?? 0;
+    }
+
+    renderLogs() {
+        const tbody = document.getElementById("logsTableBody");
+        const noLogsMessage = document.getElementById("noLogsMessage");
+        const template = document.getElementById("logRowTemplate");
+
+        if (!tbody) return;
+
+        tbody.innerHTML = "";
+
+        if (this.cachedLogs.length === 0) {
+            this.hideLoadMore();
+            noLogsMessage.style.display = "block";
+            return;
+        }
+
+        noLogsMessage.style.display = "none";
+
+        this.cachedLogs.forEach((log, index) => {
+            const row = document.createElement("tr");
+            row.className = `log-entry log-level-${log.level.toLowerCase()}`;
+            if (log.expandable) {
+                row.classList.add(" expandable");
+                row.dataset.expanded = "false";
+            }
+
+            row.innerHTML = `
+                <td class="log-timestamp">${this.formatTimestamp(log.timestamp)}</td>
+                <td class="log-level">
+                    <span class="badge bg-${this.getLevelBadgeColor(log.level)}">${log.level}</span>
+                </td>
+                <td class="log-module">${this.escapeHtml(log.module)}</td>
+                <td class="log-message">
+                    <span class="log-message-text">${this.escapeHtml(log.message)}</span>
+                    ${log.expandable ? '<i class="mdi mdi-chevron-down expand-icon"></i>' : ""}
+                </td>
+                <td class="log-operation">
+                    ${log.operation_id ? `<code class="operation-id">${this.escapeHtml(log.operation_id.substring(0, 8))}</code>` : "-"}
+                </td>
+            `;
+
+            if (log.expandable) {
+                row.addEventListener("click", () => this.toggleExpand(row, log));
+                row.style.cursor = "pointer";
+            }
+
+            tbody.appendChild(row);
+        });
+    }
+
+    toggleExpand(row, log) {
+        const isExpanded = row.dataset.expanded === "true";
+
+        const existingDetail = row.nextElementSibling;
+        if (existingDetail && existingDetail.classList.contains("log-detail-row")) {
+            existingDetail.remove();
+            row.dataset.expanded = "false";
+            row.querySelector(".expand-icon")?.classList.replace("mdi-chevron-up", "mdi-chevron-down");
+            return;
+        }
+
+        const detailRow = document.createElement("tr");
+        detailRow.className = "log-detail-row";
+        detailRow.innerHTML = `
+            <td colspan="5" class="p-0">
+                <div class="log-detail-content" style="display: none;">
+                    <div class="p-3 bg-light border-top">
+                        ${log.expandable && log.expandable.traceback ? `
+                            <h6 class="mb-2">Traceback:</h6>
+                            <pre class="mb-0 small"><code>${this.escapeHtml(log.expandable.traceback)}</code></pre>
+                        ` : ""}
+                        ${log.operation ? `<div class="mb-2"><strong>Operation:</strong> ${this.escapeHtml(log.operation)}</div>` : ""}
+                        ${log.phase ? `<div class="mb-2"><strong>Phase:</strong> ${this.escapeHtml(log.phase)}</div>` : ""}
+                        ${log.resource_type && log.resource_id ? `<div class="mb-2"><strong>Resource:</strong> ${this.escapeHtml(log.resource_type)}#${this.escapeHtml(String(log.resource_id))}</div>` : ""}
+                    </div>
+                </div>
+            </td>
+        `;
+
+        row.after(detailRow);
+        const content = detailRow.querySelector(".log-detail-content");
+        if (content) {
+            content.style.display = "block";
+        }
+
+        row.dataset.expanded = "true";
+        const icon = row.querySelector(".expand-icon");
+        if (icon) {
+            icon.classList.replace("mdi-chevron-down", "mdi-chevron-up");
+        }
+    }
+
+    formatTimestamp(timestamp) {
+        if (!timestamp) return "-";
+        try {
+            const date = new Date(timestamp);
+            return date.toLocaleString();
+        } catch {
+            return timestamp;
+        }
+    }
+
+    getLevelBadgeColor(level) {
+        const colors = {
+            DEBUG: "secondary",
+            INFO: "primary",
+            WARNING: "warning",
+            ERROR: "danger",
+            CRITICAL: "danger",
+        };
+        return colors[level] || "secondary";
+    }
+
+    escapeHtml(text) {
+        if (!text) return "";
+        const div = document.createElement("div");
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    updateLogCount() {
+        const countEl = document.getElementById("logCount");
+        const totalEl = document.getElementById("totalCount");
+        if (countEl) {
+            countEl.textContent = this.cachedLogs.length;
+        }
+        if (totalEl && this.total !== this.cachedLogs.length) {
+            totalEl.textContent = ` (${this.total} total)`;
+            totalEl.style.display = "inline";
+        }
+    }
+
+    updateFilterIndicator(activeFilters) {
+        const indicator = document.getElementById("filterIndicator");
+        const badge = document.getElementById("activeFiltersBadge");
+
+        if (!indicator || !badge) return;
+
+        const filters = [];
+
+        if (this.currentLevel) {
+            filters.push(`level=${this.currentLevel}`);
+        }
+
+        if (this.currentOperationId) {
+            filters.push(`operation=${this.currentOperationId.substring(0, 8)}`);
+        }
+
+        if (filters.length > 0) {
+            badge.textContent = `Filtered: ${filters.join(", ")}`;
+            indicator.style.display = "block";
+        } else {
+            indicator.style.display = "none";
+        }
+    }
+
+    clearFilters() {
+        this.currentLevel = "";
+        this.currentOperationId = "";
+
+        const levelFilter = document.getElementById("levelFilter");
+        const operationIdFilter = document.getElementById("operationIdFilter");
+
+        if (levelFilter) levelFilter.value = "";
+        if (operationIdFilter) operationIdFilter.value = "";
+
+        this.applyFilters();
+    }
+
+    showLoading() {
+        const loadingRow = document.getElementById("loadingRow");
+        if (loadingRow) {
+            loadingRow.style.display = "";
+        }
+    }
+
+    hideLoading() {
+        const loadingRow = document.getElementById("loadingRow");
+        if (loadingRow) {
+            loadingRow.style.display = "none";
+        }
+    }
+
+    showError(message) {
+        const errorMessage = document.getElementById("errorMessage");
+        const errorText = document.getElementById("errorText");
+        if (errorMessage) {
+            errorMessage.style.display = "block";
+        }
+        if (errorText) {
+            errorText.textContent = message;
+        }
+        this.hideLoading();
+    }
+
+    hideError() {
+        const errorMessage = document.getElementById("errorMessage");
+        if (errorMessage) {
+            errorMessage.style.display = "none";
+        }
+    }
+
+    showLoadMore() {
+        const loadMoreBtn = document.getElementById("loadMoreBtn");
+        if (loadMoreBtn) {
+            loadMoreBtn.style.display = "";
+        }
+    }
+
+    hideLoadMore() {
+        const loadMoreBtn = document.getElementById("loadMoreBtn");
+        if (loadMoreBtn) {
+            loadMoreBtn.style.display = "none";
+        }
+    }
+
+    async loadMore() {
+        if (this.isLoading) return;
+        if (this.cachedLogs.length >= this.total) return;
+
+        this.isLoading = true;
+
+        try {
+            const params = new URLSearchParams();
+            if (this.currentLevel) {
+                params.append("level", this.currentLevel);
+            }
+            params.append("limit", this.limit.toString());
+            params.append("offset", this.currentOffset.toString());
+
+            const url = `${this.logsApiUrl}?${params.toString()}`;
+            const response = await fetch(url, {
+                headers: {
+                    Accept: "application/json",
+                },
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+
+            const data = await response.json();
+            const newLogs = data.logs || [];
+            this.allLogs = [...this.allLogs, ...newLogs];
+            this.total = data.total || this.allLogs.length;
+            this.currentOffset = this.allLogs.length;
+
+            this.applyFilters();
+
+            if (this.currentOffset >= this.total) {
+                this.hideLoadMore();
+            }
+        } catch (error) {
+            console.error("Failed to load more logs:", error);
+            this.showError(error.message || "Failed to load more logs");
+        } finally {
+            this.isLoading = false;
+        }
+    }
+
+    startAutoRefresh() {
+        this.stopAutoRefresh();
+        if (this.isAutoRefreshEnabled) {
+            this.autoRefreshTimer = setInterval(() => {
+                this.fetchLogs();
+            }, this.autoRefreshInterval);
+        }
+    }
+
+    stopAutoRefresh() {
+        if (this.autoRefreshTimer) {
+            clearInterval(this.autoRefreshTimer);
+            this.autoRefreshTimer = null;
+        }
+    }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    new LogsPage();
+});

--- a/netbox_proxbox/static/netbox_proxbox/js/logs.js
+++ b/netbox_proxbox/static/netbox_proxbox/js/logs.js
@@ -13,6 +13,7 @@ class LogsPage {
         this.currentOperationId = "";
         this.autoRefreshInterval = 5000;
         this.autoRefreshTimer = null;
+        this.operationIdFetchTimer = null;
         this.isAutoRefreshEnabled = true;
         this.currentOffset = 0;
         this.limit = 200;
@@ -60,7 +61,7 @@ class LogsPage {
         if (operationIdFilter) {
             operationIdFilter.addEventListener("input", (e) => {
                 this.currentOperationId = e.target.value.trim();
-                this.applyFilters();
+                this.scheduleOperationFetch();
             });
         }
 
@@ -80,13 +81,14 @@ class LogsPage {
             return;
         }
 
+        this.stopOperationFetch();
         this.isLoading = true;
         this.showLoading();
 
         try {
             const params = new URLSearchParams();
-            if (this.currentLevel) {
-                params.append("level", this.currentLevel);
+            if (this.currentOperationId) {
+                params.append("operation_id", this.currentOperationId);
             }
             params.append("limit", this.limit.toString());
 
@@ -131,16 +133,8 @@ class LogsPage {
 
     applyFilters() {
         this.cachedLogs = this.allLogs.filter((log) => {
-            if (this.currentLevel) {
-                const logLevel = this.getLogLevelPriority(log.level);
-                const filterLevel = this.getLogLevelPriority(this.currentLevel);
-                if (logLevel < filterLevel) return false;
-            }
-
-            if (this.currentOperationId) {
-                if (!log.operation_id || !log.operation_id.includes(this.currentOperationId)) {
-                    return false;
-                }
+            if (this.currentLevel && log.level !== this.currentLevel) {
+                return false;
             }
 
             return true;
@@ -150,39 +144,31 @@ class LogsPage {
         this.updateFilterIndicator();
     }
 
-    getLogLevelPriority(level) {
-        const priorities = {
-            DEBUG: 0,
-            INFO: 1,
-            WARNING: 2,
-            ERROR: 3,
-            CRITICAL: 4,
-        };
-        return priorities[level] ?? 0;
-    }
-
     renderLogs() {
         const tbody = document.getElementById("logsTableBody");
         const noLogsMessage = document.getElementById("noLogsMessage");
-        const template = document.getElementById("logRowTemplate");
 
         if (!tbody) return;
 
         tbody.innerHTML = "";
 
         if (this.cachedLogs.length === 0) {
-            this.hideLoadMore();
             noLogsMessage.style.display = "block";
+            if (this.allLogs.length < this.total) {
+                this.showLoadMore();
+            } else {
+                this.hideLoadMore();
+            }
             return;
         }
 
         noLogsMessage.style.display = "none";
 
-        this.cachedLogs.forEach((log, index) => {
+        this.cachedLogs.forEach((log) => {
             const row = document.createElement("tr");
             row.className = `log-entry log-level-${log.level.toLowerCase()}`;
             if (log.expandable) {
-                row.classList.add(" expandable");
+                row.classList.add("expandable");
                 row.dataset.expanded = "false";
             }
 
@@ -211,8 +197,6 @@ class LogsPage {
     }
 
     toggleExpand(row, log) {
-        const isExpanded = row.dataset.expanded === "true";
-
         const existingDetail = row.nextElementSibling;
         if (existingDetail && existingDetail.classList.contains("log-detail-row")) {
             existingDetail.remove();
@@ -301,15 +285,19 @@ class LogsPage {
         const filters = [];
 
         if (this.currentLevel) {
-            filters.push(`level=${this.currentLevel}`);
+            filters.push(`Client: level=${this.currentLevel}`);
         }
 
         if (this.currentOperationId) {
-            filters.push(`operation=${this.currentOperationId.substring(0, 8)}`);
+            filters.push(`Backend: operation=${this.currentOperationId.substring(0, 8)}`);
+        }
+
+        if (!this.currentOperationId && activeFilters && activeFilters.operation_id) {
+            filters.push(`Backend: operation=${String(activeFilters.operation_id).substring(0, 8)}`);
         }
 
         if (filters.length > 0) {
-            badge.textContent = `Filtered: ${filters.join(", ")}`;
+            badge.textContent = filters.join(" | ");
             indicator.style.display = "block";
         } else {
             indicator.style.display = "none";
@@ -326,7 +314,7 @@ class LogsPage {
         if (levelFilter) levelFilter.value = "";
         if (operationIdFilter) operationIdFilter.value = "";
 
-        this.applyFilters();
+        this.fetchLogs();
     }
 
     showLoading() {
@@ -384,8 +372,8 @@ class LogsPage {
 
         try {
             const params = new URLSearchParams();
-            if (this.currentLevel) {
-                params.append("level", this.currentLevel);
+            if (this.currentOperationId) {
+                params.append("operation_id", this.currentOperationId);
             }
             params.append("limit", this.limit.toString());
             params.append("offset", this.currentOffset.toString());
@@ -433,6 +421,23 @@ class LogsPage {
         if (this.autoRefreshTimer) {
             clearInterval(this.autoRefreshTimer);
             this.autoRefreshTimer = null;
+        }
+    }
+
+    scheduleOperationFetch() {
+        if (this.operationIdFetchTimer) {
+            clearTimeout(this.operationIdFetchTimer);
+        }
+        this.operationIdFetchTimer = setTimeout(() => {
+            this.operationIdFetchTimer = null;
+            this.fetchLogs();
+        }, 300);
+    }
+
+    stopOperationFetch() {
+        if (this.operationIdFetchTimer) {
+            clearTimeout(this.operationIdFetchTimer);
+            this.operationIdFetchTimer = null;
         }
     }
 }

--- a/netbox_proxbox/static/netbox_proxbox/styles/logs.css
+++ b/netbox_proxbox/static/netbox_proxbox/styles/logs.css
@@ -1,0 +1,153 @@
+/* Backend Logs page styles */
+
+.logs-table {
+    font-size: 0.875rem;
+}
+
+.logs-table thead th {
+    background-color: var(--bg-light);
+    border-bottom: 2px solid var(--border-color);
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.log-entry {
+    transition: background-color 0.15s ease-in-out;
+}
+
+.log-entry:hover {
+    background-color: rgba(var(--bs-primary-rgb), 0.05);
+}
+
+.log-entry.log-level-debug {
+    color: #6c757d;
+}
+
+.log-entry.log-level-info {
+    color: #0d6efd;
+}
+
+.log-entry.log-level-warning {
+    color: #fd7e14;
+    background-color: rgba(253, 126, 20, 0.05);
+}
+
+.log-entry.log-level-error,
+.log-entry.log-level-critical {
+    color: #dc3545;
+    background-color: rgba(220, 53, 69, 0.05);
+}
+
+.log-entry.log-level-critical {
+    font-weight: 600;
+}
+
+.log-timestamp {
+    font-family: monospace;
+    font-size: 0.8rem;
+    white-space: nowrap;
+    color: var(--bs-secondary-color);
+}
+
+.log-level .badge {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.log-module {
+    font-family: monospace;
+    font-size: 0.8rem;
+    color: var(--bs-secondary-color);
+}
+
+.log-message {
+    max-width: 0;
+    word-break: break-word;
+}
+
+.log-message-text {
+    display: inline;
+}
+
+.expand-icon {
+    margin-left: 0.5rem;
+    font-size: 0.875rem;
+    vertical-align: middle;
+    transition: transform 0.2s ease;
+}
+
+.log-entry.expanded .expand-icon {
+    transform: rotate(180deg);
+}
+
+.operation-id {
+    font-size: 0.75rem;
+    background-color: var(--bg-light);
+    padding: 0.125rem 0.375rem;
+    border-radius: 0.25rem;
+    word-break: break-all;
+}
+
+.log-detail-row td {
+    background-color: var(--bg-light);
+    border-top: none !important;
+}
+
+.log-detail-content {
+    animation: slideDown 0.2s ease-out;
+}
+
+@keyframes slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.log-detail-content pre {
+    max-height: 300px;
+    overflow-y: auto;
+    background-color: #2d2d2d;
+    color: #f8f8f2;
+    padding: 1rem;
+    border-radius: 0.375rem;
+    font-size: 0.8rem;
+}
+
+#autoRefreshToggle:checked + label {
+    color: var(--bs-success);
+}
+
+#filterIndicator .badge {
+    font-weight: 500;
+}
+
+#loadingRow td {
+    background-color: transparent;
+}
+
+.spinner-border-sm {
+    width: 1rem;
+    height: 1rem;
+    border-width: 0.15em;
+}
+
+@media (max-width: 768px) {
+    .logs-table {
+        font-size: 0.8rem;
+    }
+
+    .log-timestamp {
+        font-size: 0.75rem;
+    }
+
+    .log-module {
+        display: none;
+    }
+}

--- a/netbox_proxbox/templates/netbox_proxbox/logs.html
+++ b/netbox_proxbox/templates/netbox_proxbox/logs.html
@@ -1,0 +1,125 @@
+{% extends 'base/layout.html' %}
+{% load i18n %}
+{% load static %}
+
+{% block title %}{% trans "Backend Logs" %}{% endblock %}
+
+{% block head %}
+    <script>
+        window.proxboxLogsConfig = {
+            logsApiUrl: "{{ logs_api_url|default:''|escapejs }}",
+            fastapiUrl: "{{ fastapi_url|default:''|escapejs }}"
+        };
+    </script>
+    <script type="module" src="{% static 'netbox_proxbox/js/logs.js' %}"></script>
+    <link rel="stylesheet" href="{% static 'netbox_proxbox/styles/logs.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <div class="d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">
+                        <i class="mdi mdi-file-document-outline"></i>
+                        {% trans "Backend Logs" %}
+                    </h5>
+                    <div class="d-flex align-items-center gap-2">
+                        <div class="form-check form-switch mb-0">
+                            <input class="form-check-input" type="checkbox" id="autoRefreshToggle" checked>
+                            <label class="form-check-label" for="autoRefreshToggle">
+                                {% trans "Auto-refresh" %}
+                            </label>
+                        </div>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" id="refreshBtn">
+                            <i class="mdi mdi-refresh"></i>
+                            {% trans "Refresh" %}
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="card-header">
+                <div class="row g-2 align-items-center">
+                    <div class="col-auto">
+                        <label for="levelFilter" class="col-form-label">{% trans "Level:" %}</label>
+                    </div>
+                    <div class="col-auto">
+                        <select class="form-select form-select-sm" id="levelFilter" style="width: auto;">
+                            <option value="">{% trans "All" %}</option>
+                            <option value="DEBUG">DEBUG</option>
+                            <option value="INFO">INFO</option>
+                            <option value="WARNING">WARNING</option>
+                            <option value="ERROR">ERROR</option>
+                            <option value="CRITICAL">CRITICAL</option>
+                        </select>
+                    </div>
+                    <div class="col-auto">
+                        <input type="text" class="form-control form-control-sm" id="operationIdFilter" placeholder="{% trans 'Operation ID' %}" style="width: 200px;">
+                    </div>
+                    <div class="col-auto">
+                        <button type="button" class="btn btn-outline-secondary btn-sm" id="clearFiltersBtn">
+                            {% trans "Clear Filters" %}
+                        </button>
+                    </div>
+                    <div class="col-auto ms-auto" id="filterIndicator" style="display: none;">
+                        <span class="badge bg-info" id="activeFiltersBadge"></span>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover table-sm table-striped logs-table mb-0">
+                        <thead>
+                            <tr>
+                                <th style="width: 180px;">{% trans "Timestamp" %}</th>
+                                <th style="width: 80px;">{% trans "Level" %}</th>
+                                <th style="width: 150px;">{% trans "Module" %}</th>
+                                <th>{% trans "Message" %}</th>
+                                <th style="width: 120px;">{% trans "Operation" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody id="logsTableBody">
+                            <tr id="loadingRow">
+                                <td colspan="5" class="text-center text-muted py-4">
+                                    <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                                    {% trans "Loading logs..." %}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div id="noLogsMessage" class="text-center py-4" style="display: none;">
+                    <p class="text-muted mb-0">{% trans "No logs to display" %}</p>
+                </div>
+                <div id="errorMessage" class="text-center py-4" style="display: none;">
+                    <p class="text-danger mb-0" id="errorText"></p>
+                </div>
+            </div>
+            <div class="card-footer">
+                <div class="d-flex justify-content-between align-items-center">
+                    <div class="text-muted small">
+                        <span id="logCount">0</span> {% trans "logs" %}
+                        <span id="totalCount" class="text-muted" style="display: none;"></span>
+                    </div>
+                    <div>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" id="loadMoreBtn" style="display: none;">
+                            {% trans "Load More" %}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<template id="logRowTemplate">
+    <tr class="log-entry">
+        <td class="log-timestamp"></td>
+        <td class="log-level"></td>
+        <td class="log-module"></td>
+        <td class="log-message"></td>
+        <td class="log-operation"></td>
+    </tr>
+</template>
+{% endblock %}

--- a/netbox_proxbox/urls.py
+++ b/netbox_proxbox/urls.py
@@ -165,4 +165,5 @@ urlpatterns = [
     path("proxmox-card/<int:pk>/", views.get_proxmox_card, name="proxmox_card"),
     path("websocket/<str:message>", WebSocketView.as_view(), name="websocket"),
     path("jobs/<int:pk>/stream/", views.JobStreamSSEView.as_view(), name="job_stream"),
+    path("logs/", views.BackendLogsView.as_view(), name="backend_logs"),
 ]

--- a/netbox_proxbox/views/__init__.py
+++ b/netbox_proxbox/views/__init__.py
@@ -51,6 +51,7 @@ from .endpoints import (
 )
 from .external_pages import DiscordView, DiscussionsView, TelegramView
 from .keepalive_status import get_service_status
+from .logs import BackendLogsView
 from .schedule_sync import QuickScheduleSyncFromHomeView, ScheduleSyncView
 from .settings import SettingsView
 from .storage import (

--- a/netbox_proxbox/views/logs.py
+++ b/netbox_proxbox/views/logs.py
@@ -1,0 +1,34 @@
+"""Backend logs page view for viewing proxbox-api log buffer."""
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import render
+from django.views import View
+
+from netbox_proxbox.models import FastAPIEndpoint
+from netbox_proxbox.utils import get_fastapi_url
+
+
+class BackendLogsView(LoginRequiredMixin, View):
+    """Display backend logs from the proxbox-api log buffer."""
+
+    template_name = "netbox_proxbox/logs.html"
+
+    def get(self, request):
+        """Render the logs page with FastAPI URL for JavaScript."""
+        fastapi_endpoint = FastAPIEndpoint.objects.restrict(
+            request.user, "view"
+        ).first()
+
+        fastapi_info = {}
+        if fastapi_endpoint:
+            fastapi_info = get_fastapi_url(fastapi_endpoint) or {}
+
+        return render(
+            request,
+            self.template_name,
+            {
+                "fastapi_url": fastapi_info.get("http_url", ""),
+                "fastapi_websocket_url": fastapi_info.get("websocket_url", ""),
+                "logs_api_url": f"{fastapi_info.get('http_url', '')}/admin/logs",
+            },
+        )

--- a/netbox_proxbox/views/logs.py
+++ b/netbox_proxbox/views/logs.py
@@ -1,14 +1,14 @@
 """Backend logs page view for viewing proxbox-api log buffer."""
 
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import render
 from django.views import View
 
 from netbox_proxbox.models import FastAPIEndpoint
 from netbox_proxbox.utils import get_fastapi_url
+from utilities.views import ConditionalLoginRequiredMixin
 
 
-class BackendLogsView(LoginRequiredMixin, View):
+class BackendLogsView(ConditionalLoginRequiredMixin, View):
     """Display backend logs from the proxbox-api log buffer."""
 
     template_name = "netbox_proxbox/logs.html"
@@ -23,12 +23,13 @@ class BackendLogsView(LoginRequiredMixin, View):
         if fastapi_endpoint:
             fastapi_info = get_fastapi_url(fastapi_endpoint) or {}
 
+        fastapi_url = fastapi_info.get("http_url", "")
         return render(
             request,
             self.template_name,
             {
-                "fastapi_url": fastapi_info.get("http_url", ""),
+                "fastapi_url": fastapi_url,
                 "fastapi_websocket_url": fastapi_info.get("websocket_url", ""),
-                "logs_api_url": f"{fastapi_info.get('http_url', '')}/admin/logs",
+                "logs_api_url": f"{fastapi_url}/admin/logs" if fastapi_url else "",
             },
         )

--- a/tests/test_backend_logs_view.py
+++ b/tests/test_backend_logs_view.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from .conftest import load_plugin_module
+
+
+def test_backend_logs_view_exposes_fastapi_and_logs_urls(monkeypatch):
+    module = load_plugin_module(
+        "netbox_proxbox.views.logs",
+        monkeypatch=monkeypatch,
+        fastapi_endpoint=SimpleNamespace(
+            domain="proxbox.local",
+            ip_address="10.0.0.5/24",
+            port=8800,
+            verify_ssl=True,
+            websocket_port=8801,
+            websocket_domain="proxbox.local",
+            use_websocket=True,
+        ),
+        get_fastapi_url=lambda endpoint: {
+            "http_url": "https://proxbox.local:8800",
+            "websocket_url": "wss://proxbox.local:8801/ws",
+        },
+    )
+
+    request = SimpleNamespace(
+        method="GET",
+        user=SimpleNamespace(is_authenticated=True),
+    )
+    response = module.BackendLogsView().get(request)
+    context = response["context"]
+
+    assert response["template"] == "netbox_proxbox/logs.html"
+    assert context["fastapi_url"] == "https://proxbox.local:8800"
+    assert context["fastapi_websocket_url"] == "wss://proxbox.local:8801/ws"
+    assert context["logs_api_url"] == "https://proxbox.local:8800/admin/logs"
+

--- a/tests/test_backend_logs_view.py
+++ b/tests/test_backend_logs_view.py
@@ -35,4 +35,3 @@ def test_backend_logs_view_exposes_fastapi_and_logs_urls(monkeypatch):
     assert context["fastapi_url"] == "https://proxbox.local:8800"
     assert context["fastapi_websocket_url"] == "wss://proxbox.local:8801/ws"
     assert context["logs_api_url"] == "https://proxbox.local:8800/admin/logs"
-

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -164,6 +164,18 @@ def test_job_log_view_uses_netbox_status_colors():
     assert "ip-addresses" in contents
 
 
+def test_backend_logs_page_javascript_filters_levels_client_side_and_fetches_operation_id():
+    contents = _read("netbox_proxbox/static/netbox_proxbox/js/logs.js")
+
+    assert 'params.append("operation_id", this.currentOperationId);' in contents
+    assert 'params.append("level", this.currentLevel);' not in contents
+    assert "log.level !== this.currentLevel" in contents
+    assert "scheduleOperationFetch()" in contents
+    assert "Client: level=" in contents
+    assert "Backend: operation=" in contents
+    assert "getLogLevelPriority" not in contents
+
+
 def test_combined_interface_views_import_vm_interface_directly():
     contents = _read("netbox_proxbox/views/__init__.py")
     assert "from virtualization.models import VMInterface, VirtualMachine" in contents


### PR DESCRIPTION
## Summary

Implements [issue #316](https://github.com/emersonfelipesp/netbox-proxbox/issues/316) - Create a `Backend Logs` page on plugin.

Adds a new "Backend Logs" page that fetches and displays logs from the proxbox-api backend, including DEBUG level logs.

## Changes

### New Files
- `views/logs.py` - BackendLogsView that fetches logs from `GET /admin/logs` on proxbox-api
- `templates/netbox_proxbox/logs.html` - Logs page template with filter bar and table
- `static/netbox_proxbox/js/logs.js` - JavaScript class for fetching, filtering, auto-refresh
- `static/netbox_proxbox/styles/logs.css` - Styling for log levels (color-coded) and expandable rows

### Modified Files
- `navigation.py` - Added "Backend Logs" menu item under Proxmox Plugin group
- `urls.py` - Added `/logs/` route
- `views/__init__.py` - Exported BackendLogsView

## Features Implemented

1. **Log Retrieval**: Fetches logs from proxbox-api's `GET /admin/logs` endpoint
2. **Non-blocking**: Log fetching is independent from sync operations
3. **User-friendly Display**: 
   - Color-coded log levels (DEBUG=gray, INFO=blue, WARNING=orange, ERROR/CRITICAL=red)
   - Expandable rows showing full message, traceback, operation context
4. **Client-side Filtering**: Level dropdown filters displayed logs without refetching
5. **Server-side Filtering**: Operation ID filter sends filter to backend
6. **Auto-refresh**: Toggle button enables 5-second polling; shows "Filtered by: DEBUG" indicator when active

## Architecture

```
Browser (logs.js) 
    -> GET /admin/logs?level=DEBUG (proxbox-api)
    -> LogBufferHandler (in-memory circular buffer, 10k entries)
    -> Python logging (proxbox logger)
```

Each full sync operation generates a unique `operation_id` (UUID) that propagates through all sync service logs, allowing correlation of related log entries.

## PRs

- This PR requires: [emersonfelipesp/proxbox-api#38](https://github.com/emersonfelipesp/proxbox-api/pull/38)