### PR TITLE
fix: add Docker network aliases and improve stack readiness checks

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -91,20 +91,20 @@ jobs:
           docker run -d --name netbox-e2e-redis --network proxbox-e2e \
             redis:7-alpine
 
-          docker run -d --name proxmox-e2e-mock --network proxbox-e2e -p 18006:8006 \
+          docker run -d --name proxmox-e2e-mock --network proxbox-e2e --network-alias proxmox-mock -p 18006:8006 \
             -v "$PWD/tests/e2e:/e2e:ro" \
             python:3.12-slim sh -c "pip install --no-cache-dir fastapi uvicorn && uvicorn mock_proxmox_api:app --app-dir /e2e --host 0.0.0.0 --port 8006"
 
           if [ "${{ matrix.install_source }}" = "local" ]; then
-            docker run -d --name proxbox-e2e-api --network proxbox-e2e -p 18800:8000 \
+            docker run -d --name proxbox-e2e-api --network proxbox-e2e --network-alias proxbox-api -p 18800:8000 \
               -v "$PWD/proxbox-api-source:/src:ro" \
               python:3.12-slim sh -c "pip install --no-cache-dir fastapi uvicorn /src && uvicorn proxbox_api.main:app --host 0.0.0.0 --port 8000 --app-dir /src"
           else
-            docker run -d --name proxbox-e2e-api --network proxbox-e2e -p 18800:8000 \
+            docker run -d --name proxbox-e2e-api --network proxbox-e2e --network-alias proxbox-api -p 18800:8000 \
               python:3.12-slim sh -c "pip install --no-cache-dir fastapi uvicorn proxbox-api && uvicorn proxbox_api.main:app --host 0.0.0.0 --port 8000"
           fi
 
-          docker run -d --name netbox-e2e --network proxbox-e2e -p 18080:8080 \
+          docker run -d --name netbox-e2e --network proxbox-e2e --network-alias netbox -p 18080:8080 \
             -e DB_HOST=netbox-e2e-postgres \
             -e DB_NAME=netbox \
             -e DB_USER=netbox \
@@ -137,11 +137,23 @@ jobs:
           done
 
           for i in $(seq 1 60); do
-            if curl -fsS --max-time 5 http://127.0.0.1:18800/ >/dev/null 2>&1; then
+            if curl -sS --max-time 5 http://127.0.0.1:18006/api2/json/version >/dev/null 2>&1; then
               break
             fi
             sleep 2
             if [ "$i" -eq 60 ]; then
+              echo "proxmox mock did not become ready"
+              docker logs proxmox-e2e-mock || true
+              exit 1
+            fi
+          done
+
+          for i in $(seq 1 90); do
+            if curl -sS --max-time 5 http://127.0.0.1:18800/ >/dev/null 2>&1; then
+              break
+            fi
+            sleep 2
+            if [ "$i" -eq 90 ]; then
               echo "proxbox-api did not become ready"
               docker logs proxbox-e2e-api || true
               exit 1

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -137,7 +137,7 @@ jobs:
           done
 
           for i in $(seq 1 60); do
-            if curl -sS --max-time 5 http://127.0.0.1:18006/api2/json/version >/dev/null 2>&1; then
+            if curl -fsS --max-time 5 http://127.0.0.1:18006/api2/json/version >/dev/null 2>&1; then
               break
             fi
             sleep 2
@@ -149,7 +149,8 @@ jobs:
           done
 
           for i in $(seq 1 90); do
-            if curl -sS --max-time 5 http://127.0.0.1:18800/ >/dev/null 2>&1; then
+            http_code="$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' http://127.0.0.1:18800/ 2>/dev/null || true)"
+            if [ "$http_code" -ge 100 ] 2>/dev/null && [ "$http_code" -lt 500 ]; then
               break
             fi
             sleep 2


### PR DESCRIPTION
The e2e containers were reachable only by their Docker names
(netbox-e2e, proxmox-e2e-mock, proxbox-e2e-api) but the proxbox-api
configuration and plugin endpoint setup expected the shorter aliases
(netbox, proxmox-mock, proxbox-api) used in stack_setup.py and
ensure_netbox_plugin_endpoints. Without --network-alias these names
could not be resolved inside the containers, causing proxbox-api to
fail connecting to NetBox and Proxmox, and the rqworker/NetBox plugin
to fail connecting to proxbox-api.

Changes:
- netbox-e2e: add --network-alias netbox
- proxmox-e2e-mock: add --network-alias proxmox-mock
- proxbox-e2e-api (both local and pypi): add --network-alias proxbox-api
- Add proxmox mock readiness check before proxbox-api check
- Increase proxbox-api readiness window from 120s to 180s
- Drop -f flag from proxbox-api curl check so any HTTP response
  (including 404) counts as "server up", matching wait_http_ok()

https://claude.ai/code/session_01RYeAZyeWym2qneA5Ld6TEe