### PR TITLE
feat: merge v0.0.13 into develop

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   PROXBOX_API_RELEASE_VERSION: 0.0.8.post1
-  NETBOX_IMAGE: netboxcommunity/netbox:v4.6.0-beta1
+  NETBOX_IMAGE: netboxcommunity/netbox:v4.6.0-beta2
   PROXBOX_API_IMAGE: emersonfelipesp/proxbox-api
   PROXMOX_SDK_IMAGE: emersonfelipesp/proxmox-sdk
 

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: both
+      dependency_mode:
+        description: "dev = build proxbox-api from GitHub source; published = pull from Docker Hub"
+        required: false
+        type: string
+        default: dev
   workflow_dispatch:
     inputs:
       install_source:
@@ -20,6 +25,14 @@ on:
           - pypi
           - container
         default: both
+      dependency_mode:
+        description: "dev = build proxbox-api from GitHub source; published = pull from Docker Hub"
+        required: false
+        type: choice
+        options:
+          - dev
+          - published
+        default: dev
   schedule:
     - cron: "31 2 * * *"
 
@@ -87,7 +100,6 @@ jobs:
             redis:7-alpine
 
           docker pull "${PROXMOX_SDK_IMAGE}:dev-nginx"
-          docker pull "${PROXBOX_API_IMAGE}:${PROXBOX_API_RELEASE_VERSION}"
           docker pull "${NETBOX_IMAGE}"
 
           docker run -d --name proxmox-e2e-mock --network proxbox-e2e -p 18006:8000 \
@@ -97,9 +109,18 @@ jobs:
             -e APP_MODULE=proxmox_sdk.mock_main:app \
             "${PROXMOX_SDK_IMAGE}:dev-nginx"
 
-          docker run -d --name proxbox-e2e-api --network proxbox-e2e -p 18800:8000 \
-            -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=true \
-            "${PROXBOX_API_IMAGE}:${PROXBOX_API_RELEASE_VERSION}"
+          if [ "${{ inputs.dependency_mode }}" = "published" ]; then
+            docker pull "${PROXBOX_API_IMAGE}:${PROXBOX_API_RELEASE_VERSION}"
+            docker run -d --name proxbox-e2e-api --network proxbox-e2e -p 18800:8000 \
+              -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=true \
+              "${PROXBOX_API_IMAGE}:${PROXBOX_API_RELEASE_VERSION}"
+          else
+            git clone --depth 1 https://github.com/emersonfelipesp/proxbox-api.git /tmp/proxbox-api-src
+            docker build --target raw -t proxbox-api-e2e:dev /tmp/proxbox-api-src
+            docker run -d --name proxbox-e2e-api --network proxbox-e2e -p 18800:8000 \
+              -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=true \
+              proxbox-api-e2e:dev
+          fi
 
           if [ -n "${NETBOX_PLUGIN_MOUNT}" ]; then
             # shellcheck disable=SC2086

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   PROXBOX_API_RELEASE_VERSION: 0.0.8
-  NETBOX_IMAGE: netboxcommunity/netbox:v4.6.0-beta1
+  NETBOX_IMAGE: netboxcommunity/netbox:v4.6.0-beta2
   PROXBOX_API_IMAGE: emersonfelipesp/proxbox-api
   PROXMOX_SDK_IMAGE: emersonfelipesp/proxmox-sdk
 

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -133,6 +133,7 @@ jobs:
     uses: ./.github/workflows/e2e-docker.yml
     with:
       install_source: local
+      dependency_mode: dev
 
   publish-pypi:
     name: publish to PyPI
@@ -174,6 +175,7 @@ jobs:
     uses: ./.github/workflows/e2e-docker.yml
     with:
       install_source: pypi
+      dependency_mode: published
 
   e2e-docker-container:
     name: E2E Docker / container
@@ -182,3 +184,4 @@ jobs:
     uses: ./.github/workflows/e2e-docker.yml
     with:
       install_source: container
+      dependency_mode: published

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,38 @@ The current plugin config lives in [`netbox_proxbox/__init__.py`](./netbox_proxb
 - **Run now on Job detail:** Shown only when the job is in a **terminal** state (**completed**, **errored**, or **failed**), including after **Cancel** (failed). It is **not** shown for **pending**, **scheduled**, or **running**—use **Cancel** first if a queued run should be abandoned, then **Run now** on the finished row to queue a new sync with the same parameters.
 - **Full update (UI vs jobs):** The plugin home may still use non-streaming helpers such as [`sync_full_update_resource`](./netbox_proxbox/services/backend_proxy.py) for JSON/redirect flows. Scheduled or immediate **Proxbox Sync** jobs use **`full-update/stream`** on proxbox-api and execute the full stage chain in one stream: devices, storage, virtual machines, virtual disks, backups, snapshots, network interfaces, IP addresses, VM interfaces, backup routines, and replications.
 
+## CI/CD Workflows
+
+### E2E Docker workflow (`e2e-docker.yml`)
+
+Accepts two inputs:
+
+| Input | Values | Default | Effect |
+|-------|--------|---------|--------|
+| `install_source` | `local`, `pypi`, `container`, `both` | `both` | How netbox-proxbox is installed inside the NetBox container |
+| `dependency_mode` | `dev`, `published` | `dev` | Whether proxbox-api is built from GitHub source or pulled from Docker Hub |
+
+**`dependency_mode: dev`** — clones `emersonfelipesp/proxbox-api` at HEAD and builds the `raw` Docker target locally. Use this for pre-publish E2E to verify against the latest source.
+
+**`dependency_mode: published`** — pulls `emersonfelipesp/proxbox-api:<PROXBOX_API_RELEASE_VERSION>` from Docker Hub. Use this for post-publish E2E to verify the released image works end-to-end.
+
+### Release pipeline (`publish-testpypi.yml`)
+
+```
+prepare-release
+├── e2e-docker-local  (install_source=local,  dependency_mode=dev)       ← pre-publish gate
+├── validate-testpypi (lint, type check, compile, tests)
+└── publish-pypi      (needs both above)
+      ├── e2e-docker-pypi       (install_source=pypi,      dependency_mode=published)
+      └── e2e-docker-container  (install_source=container, dependency_mode=published)
+```
+
+The pre-publish E2E (`e2e-docker-local` with `dependency_mode=dev`) gates `publish-pypi` — if the dev stack does not work end-to-end, the package is not published.
+
+The post-publish E2E jobs (`dependency_mode=published`) run after `publish-pypi` to verify that the published PyPI package works against the released proxbox-api Docker Hub image.
+
+---
+
 ## How To Navigate
 
 - Start with [`netbox_proxbox/CLAUDE.md`](./netbox_proxbox/CLAUDE.md) for the package-level map.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ Sync runs on-demand from the NetBox UI or scheduled automatically via NetBox's j
 
 | NetBox   | netbox-proxbox | proxbox-api | netbox-sdk     | proxmox-sdk    |
 |----------|----------------|-------------|----------------|----------------|
+| >=4.6.0-beta2  | v0.0.14        | v0.0.10           | v0.0.7.post6   | v0.0.3.post1   |
 | >=4.6.0-beta1  | v0.0.12        | v0.0.8.post1      | v0.0.7.post6   | v0.0.3.post1   |
 | >=4.5.7  | v0.0.11        | v0.0.7      | v0.0.7.post4   | v0.0.2.post2   |
 
 ## Requirements
 
 - NetBox 4.6.x
-- Verified with NetBox v4.6.0-beta1
+- Verified with NetBox v4.6.0-beta2
 - Python 3.12+
 - Proxmox VE 7.x or 8.x
 - Proxbox API backend (see below)

--- a/netbox_proxbox/__init__.py
+++ b/netbox_proxbox/__init__.py
@@ -118,7 +118,7 @@ class ProxboxConfig(PluginConfig):
     name = "netbox_proxbox"
     verbose_name = "Proxbox"
     description = "Integrates Proxmox and Netbox"
-    version = "0.0.13"
+    version = "0.0.14"
     author = "Emerson Felipe (@emersonfelipesp)"
     author_email = "emersonfelipe.2003@gmail.com"
     min_version = "4.6.0"

--- a/netbox_proxbox/__init__.py
+++ b/netbox_proxbox/__init__.py
@@ -118,7 +118,7 @@ class ProxboxConfig(PluginConfig):
     name = "netbox_proxbox"
     verbose_name = "Proxbox"
     description = "Integrates Proxmox and Netbox"
-    version = "0.0.12"
+    version = "0.0.13"
     author = "Emerson Felipe (@emersonfelipesp)"
     author_email = "emersonfelipe.2003@gmail.com"
     min_version = "4.6.0"

--- a/netbox_proxbox/forms/settings.py
+++ b/netbox_proxbox/forms/settings.py
@@ -234,10 +234,11 @@ class ProxboxPluginSettingsForm(forms.Form):
     overwrite_vm_tags = forms.BooleanField(
         required=False,
         initial=True,
-        label="Overwrite VM tags",
+        label="Merge VM tags",
         help_text=(
-            "When disabled, sync never changes the tags on existing NetBox virtual machines "
-            "that already have tags assigned. Tags are still applied when the VM is first created."
+            "When enabled (default), sync ensures the Proxbox tag is present while preserving "
+            "all other existing tags. When disabled, sync never changes tags on existing virtual "
+            "machines; tags are still applied when the VM is first created."
         ),
     )
 

--- a/netbox_proxbox/forms/settings.py
+++ b/netbox_proxbox/forms/settings.py
@@ -195,6 +195,51 @@ class ProxboxPluginSettingsForm(forms.Form):
         label="Proxmox retry back-off (seconds)",
         help_text="Default exponential back-off base delay in seconds between Proxmox retries. Individual endpoints can override this.",
     )
+    overwrite_device_role = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Overwrite device role",
+        help_text=(
+            "When disabled, sync never changes the device role on existing Proxmox node devices "
+            "that already have a role assigned. The role is still set when the device is first created."
+        ),
+    )
+    overwrite_device_type = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Overwrite device type",
+        help_text=(
+            "When disabled, sync never changes the device type on existing Proxmox node devices "
+            "that already have a device type assigned. The device type is still set at create time."
+        ),
+    )
+    overwrite_device_tags = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Overwrite device tags",
+        help_text=(
+            "When disabled, sync never changes the tags on existing Proxmox node devices "
+            "that already have tags assigned. Tags are still applied when the device is first created."
+        ),
+    )
+    overwrite_vm_role = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Overwrite VM role",
+        help_text=(
+            "When disabled, sync never changes the role on existing NetBox virtual machines "
+            "that already have a role assigned. The role is still set when the VM is first created."
+        ),
+    )
+    overwrite_vm_tags = forms.BooleanField(
+        required=False,
+        initial=True,
+        label="Overwrite VM tags",
+        help_text=(
+            "When disabled, sync never changes the tags on existing NetBox virtual machines "
+            "that already have tags assigned. Tags are still applied when the VM is first created."
+        ),
+    )
 
     def clean_backend_log_file_path(self) -> str:
         """Require an absolute log file path including a filename."""

--- a/netbox_proxbox/migrations/0033_pluginsettings_controlled_fields.py
+++ b/netbox_proxbox/migrations/0033_pluginsettings_controlled_fields.py
@@ -1,0 +1,96 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_proxbox", "0032_proxmoxendpoint_timeout_retries_pluginsettings_proxmox_defaults"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" ADD COLUMN IF NOT EXISTS "overwrite_device_role" boolean NOT NULL DEFAULT true;',
+                    reverse_sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" DROP COLUMN IF EXISTS "overwrite_device_role";',
+                ),
+                migrations.RunSQL(
+                    sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" ADD COLUMN IF NOT EXISTS "overwrite_device_type" boolean NOT NULL DEFAULT true;',
+                    reverse_sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" DROP COLUMN IF EXISTS "overwrite_device_type";',
+                ),
+                migrations.RunSQL(
+                    sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" ADD COLUMN IF NOT EXISTS "overwrite_device_tags" boolean NOT NULL DEFAULT true;',
+                    reverse_sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" DROP COLUMN IF EXISTS "overwrite_device_tags";',
+                ),
+                migrations.RunSQL(
+                    sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" ADD COLUMN IF NOT EXISTS "overwrite_vm_role" boolean NOT NULL DEFAULT true;',
+                    reverse_sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" DROP COLUMN IF EXISTS "overwrite_vm_role";',
+                ),
+                migrations.RunSQL(
+                    sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" ADD COLUMN IF NOT EXISTS "overwrite_vm_tags" boolean NOT NULL DEFAULT true;',
+                    reverse_sql='ALTER TABLE "netbox_proxbox_proxboxpluginsettings" DROP COLUMN IF EXISTS "overwrite_vm_tags";',
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="overwrite_device_role",
+                    field=models.BooleanField(
+                        default=True,
+                        verbose_name="Overwrite device role",
+                        help_text=(
+                            "When disabled, sync never changes the device role on existing Proxmox node devices "
+                            "that already have a role assigned. The role is still set when the device is first created."
+                        ),
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="overwrite_device_type",
+                    field=models.BooleanField(
+                        default=True,
+                        verbose_name="Overwrite device type",
+                        help_text=(
+                            "When disabled, sync never changes the device type on existing Proxmox node devices "
+                            "that already have a device type assigned. The device type is still set at create time."
+                        ),
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="overwrite_device_tags",
+                    field=models.BooleanField(
+                        default=True,
+                        verbose_name="Overwrite device tags",
+                        help_text=(
+                            "When disabled, sync never changes the tags on existing Proxmox node devices "
+                            "that already have tags assigned. Tags are still applied when the device is first created."
+                        ),
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="overwrite_vm_role",
+                    field=models.BooleanField(
+                        default=True,
+                        verbose_name="Overwrite VM role",
+                        help_text=(
+                            "When disabled, sync never changes the role on existing NetBox virtual machines "
+                            "that already have a role assigned. The role is still set when the VM is first created."
+                        ),
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="overwrite_vm_tags",
+                    field=models.BooleanField(
+                        default=True,
+                        verbose_name="Overwrite VM tags",
+                        help_text=(
+                            "When disabled, sync never changes the tags on existing NetBox virtual machines "
+                            "that already have tags assigned. Tags are still applied when the VM is first created."
+                        ),
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/netbox_proxbox/models/plugin_settings.py
+++ b/netbox_proxbox/models/plugin_settings.py
@@ -238,10 +238,11 @@ class ProxboxPluginSettings(NetBoxModel):
     )
     overwrite_vm_tags = models.BooleanField(
         default=True,
-        verbose_name=_("Overwrite VM tags"),
+        verbose_name=_("Merge VM tags"),
         help_text=_(
-            "When disabled, sync never changes the tags on existing NetBox virtual machines "
-            "that already have tags assigned. Tags are still applied when the VM is first created."
+            "When enabled, sync merges existing NetBox VM tags with the Proxbox tag, preserving "
+            "user-assigned tags. When disabled, sync never changes tags on existing virtual "
+            "machines; tags are still applied at VM creation."
         ),
     )
 

--- a/netbox_proxbox/models/plugin_settings.py
+++ b/netbox_proxbox/models/plugin_settings.py
@@ -204,6 +204,46 @@ class ProxboxPluginSettings(NetBoxModel):
             "Individual endpoints can override this value."
         ),
     )
+    overwrite_device_role = models.BooleanField(
+        default=True,
+        verbose_name=_("Overwrite device role"),
+        help_text=_(
+            "When disabled, sync never changes the device role on existing Proxmox node devices "
+            "that already have a role assigned. The role is still set when the device is first created."
+        ),
+    )
+    overwrite_device_type = models.BooleanField(
+        default=True,
+        verbose_name=_("Overwrite device type"),
+        help_text=_(
+            "When disabled, sync never changes the device type on existing Proxmox node devices "
+            "that already have a device type assigned. The device type is still set at create time."
+        ),
+    )
+    overwrite_device_tags = models.BooleanField(
+        default=True,
+        verbose_name=_("Overwrite device tags"),
+        help_text=_(
+            "When disabled, sync never changes the tags on existing Proxmox node devices "
+            "that already have tags assigned. Tags are still applied when the device is first created."
+        ),
+    )
+    overwrite_vm_role = models.BooleanField(
+        default=True,
+        verbose_name=_("Overwrite VM role"),
+        help_text=_(
+            "When disabled, sync never changes the role on existing NetBox virtual machines "
+            "that already have a role assigned. The role is still set when the VM is first created."
+        ),
+    )
+    overwrite_vm_tags = models.BooleanField(
+        default=True,
+        verbose_name=_("Overwrite VM tags"),
+        help_text=_(
+            "When disabled, sync never changes the tags on existing NetBox virtual machines "
+            "that already have tags assigned. Tags are still applied when the VM is first created."
+        ),
+    )
 
     class Meta:
         verbose_name = _("Proxbox plugin settings")

--- a/netbox_proxbox/sync_params.py
+++ b/netbox_proxbox/sync_params.py
@@ -69,6 +69,56 @@ def _primary_ip_preference_setting() -> str:
         return "ipv4"
 
 
+def _overwrite_device_role_setting() -> bool:
+    """Return plugin setting for whether sync should overwrite the device role."""
+    try:
+        from netbox_proxbox.models import ProxboxPluginSettings
+
+        return bool(ProxboxPluginSettings.get_solo().overwrite_device_role)
+    except (ImportError, RuntimeError, AttributeError):
+        return True
+
+
+def _overwrite_device_type_setting() -> bool:
+    """Return plugin setting for whether sync should overwrite the device type."""
+    try:
+        from netbox_proxbox.models import ProxboxPluginSettings
+
+        return bool(ProxboxPluginSettings.get_solo().overwrite_device_type)
+    except (ImportError, RuntimeError, AttributeError):
+        return True
+
+
+def _overwrite_device_tags_setting() -> bool:
+    """Return plugin setting for whether sync should overwrite device tags."""
+    try:
+        from netbox_proxbox.models import ProxboxPluginSettings
+
+        return bool(ProxboxPluginSettings.get_solo().overwrite_device_tags)
+    except (ImportError, RuntimeError, AttributeError):
+        return True
+
+
+def _overwrite_vm_role_setting() -> bool:
+    """Return plugin setting for whether sync should overwrite the VM role."""
+    try:
+        from netbox_proxbox.models import ProxboxPluginSettings
+
+        return bool(ProxboxPluginSettings.get_solo().overwrite_vm_role)
+    except (ImportError, RuntimeError, AttributeError):
+        return True
+
+
+def _overwrite_vm_tags_setting() -> bool:
+    """Return plugin setting for whether sync should overwrite VM tags."""
+    try:
+        from netbox_proxbox.models import ProxboxPluginSettings
+
+        return bool(ProxboxPluginSettings.get_solo().overwrite_vm_tags)
+    except (ImportError, RuntimeError, AttributeError):
+        return True
+
+
 def _serialize_sync_params(
     *,
     sync_types: list[str],

--- a/netbox_proxbox/sync_stages.py
+++ b/netbox_proxbox/sync_stages.py
@@ -28,6 +28,11 @@ from netbox_proxbox.sync_params import (
     _use_guest_agent_interface_name_setting,
     _ignore_ipv6_link_local_addresses_setting,
     _primary_ip_preference_setting,
+    _overwrite_device_role_setting,
+    _overwrite_device_type_setting,
+    _overwrite_device_tags_setting,
+    _overwrite_vm_role_setting,
+    _overwrite_vm_tags_setting,
     _serialize_sync_params,
 )
 from netbox_proxbox.sync_ownership import (
@@ -166,6 +171,21 @@ def _build_base_query_params(
         "true" if _ignore_ipv6_link_local_addresses_setting() else "false"
     )
     base_query["primary_ip_preference"] = _primary_ip_preference_setting()
+    base_query["overwrite_device_role"] = (
+        "true" if _overwrite_device_role_setting() else "false"
+    )
+    base_query["overwrite_device_type"] = (
+        "true" if _overwrite_device_type_setting() else "false"
+    )
+    base_query["overwrite_device_tags"] = (
+        "true" if _overwrite_device_tags_setting() else "false"
+    )
+    base_query["overwrite_vm_role"] = (
+        "true" if _overwrite_vm_role_setting() else "false"
+    )
+    base_query["overwrite_vm_tags"] = (
+        "true" if _overwrite_vm_tags_setting() else "false"
+    )
     if proxmox_endpoint_ids:
         base_query["proxmox_endpoint_ids"] = ",".join(proxmox_endpoint_ids)
     if netbox_endpoint_ids:

--- a/netbox_proxbox/views/settings.py
+++ b/netbox_proxbox/views/settings.py
@@ -55,6 +55,11 @@ class SettingsView(
                 "proxmox_timeout": settings_obj.proxmox_timeout,
                 "proxmox_max_retries": settings_obj.proxmox_max_retries,
                 "proxmox_retry_backoff": settings_obj.proxmox_retry_backoff,
+                "overwrite_device_role": settings_obj.overwrite_device_role,
+                "overwrite_device_type": settings_obj.overwrite_device_type,
+                "overwrite_device_tags": settings_obj.overwrite_device_tags,
+                "overwrite_vm_role": settings_obj.overwrite_vm_role,
+                "overwrite_vm_tags": settings_obj.overwrite_vm_tags,
             }
         )
         return render(request, self.template_name, {"form": form})
@@ -139,6 +144,21 @@ class SettingsView(
             settings_obj.proxmox_retry_backoff = form.cleaned_data[
                 "proxmox_retry_backoff"
             ]
+            settings_obj.overwrite_device_role = form.cleaned_data.get(
+                "overwrite_device_role", True
+            )
+            settings_obj.overwrite_device_type = form.cleaned_data.get(
+                "overwrite_device_type", True
+            )
+            settings_obj.overwrite_device_tags = form.cleaned_data.get(
+                "overwrite_device_tags", True
+            )
+            settings_obj.overwrite_vm_role = form.cleaned_data.get(
+                "overwrite_vm_role", True
+            )
+            settings_obj.overwrite_vm_tags = form.cleaned_data.get(
+                "overwrite_vm_tags", True
+            )
             encryption_enabled = form.cleaned_data.get("encryption_enabled", False)
             if encryption_enabled:
                 new_key = form.cleaned_data.get("encryption_key", "").strip()
@@ -170,6 +190,11 @@ class SettingsView(
                     "proxmox_timeout",
                     "proxmox_max_retries",
                     "proxmox_retry_backoff",
+                    "overwrite_device_role",
+                    "overwrite_device_type",
+                    "overwrite_device_tags",
+                    "overwrite_vm_role",
+                    "overwrite_vm_tags",
                 ]
             )
             messages.success(request, "Proxbox plugin settings updated.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-proxbox"
-version = "0.0.13"
+version = "0.0.14"
 description = "Netbox Plugin - Integrate Proxmox and Netbox"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-proxbox"
-version = "0.0.12"
+version = "0.0.13"
 description = "Netbox Plugin - Integrate Proxmox and Netbox"
 readme = "README.md"
 authors = [

--- a/tests/test_settings_view_encryption.py
+++ b/tests/test_settings_view_encryption.py
@@ -65,6 +65,11 @@ def _fake_settings_obj(encryption_key: str = "") -> SimpleNamespace:
         proxmox_timeout=5,
         proxmox_max_retries=0,
         proxmox_retry_backoff="0.50",
+        overwrite_device_role=True,
+        overwrite_device_type=True,
+        overwrite_device_tags=True,
+        overwrite_vm_role=True,
+        overwrite_vm_tags=True,
         save=_save,
         _saved=saved,
     )


### PR DESCRIPTION
## Summary

- feat(v0.0.13): add controlled fields settings for Device/VM sync (closes #335)
- fix: save and display overwrite_* settings in settings view
- chore(v0.0.14): certify NetBox v4.6.0-beta2 compatibility, bump to v0.0.14
- fix: update overwrite_vm_tags label to reflect merge semantics
- ci: add dependency_mode input and pre/post-publish E2E separation

## Test plan

- [ ] Verify controlled fields settings UI renders correctly in NetBox plugin settings
- [ ] Confirm overwrite_* values persist after save and display in settings view
- [ ] Confirm NetBox v4.6.0-beta2 compatibility
- [ ] Validate CI workflow with new dependency_mode input and E2E gate separation