### PR TITLE
chore: refresh docs, tests, and CI for 0.0.13.post1 / NetBox 4.6.0-beta2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,16 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
-      - name: Install ruff
-        run: pip install ruff
+      - name: Install ruff and bandit
+        run: pip install ruff bandit
 
       - name: Run ruff (lint + format check)
         run: |
           ruff check .
           ruff format --check .
+
+      - name: Run bandit (security lint)
+        run: bandit -r netbox_proxbox proxbox_cli -ll
 
   typecheck:
     runs-on: ubuntu-latest
@@ -70,14 +73,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: [lint, typecheck, compile]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
 
       - name: Install dependencies
@@ -89,6 +96,7 @@ jobs:
         run: pytest --cov=netbox_proxbox --cov-report=term-missing --cov-report=xml tests
 
       - name: Upload coverage report
+        if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v6
         with:
           name: netbox-proxbox-coverage

--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   PROXBOX_API_RELEASE_VERSION: 0.0.9
-  NETBOX_IMAGE: netboxcommunity/netbox:v4.6.0-beta1
+  NETBOX_IMAGE: netboxcommunity/netbox:v4.6.0-beta2
   PROXBOX_API_IMAGE: emersonfelipesp/proxbox-api
   PROXMOX_SDK_IMAGE: emersonfelipesp/proxmox-sdk
 
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install requests playwright
+          python -m pip install -e ".[screenshot]"
           playwright install chromium --with-deps
 
       - name: Resolve plugin install spec

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: dev
+      netbox_image:
+        description: "Override NetBox image (e.g. netboxcommunity/netbox:v4.6.0-beta2). Empty = workflow default."
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       install_source:
@@ -33,12 +38,17 @@ on:
           - dev
           - published
         default: dev
+      netbox_image:
+        description: "Override NetBox image (full ref). Leave empty for workflow default."
+        required: false
+        type: string
+        default: ""
   schedule:
     - cron: "31 2 * * *"
 
 env:
   PROXBOX_API_RELEASE_VERSION: 0.0.9
-  NETBOX_IMAGE: netboxcommunity/netbox:v4.6.0-beta1
+  NETBOX_IMAGE: ${{ inputs.netbox_image != '' && inputs.netbox_image || 'netboxcommunity/netbox:v4.6.0-beta2' }}
   PROXBOX_API_IMAGE: emersonfelipesp/proxbox-api
   PROXMOX_SDK_IMAGE: emersonfelipesp/proxmox-sdk
 

--- a/.github/workflows/nightly-contracts.yml
+++ b/.github/workflows/nightly-contracts.yml
@@ -22,9 +22,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[test,dev,cli]"
+          # ``proxbox-api`` powers the cross-repo SSE/overwrite-flags contract
+          # mirrors. It is already pinned in the [test] extra; install it
+          # explicitly so the upcoming step can drop ``importorskip`` skips.
+          python -m pip install proxbox-api==0.0.9
 
       - name: Run ty
         run: ty check proxbox_cli
 
       - name: Run contract-sensitive mocked tests
         run: pytest -q tests/test_keepalive_status.py tests/test_sync.py tests/test_cards.py
+
+      - name: Run cross-repo contract mirrors (requires proxbox-api)
+        run: pytest -q tests/test_sse_schema_mirror.py tests/test_overwrite_flags_contract.py

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -20,8 +20,15 @@ The plugin exposes a singleton-style **Proxbox plugin settings** object for runt
 
 See [Plugin Settings](./plugin-settings.md) for the full field reference.
 
+## Sync Overwrite Flags
+
+Every `overwrite_*` toggle (device fields, VM fields, tags, primary IP, status) is now configurable both globally on the plugin settings object and per-endpoint on the **Settings** tab of each `ProxmoxEndpoint`. Per-endpoint values use tri-state semantics: **Use plugin default**, **Always overwrite**, or **Never overwrite**.
+
+See [Sync Overwrite Flags](./sync-overwrite-flags.md) for the full flag matrix and merge-vs-replace semantics.
+
 ## Next Steps
 
 - Review [Required Parameters](./required-parameters.md) before creating endpoint records.
 - Configure [Plugin Settings](./plugin-settings.md) to tune sync performance and security.
+- Pin [Sync Overwrite Flags](./sync-overwrite-flags.md) globally or per-endpoint to control which Proxmox fields can replace existing NetBox values.
 - Use [Scheduled Sync](../features/scheduled-sync.md) when you want recurring background jobs instead of manual syncs.

--- a/docs/configuration/plugin-settings.md
+++ b/docs/configuration/plugin-settings.md
@@ -32,6 +32,24 @@ These fields tune how aggressively Proxbox calls the NetBox API during sync oper
 
 ---
 
+## Sync Overwrite Flags
+
+The Plugin Settings object also stores **global defaults** for every `overwrite_*` flag (device fields, VM fields, tags, primary IP, status, and custom fields). Per-endpoint overrides live on the **Settings** tab of each `ProxmoxEndpoint`.
+
+Tri-state semantics on the per-endpoint tab:
+
+| Setting | Effect |
+|---|---|
+| **Use plugin default** (None) | Inherit the value from the global Plugin Settings object. |
+| **Always overwrite** (True) | The sync overwrites the existing NetBox value with the Proxmox value on every run. |
+| **Never overwrite** (False) | The sync preserves the existing NetBox value and only writes when the field is empty. |
+
+The `overwrite_vm_tags` toggle controls **merge vs replace** semantics: when enabled, Proxbox-managed tags replace the existing tag set; when disabled, Proxbox tags are merged with whatever tags are already present on the NetBox VM.
+
+See [Sync Overwrite Flags](./sync-overwrite-flags.md) for the full flag matrix.
+
+---
+
 ## SSRF Protection
 
 These settings guard against Server-Side Request Forgery by validating endpoint IPs before Proxbox contacts them.

--- a/docs/configuration/sync-overwrite-flags.md
+++ b/docs/configuration/sync-overwrite-flags.md
@@ -92,8 +92,9 @@ reverting:
 
 ## Migration note
 
-Upgrading the plugin past version 0.0.13 adds the 16 new per-endpoint
-overwrite columns. After installing the new release run:
+The 16 new per-endpoint overwrite columns shipped in `netbox-proxbox 0.0.13`
+(migration `0035_overwrite_fields_expansion`). When upgrading from `0.0.12` or
+earlier, run:
 
 ```bash
 python manage.py migrate netbox_proxbox

--- a/docs/features/proxmox-config-tab.md
+++ b/docs/features/proxmox-config-tab.md
@@ -1,0 +1,49 @@
+# Proxmox Config Tab
+
+The **Proxmox Config** tab is a live read-only view of a virtual machine's current Proxmox configuration, embedded as a tab on each NetBox `VirtualMachine` detail page.
+
+## What It Shows
+
+The tab fetches the latest config payload directly from the proxbox-api backend via the configured `FastAPIEndpoint` and renders the parsed `ProxmoxVMConfig` schema for the VM. Both **QEMU** and **LXC** guests are supported.
+
+Typical contents:
+
+- VM name, VM ID, node, type (`qemu` or `lxc`)
+- CPU and memory configuration
+- Disks (with storage and size)
+- Network interfaces (with VLAN/bridge mapping)
+- Boot order and any guest-agent settings
+- Any other key/value pairs returned by the Proxmox API
+
+The data is **fetched live** from Proxmox on every page load — no NetBox-side caching is involved. Use the regular sync actions to persist any of these values into NetBox models.
+
+## How It Resolves The VM
+
+The tab determines which Proxmox VM to query using the following lookup order:
+
+1. **`proxmox_vm_id` custom field** on the NetBox `VirtualMachine` (preferred).
+2. Legacy `cf_proxmox_vm_id` custom field, if present.
+3. `proxmox_node` / `node` custom field, falling back to a regex match against the VM `description` (`Synced from Proxmox node <name>`).
+4. `virtual_machine_type` slug to pick `qemu` vs `lxc`; falls back to `proxmox_vm_type` custom field, defaulting to `qemu`.
+
+If the VM ID cannot be resolved, the tab renders an explanatory message instead of attempting a backend call.
+
+## Backend Path
+
+When all values resolve, the tab issues a GET against the proxbox-api endpoint that proxies to:
+
+```
+GET /nodes/{node}/{qemu|lxc}/{vmid}/config?source=database
+```
+
+The plugin sends the configured backend authentication header (see [Authentication](../developer/authentication.md)) and validates the response payload against the `ProxmoxVMConfig` Pydantic schema before rendering. Validation errors are surfaced in the tab body so operators can see when Proxmox returned something unexpected.
+
+## Permissions
+
+The tab uses NetBox's standard `virtualization.view_virtualmachine` permission. The `get_queryset` method calls `VirtualMachine.objects.restrict(request.user, "view")` so users only see configs for VMs they are allowed to view.
+
+## Related Pages
+
+- [Virtual Machine](./virtual-machine.md) — sync actions that write Proxmox-derived values back into NetBox.
+- [Synchronized Data](./synchronized-data.md) — what fields the regular sync stages persist.
+- [Backend Logs](./backend-logs.md) — for diagnosing backend errors that show up in the tab body.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,20 +6,21 @@ Proxbox is a NetBox plugin that integrates Proxmox with NetBox through a separat
 
 | NetBox   | netbox-proxbox | proxbox-api | netbox-sdk     | proxmox-sdk    |
 |----------|----------------|-------------|----------------|----------------|
-| >=4.6.0-beta1  | v0.0.12        | v0.0.8.post1 | v0.0.7.post6   | v0.0.3.post1   |
+| >=4.6.0-beta2 | v0.0.13.post1 | v0.0.9 | v0.0.7.post6 | v0.0.3.post1 |
+| >=4.6.0-beta1 | v0.0.12       | v0.0.8.post1 | v0.0.7.post6 | v0.0.3.post1 |
 | >=4.5.7  | v0.0.11        | v0.0.7      | v0.0.7.post4   | v0.0.2.post2   |
 
 The current repository code declares support for:
 
 - NetBox `4.6.x`
-- Plugin version `0.0.12` in source
+- Plugin version `0.0.13.post1` in source
 
 That support comes directly from the plugin config in this repository:
 
 - `min_version = "4.6.0"`
 - `max_version = "4.6.99"`
 
-This compatibility line targets NetBox `v4.6.0-beta1` and adds native `VirtualMachineType` sync.
+This compatibility line is certified against NetBox `v4.6.0-beta2`. It adds per-endpoint Settings tabs, surfaces every `overwrite_*` flag in the plugin UI, enforces VM-sync device flags on the proxbox-api side, and ships endpoint CSV/JSON/YAML import/export pages.
 
 ## Important Packaging Note
 
@@ -32,24 +33,27 @@ The repository is ahead of the latest published PyPI release of `netbox-proxbox`
 
 The current codebase includes NetBox models for:
 
-- Proxmox endpoints
-- NetBox endpoints
-- FastAPI endpoints
-- Sync processes
-- VM backups
-- VM snapshots
+- Proxmox endpoints (with per-endpoint sync overwrite flags and Settings tab)
+- NetBox endpoints (singleton)
+- FastAPI endpoints (singleton)
 - Proxmox clusters and hypervisor nodes (with links to NetBox Cluster and Device objects)
+- Proxmox storage rows
 - Backup routines (Proxmox vzdump schedules with retention policies)
 - Replications (Proxmox storage replication metadata)
+- VM backups
+- VM snapshots
+- VM task history
+- Plugin-wide settings (`ProxboxPluginSettings`)
 
 The plugin UI exposes sync actions for:
 
-- devices
-- virtual machines
-- containers
-- full update
-- VM backups
-- VM snapshots
+- Devices (Proxmox node → NetBox `Device`)
+- Virtual machines and containers (with per-VM targeted sync)
+- Full update (single SSE stream covering devices, storage, VMs, virtual disks, backups, snapshots, network interfaces, IP addresses, VM interfaces, backup routines, and replications)
+- Storage
+- Virtual disks
+- Network interfaces and IP addresses
+- VM backups and snapshots
 - Backup routines
 - Replications
 

--- a/docs/installation/1-installing-plugin.md
+++ b/docs/installation/1-installing-plugin.md
@@ -2,7 +2,7 @@
 
 ## Read This First
 
-The current repository code targets NetBox `4.5.x`, but the repository is ahead of the latest published PyPI build of `netbox-proxbox`.
+The current repository code targets NetBox `4.6.x` (certified against `v4.6.0-beta2`), but the repository is ahead of the latest published PyPI build of `netbox-proxbox`.
 
 If you need the code documented in this repository, use [Installing the Plugin Using Git](./2-installing-plugin-git.md) instead.
 
@@ -28,7 +28,7 @@ PLUGINS = ["netbox_proxbox"]
 
 ## Recommendation
 
-For NetBox `4.5.x`, prefer the Git/source installation path documented in this repository.
+For NetBox `4.6.x`, prefer the Git/source installation path documented in this repository.
 
 ## Next Step
 

--- a/docs/installation/2-installing-plugin-git.md
+++ b/docs/installation/2-installing-plugin-git.md
@@ -4,7 +4,7 @@ This is the recommended installation path for the current repository state.
 
 ## Why This Is Recommended
 
-The code in this repository is `0.0.11` and targets NetBox `4.5.x` (including NetBox `v4.5.7`). That is the version line reflected by the docs in this repository.
+The code in this repository is `0.0.13.post1` and targets NetBox `4.6.x` (certified against `v4.6.0-beta2`). That is the version line reflected by the docs in this repository.
 
 ## Install
 
@@ -31,8 +31,8 @@ PLUGINS = ["netbox_proxbox"]
 
 ## Notes
 
-- The plugin declares `min_version = "4.5.0"` and `max_version = "4.5.99"`.
-- NetBox `v4.5.7` introduces django-rq `4.0` support; Proxbox uses NetBox's JobRunner queue APIs and is compatible with this line.
+- The plugin declares `min_version = "4.6.0"` and `max_version = "4.6.99"`.
+- Proxbox uses NetBox's JobRunner queue APIs and runs on the default RQ queue (`RQ_QUEUE_DEFAULT`).
 - The project requires Python `>=3.12`.
 - `pip install -e` is useful while the repository is moving faster than packaged releases.
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -21,9 +21,10 @@ pip install -e /opt/netbox/netbox/netbox-proxbox
 
 ## Important Notes
 
-- Proxbox `0.0.12` targets NetBox `4.6.x`. If you are still on NetBox `4.5.x`, use `0.0.11`.
+- Proxbox `0.0.13.post1` is the current release for NetBox `4.6.x` (certified against `v4.6.0-beta2`). It pins `proxbox-api==0.0.9`. If you are still on NetBox `4.5.x`, stay on `0.0.11`.
 - Recent releases moved sync execution to NetBox Jobs and the default RQ queue, so keep a standard NetBox RQ worker running after upgrade.
-- Review the release notes before jumping from older `0.0.7` or early `0.0.9` installs; the `0.0.11` line continues the NetBox `4.5.x` compatibility range while `0.0.12` requires NetBox `4.6.0` or later.
+- Review the release notes before jumping from older `0.0.7` or early `0.0.9` installs; the `0.0.11` line continues the NetBox `4.5.x` compatibility range while `0.0.12` and later require NetBox `4.6.0` or later.
+- Upgrading to `0.0.13` introduces 16 new per-endpoint `overwrite_*` columns on `ProxmoxEndpoint`. The migration ships in this release; no manual schema work is required, but plan for the migration to run during the upgrade window.
 
 ## Backend Upgrade
 

--- a/docs/models/others.md
+++ b/docs/models/others.md
@@ -2,9 +2,11 @@
 
 The plugin's main plugin-specific models are:
 
-- `ProxmoxEndpoint`: Proxmox cluster or node credentials and connectivity settings
-- `NetBoxEndpoint`: target NetBox API endpoint and token configuration
-- `FastAPIEndpoint`: `proxbox-api` backend connectivity settings
+- `ProxmoxEndpoint`: Proxmox cluster or node credentials and connectivity settings (with per-endpoint sync overwrite flags and a Settings tab)
+- `NetBoxEndpoint`: target NetBox API endpoint and token configuration (singleton)
+- `FastAPIEndpoint`: `proxbox-api` backend connectivity settings (singleton)
+- `ProxmoxCluster`: synchronized cluster metadata linked to NetBox `Cluster`
+- `ProxmoxNode`: synchronized hypervisor node metadata linked to NetBox `Device`
 - `ProxmoxStorage`: synchronized storage rows linked to NetBox clusters and virtual disks
 - `VMBackup`: backup metadata for synchronized virtual machines
 - `VMSnapshot`: snapshot metadata for synchronized virtual machines

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -4,12 +4,14 @@ This section tracks the release line represented by this repository and keeps ol
 
 ## Current Release Line
 
-The plugin source in this repository is currently `0.0.12`.
+The plugin source in this repository is currently `0.0.13.post1`.
 
 ## Highlights By Version
 
 | Version | Summary |
 |---------|---------|
+| `0.0.13.post1` | Bumps `proxbox-api==0.0.9` pin; certifies NetBox `v4.6.0-beta2`; documents endpoint import/export page; CI screenshot rebase fix |
+| `0.0.13` | Per-endpoint Settings tab on ProxmoxEndpoint detail; surfaces all `overwrite_*` flags in the plugin UI with tri-state semantics; VM-sync device flag enforcement (overwrite_device_*) honored end-to-end; merge-semantics label for `overwrite_vm_tags`; `_ensure_device` fix; narrowed broad except handlers in sync views and template tags |
 | `0.0.12` | NetBox 4.6.x support; native `VirtualMachineType` sync (QEMU / LXC); Clusters list page and API; site/tenant on ProxmoxEndpoint; ships with proxbox-api v0.0.8.post1 |
 | `0.0.11` | Backup Routines, individual sync buttons, live job panel, Backend Logs, encryption key, endpoint CSV import/export, auto-push NetBox config to backend, three-tier error severity, extended storage/replication views, and many bug fixes |
 | `0.0.10` | Cluster and node tracking with NetBox Cluster/Device links; Mode field fix on endpoint detail |

--- a/docs/release-notes/version-0.0.13.md
+++ b/docs/release-notes/version-0.0.13.md
@@ -1,0 +1,78 @@
+# Version 0.0.13
+
+## Summary
+
+Version 0.0.13 surfaces every `overwrite_*` flag in the plugin UI, adds a per-endpoint **Settings** tab on `ProxmoxEndpoint` detail, and enforces VM-sync device flags end-to-end through the proxbox-api stream. It pairs with `proxbox-api==0.0.9` and certifies NetBox `v4.6.0-beta2`.
+
+`0.0.13.post1` is a packaging follow-up that pins `proxbox-api==0.0.9`, certifies NetBox `v4.6.0-beta2` against the published Docker Hub image, and re-publishes the documentation site with the endpoint import/export feature page surfaced.
+
+## Compatibility
+
+| NetBox         | netbox-proxbox  | proxbox-api | netbox-sdk   | proxmox-sdk    |
+|----------------|-----------------|-------------|--------------|----------------|
+| >=4.6.0-beta2  | v0.0.13.post1   | v0.0.9      | v0.0.7.post6 | v0.0.3.post1   |
+| >=4.6.0-beta1  | v0.0.13         | v0.0.9      | v0.0.7.post6 | v0.0.3.post1   |
+
+NetBox compatibility range: `4.6.0` – `4.6.99`.
+
+---
+
+## New Features
+
+### Per-Endpoint Settings Tab
+
+`ProxmoxEndpoint` detail pages gain a dedicated **Settings** tab that exposes every per-endpoint overwrite control alongside global plugin defaults. The tab is wired through `register_model_view` and reuses the existing `ConditionalLoginRequiredMixin` permission flow. See `netbox_proxbox/views/settings.py`.
+
+### All `overwrite_*` Flags Surfaced
+
+Every `overwrite_*` column on `ProxmoxEndpoint` and `ProxboxPluginSettings` is now configurable from the UI with tri-state semantics:
+
+- **Use plugin default** (None) — fall back to the global `ProxboxPluginSettings` value.
+- **Always overwrite** (True) — the sync overwrites the NetBox value.
+- **Never overwrite** (False) — preserve the existing NetBox value.
+
+The 16 new per-endpoint columns ship in migration `0035_overwrite_fields_expansion`. See [`Sync Overwrite Flags`](../configuration/sync-overwrite-flags.md) for the full flag matrix.
+
+### VM-Sync Device Flag Enforcement
+
+When a VM sync runs, the per-endpoint `overwrite_device_*` flags are now read on the plugin side and forwarded as query parameters to the proxbox-api `full-update/stream` endpoint. The backend honors them when reconciling Proxmox node devices into NetBox. See PR #342.
+
+### Endpoint Import/Export Feature Page
+
+The CSV/JSON/YAML import and export pages for `ProxmoxEndpoint`, `NetBoxEndpoint`, and `FastAPIEndpoint` are now documented as a first-class feature. See [`Endpoint Import/Export`](../features/endpoint-import-export.md).
+
+### Merge Semantics for `overwrite_vm_tags`
+
+The `overwrite_vm_tags` form label and help text now make clear that the flag controls **merge vs replace** semantics for VM tags, not append-only behavior.
+
+---
+
+## Bug Fixes
+
+| Area | Fix |
+|------|-----|
+| Sync | `_ensure_device` now resolves the existing NetBox device instead of creating a duplicate when a Proxmox node maps to an existing record |
+| Exception handling | Narrowed broad `except Exception` clauses in `views/sync.py` enqueue paths and `templatetags/proxbox_tags.py` |
+| CI | Reverted `NETBOX_IMAGE` to `v4.6.0-beta1` temporarily when `beta2` was unavailable on Docker Hub; restored to `v4.6.0-beta2` in `0.0.13.post1` |
+| CI | Rebase before push in `docs-screenshots.yml` to avoid rejection when `develop` moves during a screenshot run |
+| Settings | All `overwrite_vm_tags` references updated to reflect merge semantics |
+
+---
+
+## Database Migrations
+
+- `0033_pluginsettings_controlled_fields` — adds the global `overwrite_*` defaults to `ProxboxPluginSettings`.
+- `0034_proxmoxendpoint_overwrite_fields` — adds the initial set of per-endpoint `overwrite_*` columns to `ProxmoxEndpoint`.
+- `0035_overwrite_fields_expansion` — adds the remaining 16 per-endpoint `overwrite_*` columns so every flag has tri-state semantics.
+
+```bash
+python manage.py migrate netbox_proxbox
+```
+
+---
+
+## CI / Release Pipeline
+
+- `e2e-docker.yml` and `docs-screenshots.yml` certify `netboxcommunity/netbox:v4.6.0-beta2`.
+- The release pipeline gains a `dependency_mode` input (`dev` vs `published`) so pre-publish E2E runs against the proxbox-api source while post-publish E2E runs against the released Docker Hub image.
+- `e2e-docker.yml` and `docs-screenshots.yml` pin `PROXBOX_API_RELEASE_VERSION=0.0.9`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
     - Scheduled Sync: 'features/scheduled-sync.md'
     - Background Jobs: 'features/background-jobs.md'
     - Virtual Machine: 'features/virtual-machine.md'
+    - Proxmox Config Tab: 'features/proxmox-config-tab.md'
     - Containers: 'features/containers.md'
     - Network: 'features/network.md'
     - VLAN Management: 'features/vlan-management.md'
@@ -134,6 +135,7 @@ nav:
     - Other Models: 'models/others.md'
   - Release Notes:
     - Summary: 'release-notes/index.md'
+    - Version 0.0.13: 'release-notes/version-0.0.13.md'
     - Version 0.0.12: 'release-notes/version-0.0.12.md'
     - Version 0.0.11: 'release-notes/version-0.0.11.md'
     - Version 0.0.10: 'release-notes/version-0.0.10.md'

--- a/netbox_proxbox/services/service_status.py
+++ b/netbox_proxbox/services/service_status.py
@@ -244,8 +244,13 @@ class ServiceStatus:
                 ip_url = fastapi_detail.get("ip_address_url")
                 if ip_url:
                     try:
+                        # Intentional fallback to IP URL after SSL hostname
+                        # failure; the endpoint operator already opted into
+                        # verify=False at config time on the FastAPIEndpoint.
                         response = requests.get(
-                            ip_url, verify=False, timeout=self.request_timeout
+                            ip_url,
+                            verify=False,  # nosec B501
+                            timeout=self.request_timeout,
                         )
                         response.raise_for_status()
                         connected = True

--- a/netbox_proxbox/template_content.py
+++ b/netbox_proxbox/template_content.py
@@ -94,7 +94,8 @@ class ProxboxJobTemplateExtension(PluginTemplateExtension):
                     {"job": obj},
                 )
             )
-        return mark_safe("".join(parts))
+        # Joined HTML comes from this plugin's own templates rendered above.
+        return mark_safe("".join(parts))  # nosec
 
     def buttons(self) -> str:
         """Render Run now and Cancel buttons on Proxbox Sync job detail pages.
@@ -131,7 +132,8 @@ class ProxboxJobTemplateExtension(PluginTemplateExtension):
                     )
                 )
 
-        return mark_safe("".join(parts)) if parts else ""
+        # Joined HTML comes from this plugin's own templates rendered above.
+        return mark_safe("".join(parts)) if parts else ""  # nosec
 
     def left_page(self) -> str:
         """Show last Proxbox sync runtime and stage summary on Job detail."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,24 @@ packages = ["netbox_proxbox", "proxbox_cli"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 
+[tool.coverage.run]
+branch = true
+source = ["netbox_proxbox"]
+omit = [
+    "netbox_proxbox/migrations/*",
+    "**/__pycache__/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]
+
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -11,6 +11,15 @@ This directory contains the plugin's pytest test suite.
 - `test_cli_contracts.py`, `test_form_and_helper_source_contracts.py`, `test_frontend_contracts.py`: CLI, form/helper, and DOM/template/view contract coverage.
 - `test_jobs.py`, `test_job_cancel.py`, `test_vm_sync_now_view.py`: job queueing, cancellation, and targeted VM sync behavior.
 - `test_individual_sync_service.py`, `test_models_cluster.py`, `test_openapi_schema_service.py`, `test_proxmox_export_view.py`, `test_schedule_hints.py`, `test_schedule_sync_view.py`, `test_schemas.py`, `test_sync.py`, `test_sync_cluster.py`, `test_sync_now_cluster_node.py`, `test_utils.py`: service, model, schema, sync, and utility behavior.
+- `test_version.py`: AST-based pin on `ProxboxConfig.version`, `min_version`, `max_version`. Fails loudly when one drifts so docs and release notes stay aligned.
+- `test_signals.py`: AST contract for the three `@receiver(post_save)` handlers in `netbox_proxbox/signals.py` that bootstrap the proxbox-api backend.
+- `test_services_http_client.py`: behavior tests for `RequestsHttpClient` exception translation (`HttpConnectionError`, `HttpTimeoutError`, `HttpSslError`) and the singleton accessor; uses `unittest.mock` against `requests.get/post/put/delete`.
+- `test_views_error_utils.py`: behavior tests for `parse_requests_response_json`, `extract_backend_error_detail`, and `extract_proxmox_backend_error_detail` covering connection-refused, timeout, HTML-on-error, generic-detail-with-message, and Python-exception-append branches.
+- `test_services_sync_backup_routines.py`: behavior tests for the `_get_backup_routine_id_from_job_id` helper and the early-exit error paths of `sync_backup_routines`. Stubs Django/NetBox via importlib + `sys.modules`.
+- `test_services_backend_context.py`: AST contract for `get_fastapi_request_context` / `get_fastapi_endpoint_with_token` signatures and the three endpoint-resolution branches in `services/backend_context.py`.
+- `test_views_vm_config.py`: AST contract for `ProxmoxVMConfigTabView` — `register_model_view` path/name, `ObjectView` base, `ViewTab` label/permission, and the helper extractors.
+- `test_views_storage.py`: AST contract for the eight `ProxmoxStorage*` view classes — `__all__` membership, list-view `path=""` registration, child-tab paths/labels/permissions, and the detail view's short `request_timeout`.
+- `test_vm_sync_device_flag_enforcement.py`: pins PR #342. Asserts the six `overwrite_device_*` fields are in `OVERWRITE_FIELDS` and that `_build_base_query_params` serializes per-endpoint device-flag values into the SSE query string.
 - `test_backup_replication_views.py`: view coverage for backup routine and replication list/detail pages.
 - `test_home_context.py`: tests for home page context assembly.
 - `test_stack_setup.py`, `test_stack_sync_polling.py`: integration-level stack setup and sync polling behavior tests.
@@ -28,6 +37,9 @@ This directory contains the plugin's pytest test suite.
 - Tests rely heavily on compatibility stubs in `conftest.py` rather than a live NetBox database.
 - When changing view, job-enqueue, or template contracts, update both the runtime code and those stubs.
 - `test_frontend_contracts.py` guards against accidental regressions in public-facing attribute names and JS function signatures.
+- **Optional-dependency tests:** `test_sse_schema_mirror.py` is a contract-mirror test that requires `proxbox-api` on the import path. It uses `pytest.importorskip("proxbox_api...")` and is silently skipped in the standard CI matrix; the nightly contracts workflow installs `proxbox-api` from PyPI and runs this file explicitly so cross-repo overwrite-flag drift is detected.
+- **AST-based source contracts** (e.g. `test_version.py`, `test_signals.py`, `test_services_backend_context.py`, `test_views_vm_config.py`, `test_views_storage.py`) parse the relevant module with `ast` and never bootstrap Django. Use this pattern when the runtime cost of starting NetBox would dominate the test value — it is the same approach as `test_proxmox_endpoint_settings_view.py`.
+- **Coverage:** `pyproject.toml` defines `[tool.coverage.run]` with `source = ["netbox_proxbox"]` and `branch = true`, plus `[tool.coverage.report]` with `exclude_lines` for `TYPE_CHECKING` and `pragma: no cover` markers. CI invokes `pytest --cov=netbox_proxbox`.
 
 ## Links
 

--- a/tests/test_proxmox_endpoint_settings_view.py
+++ b/tests/test_proxmox_endpoint_settings_view.py
@@ -21,6 +21,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROXMOX_VIEW_PATH = REPO_ROOT / "netbox_proxbox" / "views" / "endpoints" / "proxmox.py"
+PROXMOX_FORM_PATH = REPO_ROOT / "netbox_proxbox" / "forms" / "proxmox.py"
 
 
 @pytest.fixture(scope="module")
@@ -143,3 +144,45 @@ def test_get_extra_context_exposes_overwrite_field_groups():
     flat = tuple(field for _name, fields in groups for field in fields)
     assert flat == mod.OVERWRITE_FIELDS
     assert len(flat) == 21
+
+
+# ── Form-level label semantics ───────────────────────────────────────────────
+
+
+def test_overwrite_vm_tags_uses_merge_label():
+    """``overwrite_vm_tags`` is the one tri-state flag with merge (not replace)
+    semantics; the Settings form must surface that distinction in its label
+    so operators are not surprised by the additive behavior (commit 66ec814).
+    """
+    source = PROXMOX_FORM_PATH.read_text(encoding="utf-8")
+    module = ast.parse(source)
+
+    settings_form = _find_class(module, "ProxmoxEndpointSettingsForm")
+    assert settings_form is not None, (
+        "ProxmoxEndpointSettingsForm missing from forms/proxmox.py"
+    )
+
+    init = next(
+        (
+            n
+            for n in settings_form.body
+            if isinstance(n, ast.FunctionDef) and n.name == "__init__"
+        ),
+        None,
+    )
+    assert init is not None, "ProxmoxEndpointSettingsForm.__init__ not found"
+
+    label_constants: list[str] = []
+    for node in ast.walk(init):
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == "label":
+                    if isinstance(node.value, ast.Constant) and isinstance(
+                        node.value.value, str
+                    ):
+                        label_constants.append(node.value.value)
+
+    assert "Merge VM tags" in label_constants, (
+        "Settings form must override the overwrite_vm_tags label to 'Merge VM tags' "
+        "so the merge-not-replace semantics are visible in the UI"
+    )

--- a/tests/test_services_backend_context.py
+++ b/tests/test_services_backend_context.py
@@ -1,0 +1,98 @@
+"""Source-contract tests for ``services.backend_context``.
+
+This module is the single source of truth for ``get_fastapi_request_context()``
+and ``get_fastapi_endpoint_with_token()``. Both helpers are imported from many
+view modules to resolve the active FastAPIEndpoint singleton, so the public
+shape of the module must stay stable. We assert it without bootstrapping
+NetBox/Django.
+
+What the contract pins down:
+
+* ``get_fastapi_request_context`` accepts an optional ``endpoint_id`` (defaults
+  to ``None``) and returns ``BackendRequestContext | None``.
+* ``get_fastapi_endpoint_with_token`` falls back from "explicit endpoint_id" →
+  "single endpoint" → "first endpoint" — the three branches that view code
+  relies on.
+* Module imports the ``BackendRequestContext`` schema and the
+  ``ensure_backend_key_registered`` helper used by the auth-retry path.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_CONTEXT_PATH = REPO_ROOT / "netbox_proxbox" / "services" / "backend_context.py"
+
+
+def _module() -> ast.Module:
+    return ast.parse(BACKEND_CONTEXT_PATH.read_text(encoding="utf-8"))
+
+
+def _functions_by_name(module: ast.Module) -> dict[str, ast.FunctionDef]:
+    return {n.name: n for n in module.body if isinstance(n, ast.FunctionDef)}
+
+
+def test_module_imports_required_collaborators():
+    source = BACKEND_CONTEXT_PATH.read_text(encoding="utf-8")
+    assert "from netbox_proxbox.models import FastAPIEndpoint" in source
+    assert "BackendRequestContext" in source
+    assert "ensure_backend_key_registered" in source
+
+
+def test_get_fastapi_request_context_signature_is_stable():
+    funcs = _functions_by_name(_module())
+    assert "get_fastapi_request_context" in funcs, (
+        "get_fastapi_request_context is imported by view code; do not rename"
+    )
+    func = funcs["get_fastapi_request_context"]
+    arg_names = [a.arg for a in func.args.args]
+    assert arg_names == ["endpoint_id"]
+    assert len(func.args.defaults) == 1, (
+        "endpoint_id must remain optional so call sites without an id keep working"
+    )
+
+
+def test_get_fastapi_endpoint_with_token_returns_tuple():
+    funcs = _functions_by_name(_module())
+    assert "get_fastapi_endpoint_with_token" in funcs
+    func = funcs["get_fastapi_endpoint_with_token"]
+
+    return_paths: list[ast.AST] = [
+        n for n in ast.walk(func) if isinstance(n, ast.Return)
+    ]
+    assert return_paths, "get_fastapi_endpoint_with_token must return a value"
+    for ret in return_paths:
+        assert isinstance(ret.value, ast.Tuple), (
+            "all return paths must yield a (endpoint, context) tuple — a single value "
+            "would silently break unpacking in callers"
+        )
+        assert len(ret.value.elts) == 2
+
+
+def test_endpoint_lookup_handles_three_branches():
+    """Endpoint resolution must cover: explicit id, single row, multi-row first()."""
+    source = BACKEND_CONTEXT_PATH.read_text(encoding="utf-8")
+    # explicit id branch:
+    assert "filter(pk=endpoint_id)" in source
+    # single-row branch:
+    assert "objects.first()" in source
+    # multi-row branch:
+    assert 'order_by("pk")' in source
+    # count gate before the multi-row pick:
+    assert "objects.count()" in source
+
+
+def test_auth_retry_helper_returns_two_tuple_with_retry_flag():
+    funcs = _functions_by_name(_module())
+    helper = funcs.get("_handle_auth_registration_and_retry")
+    assert helper is not None, (
+        "_handle_auth_registration_and_retry is the auth-retry hook used by "
+        "backend_proxy; do not delete or rename"
+    )
+    for ret in ast.walk(helper):
+        if isinstance(ret, ast.Return):
+            assert isinstance(ret.value, ast.Tuple) and len(ret.value.elts) == 2, (
+                "_handle_auth_registration_and_retry must return (headers, retry_flag)"
+            )

--- a/tests/test_services_http_client.py
+++ b/tests/test_services_http_client.py
@@ -1,0 +1,157 @@
+"""Behavior tests for ``netbox_proxbox.services.http_client``.
+
+The plugin's HTTP layer is a thin wrapper that translates ``requests``
+exceptions into typed ``HttpError`` subclasses (``HttpConnectionError``,
+``HttpTimeoutError``, ``HttpSslError``). The translation is what allows
+upstream callers — for example the dashboard keepalive checks and the SSE
+proxy — to surface specific user-facing messages without re-classifying raw
+``requests`` exceptions over and over.
+
+These tests load ``http_client.py`` directly (no Django stack required), patch
+``requests.get/post/put/delete`` with ``unittest.mock`` and verify:
+
+1. Successful calls return an ``HttpResponse`` wrapping the mocked
+   ``requests.Response``.
+2. Each ``requests`` exception subclass is mapped to the matching
+   ``HttpError`` subclass.
+3. ``stream_get`` is a context manager that closes the underlying response
+   even when the body raises mid-iteration.
+4. ``get_default_http_client()`` is a singleton.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def http_client_module():
+    spec = importlib.util.spec_from_file_location(
+        "_netbox_proxbox_http_client_under_test",
+        REPO_ROOT / "netbox_proxbox" / "services" / "http_client.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_response(status_code: int = 200, text: str = "ok") -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp._content = text.encode("utf-8")
+    resp.url = "http://test/"
+    resp.headers["Content-Type"] = "application/json"
+    return resp
+
+
+# ── Successful round-trips ───────────────────────────────────────────────────
+
+
+def test_get_returns_wrapped_response(http_client_module):
+    client = http_client_module.RequestsHttpClient()
+    raw = _make_response(204, "")
+    with patch("requests.get", return_value=raw) as mock_get:
+        resp = client.get("http://x/", headers={"a": "b"}, timeout=7, verify=False)
+    assert isinstance(resp, http_client_module.HttpResponse)
+    assert resp.status_code == 204
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["timeout"] == 7
+    assert mock_get.call_args.kwargs["verify"] is False
+    assert mock_get.call_args.kwargs["stream"] is False
+
+
+def test_post_passes_json_payload(http_client_module):
+    client = http_client_module.RequestsHttpClient()
+    raw = _make_response(201, '{"ok":true}')
+    with patch("requests.post", return_value=raw) as mock_post:
+        resp = client.post("http://x/", json={"a": 1})
+    assert resp.status_code == 201
+    assert mock_post.call_args.kwargs["json"] == {"a": 1}
+
+
+# ── Exception translation ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("requests_exc", "expected_attr"),
+    [
+        (requests.exceptions.SSLError("bad cert"), "HttpSslError"),
+        (requests.exceptions.Timeout("slow"), "HttpTimeoutError"),
+        (requests.exceptions.ConnectionError("refused"), "HttpConnectionError"),
+        (requests.exceptions.RequestException("other"), "HttpError"),
+    ],
+)
+def test_get_translates_each_requests_exception(
+    http_client_module, requests_exc, expected_attr
+):
+    client = http_client_module.RequestsHttpClient()
+    expected_cls = getattr(http_client_module, expected_attr)
+    with patch("requests.get", side_effect=requests_exc):
+        with pytest.raises(expected_cls):
+            client.get("http://x/")
+
+
+def test_post_put_delete_also_translate_exceptions(http_client_module):
+    client = http_client_module.RequestsHttpClient()
+    err = requests.exceptions.ConnectionError("refused")
+    for method, target in (
+        (client.post, "requests.post"),
+        (client.put, "requests.put"),
+        (client.delete, "requests.delete"),
+    ):
+        with patch(target, side_effect=err):
+            with pytest.raises(http_client_module.HttpConnectionError):
+                method("http://x/")
+
+
+# ── Streaming ────────────────────────────────────────────────────────────────
+
+
+def test_stream_get_closes_response_on_exit(http_client_module):
+    client = http_client_module.RequestsHttpClient()
+    closed = {"value": False}
+
+    raw = SimpleNamespace(
+        status_code=200,
+        ok=True,
+        text="",
+        url="http://x/",
+        headers={},
+        json=lambda: {},
+        raise_for_status=lambda: None,
+        iter_lines=lambda decode_unicode=False: iter(["a", "b"]),
+        close=lambda: closed.update(value=True),
+    )
+
+    with patch("requests.get", return_value=raw):
+        with client.stream_get("http://x/") as resp:
+            assert resp.status_code == 200
+            list(resp.iter_lines(decode_unicode=True))
+    assert closed["value"], "stream_get must close the response on exit"
+
+
+def test_stream_get_translates_initial_connection_error(http_client_module):
+    client = http_client_module.RequestsHttpClient()
+    with patch("requests.get", side_effect=requests.exceptions.SSLError("bad cert")):
+        cm = client.stream_get("http://x/")
+        with pytest.raises(http_client_module.HttpSslError):
+            cm.__enter__()
+
+
+# ── Singleton accessor ───────────────────────────────────────────────────────
+
+
+def test_get_default_http_client_is_singleton(http_client_module):
+    a = http_client_module.get_default_http_client()
+    b = http_client_module.get_default_http_client()
+    assert a is b
+    assert isinstance(a, http_client_module.RequestsHttpClient)

--- a/tests/test_services_sync_backup_routines.py
+++ b/tests/test_services_sync_backup_routines.py
@@ -1,0 +1,197 @@
+"""Behavior tests for ``services.sync_backup_routines.sync_backup_routines``.
+
+The full sync orchestration is heavy (Django ORM, transaction.atomic,
+proxbox-api HTTP, Pydantic schema validation). The two pieces that are easy to
+break in isolation are the small helpers and the early-exit error paths:
+
+* ``_get_backup_routine_id_from_job_id`` — splits Proxmox job ids of the form
+  ``"local:123"`` so they can be matched against backend records.
+* The "endpoint not found" / "FastAPI URL not configured" branches that abort
+  without touching the database.
+
+This test file loads the module via importlib with stubbed ``django``,
+``netbox_proxbox.models``, ``netbox_proxbox.choices``,
+``netbox_proxbox.schemas.backup_routine``, and ``netbox_proxbox.services.*``
+modules so it can exercise those paths without a NetBox environment.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def sync_backup_module(monkeypatch):
+    pkg = types.ModuleType("netbox_proxbox")
+    pkg.__path__ = [str(REPO_ROOT / "netbox_proxbox")]
+    monkeypatch.setitem(sys.modules, "netbox_proxbox", pkg)
+
+    choices = types.ModuleType("netbox_proxbox.choices")
+    choices.BackupRoutineStatusChoices = SimpleNamespace(ACTIVE="active", STALE="stale")
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.choices", choices)
+
+    class _DoesNotExist(Exception):
+        pass
+
+    class _Manager:
+        def __init__(self, item: object | None = None):
+            self.item = item
+
+        def get(self, **_kwargs):
+            if self.item is None:
+                raise _DoesNotExist()
+            return self.item
+
+        def filter(self, **_kwargs):
+            return self
+
+        def values_list(self, *_args, **_kwargs):
+            return []
+
+        def update(self, **_kwargs):
+            return (0, {})
+
+        def update_or_create(self, defaults, **_kwargs):
+            return SimpleNamespace(), True
+
+        def first(self):
+            return self.item
+
+        def count(self):
+            return 0
+
+    class _ProxmoxEndpoint:
+        DoesNotExist = _DoesNotExist
+        objects = _Manager(SimpleNamespace(pk=1, name="pve"))
+
+    class _ProxmoxNode:
+        DoesNotExist = _DoesNotExist
+        objects = _Manager()
+
+    class _ProxmoxStorage:
+        DoesNotExist = _DoesNotExist
+        objects = _Manager()
+
+    class _BackupRoutine:
+        objects = _Manager()
+
+    models = types.ModuleType("netbox_proxbox.models")
+    models.BackupRoutine = _BackupRoutine
+    models.ProxmoxEndpoint = _ProxmoxEndpoint
+    models.ProxmoxNode = _ProxmoxNode
+    models.ProxmoxStorage = _ProxmoxStorage
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.models", models)
+
+    schemas_pkg = types.ModuleType("netbox_proxbox.schemas")
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.schemas", schemas_pkg)
+
+    backup_schema = types.ModuleType("netbox_proxbox.schemas.backup_routine")
+
+    class _Schema:
+        @classmethod
+        def model_validate(cls, _data):
+            return cls()
+
+        def model_dump(self, **_kwargs):
+            return {}
+
+    backup_schema.GetClusterBackupIdResponse = _Schema
+    backup_schema.BackupRoutineSchema = _Schema
+    monkeypatch.setitem(
+        sys.modules, "netbox_proxbox.schemas.backup_routine", backup_schema
+    )
+
+    services_pkg = types.ModuleType("netbox_proxbox.services")
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.services", services_pkg)
+
+    backend_proxy = types.ModuleType("netbox_proxbox.services.backend_proxy")
+    backend_proxy.get_fastapi_request_context = lambda: None
+    monkeypatch.setitem(
+        sys.modules, "netbox_proxbox.services.backend_proxy", backend_proxy
+    )
+
+    django_pkg = types.ModuleType("django")
+    monkeypatch.setitem(sys.modules, "django", django_pkg)
+    db_mod = types.ModuleType("django.db")
+
+    class _Atomic:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    db_mod.transaction = SimpleNamespace(atomic=lambda: _Atomic())
+    monkeypatch.setitem(sys.modules, "django.db", db_mod)
+
+    sys.modules.pop("netbox_proxbox.services.sync_backup_routines", None)
+    spec = importlib.util.spec_from_file_location(
+        "netbox_proxbox.services.sync_backup_routines",
+        REPO_ROOT / "netbox_proxbox" / "services" / "sync_backup_routines.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["netbox_proxbox.services.sync_backup_routines"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_backup_routine_id_from_job_id_strips_storage_prefix(sync_backup_module):
+    assert sync_backup_module._get_backup_routine_id_from_job_id("local:123") == "123"
+    assert sync_backup_module._get_backup_routine_id_from_job_id("nfs:abc") == "abc"
+
+
+def test_get_backup_routine_id_from_job_id_returns_input_when_no_colon(
+    sync_backup_module,
+):
+    assert (
+        sync_backup_module._get_backup_routine_id_from_job_id("backup-1") == "backup-1"
+    )
+
+
+def test_sync_returns_error_when_endpoint_missing(sync_backup_module, monkeypatch):
+    """Missing ProxmoxEndpoint must short-circuit before any HTTP call."""
+    from netbox_proxbox.models import ProxmoxEndpoint
+
+    ProxmoxEndpoint.objects = type(ProxmoxEndpoint.objects)(item=None)
+
+    with patch("requests.get") as mock_get:
+        result = sync_backup_module.sync_backup_routines(endpoint_id=42)
+    assert result == {"success": False, "error": "Endpoint not found"}
+    mock_get.assert_not_called()
+
+
+def test_sync_returns_error_when_no_fastapi_url_and_context_missing(
+    sync_backup_module,
+):
+    """If no FastAPI URL is configured and no context resolves, abort."""
+    sync_backup_module.get_fastapi_request_context = lambda: None
+    with patch("requests.get") as mock_get:
+        result = sync_backup_module.sync_backup_routines(endpoint_id=1)
+    assert result["success"] is False
+    assert "FastAPI URL not configured" in result["error"]
+    mock_get.assert_not_called()
+
+
+def test_sync_propagates_http_error_for_list_endpoint(sync_backup_module):
+    """A request error on the job-list endpoint should be reported, not raised."""
+    import requests as real_requests
+
+    err = real_requests.exceptions.ConnectionError("refused")
+    with patch("requests.get", side_effect=err):
+        result = sync_backup_module.sync_backup_routines(
+            endpoint_id=1,
+            fastapi_url="http://backend:8000",
+            auth_headers={"X-Proxbox-API-Key": "k"},
+        )
+    assert result["success"] is False
+    assert "HTTP error fetching backup routine list" in result["error"]

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,82 @@
+"""Source-contract test for the plugin's Django signal handlers.
+
+These signals automatically generate API tokens and register FastAPI/NetBox
+endpoint records with the proxbox-api backend after a NetBox-side save. They
+are easy to break by accident — for example by swapping ``post_save`` for a
+``pre_save`` signal, dropping the ``@receiver`` decorator, or changing the
+sender to a non-string class reference (which then fails to import at app load
+time inside NetBox).
+
+The contract is verified statically against ``netbox_proxbox/signals.py`` so
+the test runs without booting Django or NetBox.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SIGNALS_PATH = REPO_ROOT / "netbox_proxbox" / "signals.py"
+
+EXPECTED_RECEIVERS: dict[str, str] = {
+    "ensure_fastapi_endpoint_token": "netbox_proxbox.FastAPIEndpoint",
+    "ensure_proxmox_endpoint_has_fastapi_token": "netbox_proxbox.ProxmoxEndpoint",
+    "sync_netbox_endpoint_to_backend": "netbox_proxbox.NetBoxEndpoint",
+}
+
+
+def _registered_receivers(module: ast.Module) -> dict[str, dict[str, str]]:
+    """Walk the module AST and pull (signal, sender) for every @receiver def."""
+    found: dict[str, dict[str, str]] = {}
+    for node in ast.walk(module):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for deco in node.decorator_list:
+            if not isinstance(deco, ast.Call):
+                continue
+            if not (isinstance(deco.func, ast.Name) and deco.func.id == "receiver"):
+                continue
+
+            signal_name = ""
+            if deco.args and isinstance(deco.args[0], ast.Name):
+                signal_name = deco.args[0].id
+
+            sender = ""
+            for kw in deco.keywords:
+                if kw.arg == "sender" and isinstance(kw.value, ast.Constant):
+                    sender = str(kw.value.value)
+
+            found[node.name] = {"signal": signal_name, "sender": sender}
+    return found
+
+
+def test_signal_handlers_are_registered_with_correct_senders():
+    module = ast.parse(SIGNALS_PATH.read_text(encoding="utf-8"))
+    receivers = _registered_receivers(module)
+
+    for handler_name, expected_sender in EXPECTED_RECEIVERS.items():
+        assert handler_name in receivers, (
+            f"signal handler {handler_name!r} missing from signals.py — "
+            "endpoint creation no longer auto-bootstraps the backend"
+        )
+        info = receivers[handler_name]
+        assert info["signal"] == "post_save", (
+            f"{handler_name} no longer uses post_save; pre_save runs before the row "
+            "exists in the DB and would break token generation"
+        )
+        assert info["sender"] == expected_sender, (
+            f"{handler_name} sender drifted to {info['sender']!r}; "
+            f"expected {expected_sender!r}"
+        )
+
+
+def test_signals_module_only_uses_post_save_receivers():
+    """No accidental ``pre_save`` / ``pre_delete`` handlers — they would fire
+    before the row is committed and break the bootstrap flow."""
+    module = ast.parse(SIGNALS_PATH.read_text(encoding="utf-8"))
+    for info in _registered_receivers(module).values():
+        assert info["signal"] == "post_save", (
+            "All endpoint-bootstrap receivers must run on post_save, not "
+            f"{info['signal']!r}"
+        )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,45 @@
+"""Lock the plugin version and NetBox compatibility constants in source.
+
+The plugin's ``version``, ``min_version``, and ``max_version`` are surfaced in
+several places (docs, CI, release notes). This test parses
+``netbox_proxbox/__init__.py`` directly via AST so the assertions run without
+loading Django or NetBox; future version bumps will fail loudly here as a
+reminder to update the docs and release-notes files at the same time.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INIT_PATH = REPO_ROOT / "netbox_proxbox" / "__init__.py"
+
+
+def _class_constants(class_name: str) -> dict[str, str]:
+    module = ast.parse(INIT_PATH.read_text(encoding="utf-8"))
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            constants: dict[str, str] = {}
+            for stmt in node.body:
+                if isinstance(stmt, ast.Assign) and isinstance(
+                    stmt.value, ast.Constant
+                ):
+                    for target in stmt.targets:
+                        if isinstance(target, ast.Name):
+                            constants[target.id] = stmt.value.value
+            return constants
+    raise AssertionError(f"class {class_name} not found in {INIT_PATH}")
+
+
+def test_plugin_version_is_pinned():
+    constants = _class_constants("ProxboxConfig")
+    assert constants.get("version") == "0.0.13.post1", (
+        "version drifted; update docs/, release-notes, and pyproject.toml together"
+    )
+
+
+def test_min_max_netbox_versions_are_pinned():
+    constants = _class_constants("ProxboxConfig")
+    assert constants.get("min_version") == "4.6.0"
+    assert constants.get("max_version") == "4.6.99"

--- a/tests/test_views_error_utils.py
+++ b/tests/test_views_error_utils.py
@@ -1,0 +1,174 @@
+"""Behavior tests for ``netbox_proxbox.views.error_utils``.
+
+The plugin proxies a number of operational requests to proxbox-api and then
+renders the resulting error to the user. Two helpers normalize that error
+output:
+
+* ``parse_requests_response_json`` — guards against non-JSON 5xx HTML pages.
+* ``extract_backend_error_detail`` / ``extract_proxmox_backend_error_detail``
+  — turn ``requests`` exceptions into a user-facing message and HTTP status,
+  recognising connection-refused / timeout / HTML-instead-of-JSON cases.
+
+These helpers are pure and testable with hand-built ``requests.Response``
+instances; no Django stack is required. Loading the module via importlib lets
+the test run without booting NetBox.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import requests
+import requests.exceptions
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def error_utils_module():
+    spec = importlib.util.spec_from_file_location(
+        "_netbox_proxbox_error_utils_under_test",
+        REPO_ROOT / "netbox_proxbox" / "views" / "error_utils.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _response(
+    status_code: int,
+    body: str | bytes,
+    *,
+    content_type: str = "application/json",
+    url: str = "http://backend/",
+) -> requests.Response:
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp._content = body.encode("utf-8") if isinstance(body, str) else body
+    resp.url = url
+    resp.headers["Content-Type"] = content_type
+    return resp
+
+
+# ── parse_requests_response_json ─────────────────────────────────────────────
+
+
+def test_parse_json_returns_payload_on_valid_body(error_utils_module):
+    resp = _response(200, '{"ok": true, "n": 3}')
+    payload, detail = error_utils_module.parse_requests_response_json(resp)
+    assert payload == {"ok": True, "n": 3}
+    assert detail is None
+
+
+def test_parse_json_returns_user_facing_detail_for_html(error_utils_module):
+    resp = _response(200, "<html>nginx</html>", content_type="text/html")
+    payload, detail = error_utils_module.parse_requests_response_json(resp)
+    assert payload is None
+    assert detail is not None
+    assert "not valid JSON" in detail
+    assert "<html>nginx</html>" in detail or "Body starts with" in detail
+
+
+# ── extract_backend_error_detail (no .response set) ──────────────────────────
+
+
+def test_connection_error_with_host_port_returns_targeted_message(error_utils_module):
+    exc = requests.exceptions.ConnectionError(
+        "HTTPSConnectionPool(host='10.0.0.5', port=8800): "
+        "Max retries exceeded: connection refused"
+    )
+    detail, status = error_utils_module.extract_backend_error_detail(exc)
+    assert status is None
+    assert "10.0.0.5:8800" in detail
+    assert "Connection was refused" in detail
+
+
+def test_timeout_returns_timeout_message(error_utils_module):
+    exc = requests.exceptions.Timeout(
+        "HTTPConnectionPool(host='backend', port=8000): timed out"
+    )
+    detail, status = error_utils_module.extract_backend_error_detail(exc)
+    assert status is None
+    assert "Timed out" in detail
+    assert "backend:8000" in detail
+
+
+def test_other_request_exception_returns_str_form(error_utils_module):
+    exc = requests.exceptions.RequestException("something wrong")
+    detail, status = error_utils_module.extract_backend_error_detail(exc)
+    assert status is None
+    assert "something wrong" in detail
+
+
+# ── extract_backend_error_detail (with .response) ────────────────────────────
+
+
+def test_response_with_json_detail_field(error_utils_module):
+    resp = _response(404, '{"detail": "VM not found"}')
+    exc = requests.exceptions.HTTPError(response=resp)
+    detail, status = error_utils_module.extract_backend_error_detail(exc)
+    assert status == 404
+    assert detail == "VM not found"
+
+
+def test_response_with_generic_detail_prefers_message(error_utils_module):
+    resp = _response(
+        500,
+        '{"detail": "Internal Server Error", "message": "VM disk read failed"}',
+    )
+    exc = requests.exceptions.HTTPError(response=resp)
+    detail, status = error_utils_module.extract_backend_error_detail(exc)
+    assert status == 500
+    assert detail == "VM disk read failed"
+
+
+def test_response_html_for_400_class_status_returns_helpful_message(error_utils_module):
+    resp = _response(401, "<html>Login required</html>", content_type="text/html")
+    exc = requests.exceptions.HTTPError(response=resp)
+    detail, status = error_utils_module.extract_backend_error_detail(exc)
+    assert status == 401
+    assert "HTML instead of ProxBox API JSON" in detail
+    assert "401" in detail
+    assert "NetBox UI" in detail
+
+
+def test_response_with_python_exception_field_appended(error_utils_module):
+    resp = _response(500, '{"detail": "boom", "python_exception": "RuntimeError: x"}')
+    exc = requests.exceptions.HTTPError(response=resp)
+    detail, _ = error_utils_module.extract_backend_error_detail(exc)
+    assert "boom" in detail
+    assert "RuntimeError: x" in detail
+
+
+# ── extract_proxmox_backend_error_detail (host fallback) ─────────────────────
+
+
+def test_proxmox_error_falls_back_to_target_message_when_no_response(
+    error_utils_module,
+):
+    exc = requests.exceptions.ConnectionError("connection refused")
+    detail, status = error_utils_module.extract_proxmox_backend_error_detail(
+        exc,
+        proxmox_host="pve.local",
+        proxmox_port=8006,
+        backend_url="http://backend/proxmox/sync",
+    )
+    assert status is None
+    assert "pve.local:8006" in detail
+    assert "http://backend/proxmox/sync" in detail
+
+
+def test_proxmox_error_delegates_when_response_is_present(error_utils_module):
+    resp = _response(503, '{"detail": "Service Unavailable"}')
+    exc = requests.exceptions.HTTPError(response=resp)
+    detail, status = error_utils_module.extract_proxmox_backend_error_detail(
+        exc,
+        proxmox_host="pve.local",
+        proxmox_port=8006,
+        backend_url="http://backend/proxmox/sync",
+    )
+    assert status == 503
+    assert detail == "Service Unavailable"

--- a/tests/test_views_storage.py
+++ b/tests/test_views_storage.py
@@ -1,0 +1,178 @@
+"""Source-contract tests for the ``ProxmoxStorage`` view module.
+
+Storage list/detail/edit/delete plus the three child-tab views are referenced
+across templates, ``__init__.py`` re-exports, and the URL conf. We pin the
+public shape with AST so renaming or moving these classes is a noisy regression.
+
+What is locked here:
+
+* The eight public view classes are exported from ``__all__``.
+* ``ProxmoxStorageListView`` registers at the empty-path list URL with
+  ``detail=False`` — this is what makes ``ProxmoxStorageListView`` resolvable
+  via the standard plugin URL conf.
+* The three child-children tab views (Virtual Disks, Backups, Snapshots) are
+  registered with the documented paths ``virtual-disks``, ``backups``,
+  ``snapshots`` and have a ``ViewTab`` with the right permission.
+* The detail view's ``request_timeout`` stays at 8 seconds (template asserts
+  this is short enough to render even with backend latency).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+STORAGE_PATH = (
+    Path(__file__).resolve().parents[1] / "netbox_proxbox" / "views" / "storage.py"
+)
+
+
+def _module() -> ast.Module:
+    return ast.parse(STORAGE_PATH.read_text(encoding="utf-8"))
+
+
+EXPECTED_PUBLIC = (
+    "ProxmoxStorageView",
+    "ProxmoxStorageListView",
+    "ProxmoxStorageEditView",
+    "ProxmoxStorageDeleteView",
+    "ProxmoxStorageBulkDeleteView",
+    "ProxmoxStorageVirtualDisksTabView",
+    "ProxmoxStorageBackupsTabView",
+    "ProxmoxStorageSnapshotsTabView",
+)
+
+
+def _find_class(module: ast.Module, name: str) -> ast.ClassDef:
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found in storage.py")
+
+
+def _register_calls(cls: ast.ClassDef) -> list[ast.Call]:
+    return [
+        d
+        for d in cls.decorator_list
+        if isinstance(d, ast.Call)
+        and isinstance(d.func, ast.Name)
+        and d.func.id == "register_model_view"
+    ]
+
+
+def test_public_classes_in_all():
+    module = _module()
+    public_assign = next(
+        (
+            n.value
+            for n in module.body
+            if isinstance(n, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "__all__" for t in n.targets)
+        ),
+        None,
+    )
+    assert isinstance(public_assign, ast.Tuple)
+    exported = {e.value for e in public_assign.elts if isinstance(e, ast.Constant)}
+    for name in EXPECTED_PUBLIC:
+        assert name in exported, f"{name} dropped from storage.py __all__"
+
+
+def test_each_public_class_exists():
+    module = _module()
+    for name in EXPECTED_PUBLIC:
+        _find_class(module, name)
+
+
+def test_list_view_registers_at_empty_path_with_detail_false():
+    module = _module()
+    cls = _find_class(module, "ProxmoxStorageListView")
+    decos = _register_calls(cls)
+    assert decos, "ProxmoxStorageListView must use register_model_view"
+
+    matched = False
+    for call in decos:
+        keywords = {kw.arg: kw.value for kw in call.keywords}
+        path = keywords.get("path")
+        detail = keywords.get("detail")
+        if (
+            isinstance(path, ast.Constant)
+            and path.value == ""
+            and isinstance(detail, ast.Constant)
+            and detail.value is False
+        ):
+            matched = True
+            break
+    assert matched, (
+        "ProxmoxStorageListView must register at path='' with detail=False so the "
+        "global storage list resolves under the standard plugin URL conf"
+    )
+
+
+def test_child_tab_paths_and_permissions_are_pinned():
+    module = _module()
+    expected = {
+        "ProxmoxStorageVirtualDisksTabView": (
+            "virtual-disks",
+            "Virtual Disks",
+            "virtualization.view_virtualdisk",
+        ),
+        "ProxmoxStorageBackupsTabView": (
+            "backups",
+            "Backups",
+            "netbox_proxbox.view_vmbackup",
+        ),
+        "ProxmoxStorageSnapshotsTabView": (
+            "snapshots",
+            "Snapshots",
+            "netbox_proxbox.view_vmsnapshot",
+        ),
+    }
+    for class_name, (path, label, permission) in expected.items():
+        cls = _find_class(module, class_name)
+
+        decos = _register_calls(cls)
+        assert decos, f"{class_name} must use register_model_view"
+        paths = []
+        for call in decos:
+            for kw in call.keywords:
+                if kw.arg == "path" and isinstance(kw.value, ast.Constant):
+                    paths.append(kw.value.value)
+        assert path in paths, f"{class_name} must register path={path!r}"
+
+        tab_value = next(
+            (
+                n.value
+                for n in cls.body
+                if isinstance(n, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id == "tab" for t in n.targets)
+            ),
+            None,
+        )
+        assert isinstance(tab_value, ast.Call)
+        assert isinstance(tab_value.func, ast.Name) and tab_value.func.id == "ViewTab"
+        keywords = {kw.arg: kw.value for kw in tab_value.keywords}
+        assert isinstance(keywords["label"], ast.Constant)
+        assert keywords["label"].value == label
+        assert isinstance(keywords["permission"], ast.Constant)
+        assert keywords["permission"].value == permission
+
+
+def test_detail_view_request_timeout_is_short_enough():
+    cls = _find_class(_module(), "ProxmoxStorageView")
+    timeout_value = next(
+        (
+            n.value
+            for n in cls.body
+            if isinstance(n, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "request_timeout" for t in n.targets
+            )
+        ),
+        None,
+    )
+    assert isinstance(timeout_value, ast.Constant)
+    assert isinstance(timeout_value.value, int)
+    assert timeout_value.value <= 10, (
+        "ProxmoxStorageView.request_timeout must stay short — the storage detail "
+        "page renders inline and a slow backend should not block the request"
+    )

--- a/tests/test_views_vm_config.py
+++ b/tests/test_views_vm_config.py
@@ -1,0 +1,133 @@
+"""Source-contract tests for ``views.vm_config.ProxmoxVMConfigTabView``.
+
+Booting the full Django stack to render this view from a unit test is heavy.
+The contract that callers (templates, urls, NetBox extension registry) depend
+on is small and stable, so we lock it via AST against
+``netbox_proxbox/views/vm_config.py``:
+
+* The view is registered on ``VirtualMachine`` with ``path="proxmox-config"``
+  and the name ``"proxmox_config"`` — links and URL reverses rely on both.
+* It is an ``ObjectView`` and renders the dedicated tab template.
+* The ``ViewTab`` is labelled ``"Proxmox Config"`` with the
+  ``virtualization.view_virtualmachine`` permission so VM read-permission
+  guards the live config tab.
+* The context-builder helpers ``_extract_vmid`` and ``_extract_vm_type`` exist
+  and return ``int | None`` / a string — they're imported by future tests too.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+VM_CONFIG_PATH = (
+    Path(__file__).resolve().parents[1] / "netbox_proxbox" / "views" / "vm_config.py"
+)
+
+
+def _module() -> ast.Module:
+    return ast.parse(VM_CONFIG_PATH.read_text(encoding="utf-8"))
+
+
+def _find_class(module: ast.Module, name: str) -> ast.ClassDef:
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found in vm_config.py")
+
+
+def _assign_value(cls: ast.ClassDef, target: str) -> ast.AST | None:
+    for node in cls.body:
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == target:
+                    return node.value
+    return None
+
+
+def test_view_class_subclasses_object_view():
+    cls = _find_class(_module(), "ProxmoxVMConfigTabView")
+    base_names = {
+        b.attr if isinstance(b, ast.Attribute) else getattr(b, "id", "")
+        for b in cls.bases
+    }
+    assert "ObjectView" in base_names, (
+        "tab view must remain an ObjectView so NetBox renders it under the VM detail page"
+    )
+
+
+def test_register_model_view_pins_path_and_name():
+    cls = _find_class(_module(), "ProxmoxVMConfigTabView")
+    register_call = next(
+        (
+            d
+            for d in cls.decorator_list
+            if isinstance(d, ast.Call)
+            and isinstance(d.func, ast.Name)
+            and d.func.id == "register_model_view"
+        ),
+        None,
+    )
+    assert register_call is not None, (
+        "ProxmoxVMConfigTabView must use register_model_view"
+    )
+
+    # Positional model is VirtualMachine, second positional is the view name
+    assert isinstance(register_call.args[0], ast.Name)
+    assert register_call.args[0].id == "VirtualMachine"
+    assert isinstance(register_call.args[1], ast.Constant)
+    assert register_call.args[1].value == "proxmox_config", (
+        "URL name 'proxmox_config' is referenced by templates; do not rename"
+    )
+
+    keywords = {kw.arg: kw.value for kw in register_call.keywords}
+    assert "path" in keywords
+    assert isinstance(keywords["path"], ast.Constant)
+    assert keywords["path"].value == "proxmox-config"
+
+
+def test_view_uses_dedicated_template():
+    cls = _find_class(_module(), "ProxmoxVMConfigTabView")
+    template = _assign_value(cls, "template_name")
+    assert isinstance(template, ast.Constant)
+    assert template.value == "netbox_proxbox/vm_proxmox_config.html"
+
+
+def test_tab_metadata_uses_vm_view_permission():
+    cls = _find_class(_module(), "ProxmoxVMConfigTabView")
+    tab_value = _assign_value(cls, "tab")
+    assert isinstance(tab_value, ast.Call)
+    assert isinstance(tab_value.func, ast.Name) and tab_value.func.id == "ViewTab"
+    keywords = {kw.arg: kw.value for kw in tab_value.keywords}
+    assert isinstance(keywords["label"], ast.Constant)
+    assert keywords["label"].value == "Proxmox Config"
+    assert isinstance(keywords["permission"], ast.Constant)
+    assert keywords["permission"].value == "virtualization.view_virtualmachine"
+    assert isinstance(keywords["weight"], ast.Constant)
+    assert isinstance(keywords["weight"].value, int)
+
+
+def test_extract_helpers_exist_and_return_expected_shapes():
+    """Sanity-check the small extractors so accidental rename surfaces in tests."""
+    module = _module()
+    funcs = {n.name for n in module.body if isinstance(n, ast.FunctionDef)}
+    for name in ("_extract_vmid", "_extract_vm_type", "_extract_node"):
+        assert name in funcs, f"helper {name} dropped from vm_config.py"
+
+
+def test_view_falls_back_to_first_visible_proxmox_endpoint():
+    """When the VM's cluster name doesn't match an endpoint, the picker uses
+    the first restricted Proxmox endpoint — keep that branch alive."""
+    source = VM_CONFIG_PATH.read_text(encoding="utf-8")
+    assert 'ProxmoxEndpoint.objects.restrict(request.user, "view")' in source
+    assert "proxmox_qs.first()" in source
+
+
+def test_view_uses_error_utils_helpers_for_non_json_and_request_errors():
+    source = VM_CONFIG_PATH.read_text(encoding="utf-8")
+    assert "parse_requests_response_json" in source, (
+        "view must continue to guard against HTML-on-error backend responses"
+    )
+    assert "extract_proxmox_backend_error_detail" in source, (
+        "view must surface targeted Proxmox error messages instead of raw exceptions"
+    )

--- a/tests/test_vm_sync_device_flag_enforcement.py
+++ b/tests/test_vm_sync_device_flag_enforcement.py
@@ -1,0 +1,198 @@
+"""Lock the VM-sync device flag enforcement contract (PR #342).
+
+Ensures the six ``overwrite_device_*`` flags are part of the canonical
+``OVERWRITE_FIELDS`` tuple and that they are forwarded to the proxbox-api
+``full-update/stream`` endpoint as flat query params when a sync runs.
+
+The behavior tested:
+
+1. The six device flags listed in ``OVERWRITE_FIELD_GROUPS["Device"]`` are
+   exposed in ``OVERWRITE_FIELDS`` so every sync stage that flattens the tuple
+   automatically includes them.
+2. ``sync_stages._build_base_query_params`` encodes per-endpoint device-flag
+   values as ``"true"`` / ``"false"`` strings on a single-endpoint scope so the
+   FastAPI backend honors the user's choice.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+DEVICE_OVERWRITE_FIELDS = (
+    "overwrite_device_role",
+    "overwrite_device_type",
+    "overwrite_device_tags",
+    "overwrite_device_status",
+    "overwrite_device_description",
+    "overwrite_device_custom_fields",
+)
+
+
+def _load_constants():
+    spec = importlib.util.spec_from_file_location(
+        "_netbox_proxbox_constants_for_device_flags",
+        REPO_ROOT / "netbox_proxbox" / "constants.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_all_six_device_flags_are_in_overwrite_fields():
+    constants = _load_constants()
+    for field in DEVICE_OVERWRITE_FIELDS:
+        assert field in constants.OVERWRITE_FIELDS, (
+            f"{field} dropped from OVERWRITE_FIELDS — VM sync would silently "
+            "fall back to backend default (always overwrite)"
+        )
+
+
+def test_device_group_label_uses_device_prefix():
+    constants = _load_constants()
+    device_group = next(
+        (
+            fields
+            for name, fields in constants.OVERWRITE_FIELD_GROUPS
+            if name == "Device"
+        ),
+        None,
+    )
+    assert device_group is not None, "Device group missing from OVERWRITE_FIELD_GROUPS"
+    assert device_group == DEVICE_OVERWRITE_FIELDS
+
+
+@pytest.fixture
+def sync_stages_module(monkeypatch):
+    """Load sync_stages.py with a single-endpoint scope and stub state."""
+    constants = _load_constants()
+    fields = tuple(constants.OVERWRITE_FIELDS)
+
+    state = {
+        "global": {name: True for name in fields},
+        "per_endpoint": {name: True for name in fields},
+    }
+
+    pkg = types.ModuleType("netbox_proxbox")
+    pkg.__path__ = [str(REPO_ROOT / "netbox_proxbox")]
+    monkeypatch.setitem(sys.modules, "netbox_proxbox", pkg)
+
+    constants_mod = types.ModuleType("netbox_proxbox.constants")
+    constants_mod.OVERWRITE_FIELDS = fields
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.constants", constants_mod)
+
+    choices_mod = types.ModuleType("netbox_proxbox.choices")
+    choices_mod.SyncTypeChoices = SimpleNamespace(
+        ALL="all",
+        VIRTUAL_MACHINES="virtual-machines",
+        VIRTUAL_MACHINES_BACKUPS="vm-backups",
+        VIRTUAL_MACHINES_SNAPSHOTS="vm-snapshots",
+        VIRTUAL_MACHINES_DISKS="vm-disks",
+        DEVICES="devices",
+        STORAGE="storage",
+        TASK_HISTORY="task-history",
+        NETWORK_INTERFACES="network-interfaces",
+        VM_INTERFACES="vm-interfaces",
+        IP_ADDRESSES="ip-addresses",
+        REPLICATIONS="replications",
+        BACKUP_ROUTINES="backup-routines",
+    )
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.choices", choices_mod)
+
+    class _ProxboxPluginSettings:
+        @classmethod
+        def get_solo(cls):
+            return SimpleNamespace(
+                use_guest_agent_interface_name=True,
+                proxbox_fetch_max_concurrency=8,
+                ignore_ipv6_link_local_addresses=True,
+                primary_ip_preference="ipv4",
+                **state["global"],
+            )
+
+    def _effective_overwrites():
+        return {
+            name: state["per_endpoint"][name]
+            if state["per_endpoint"][name] is not None
+            else state["global"][name]
+            for name in fields
+        }
+
+    endpoint = SimpleNamespace(
+        pk=1,
+        effective_overwrites=_effective_overwrites,
+        **state["per_endpoint"],
+    )
+
+    class _Manager:
+        def filter(self, **kwargs):
+            return self
+
+        def first(self):
+            return endpoint
+
+        def __iter__(self):
+            return iter([endpoint])
+
+    class _ProxmoxEndpoint:
+        objects = _Manager()
+
+    models_mod = types.ModuleType("netbox_proxbox.models")
+    models_mod.ProxboxPluginSettings = _ProxboxPluginSettings
+    models_mod.ProxmoxEndpoint = _ProxmoxEndpoint
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.models", models_mod)
+
+    netbox_jobs_mod = types.ModuleType("netbox.jobs")
+    netbox_jobs_mod.Job = type("Job", (), {})
+    monkeypatch.setitem(sys.modules, "netbox.jobs", netbox_jobs_mod)
+
+    for name in (
+        "netbox_proxbox.sync_types",
+        "netbox_proxbox.sync_params",
+        "netbox_proxbox.sync_ownership",
+        "netbox_proxbox.sync_stages",
+    ):
+        sys.modules.pop(name, None)
+        spec = importlib.util.spec_from_file_location(
+            name,
+            REPO_ROOT / "netbox_proxbox" / f"{name.split('.')[-1]}.py",
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+
+    module = sys.modules["netbox_proxbox.sync_stages"]
+    module._state = state  # type: ignore[attr-defined]
+    return module
+
+
+def test_device_flags_serialized_for_single_endpoint(sync_stages_module):
+    fields = _load_constants().OVERWRITE_FIELDS
+    sync_stages_module._state["per_endpoint"] = {
+        **{name: True for name in fields},
+        **{name: False for name in DEVICE_OVERWRITE_FIELDS},
+    }
+    sync_stages_module._state["global"] = {
+        **{name: True for name in fields},
+        **{name: False for name in DEVICE_OVERWRITE_FIELDS},
+    }
+
+    base_query = sync_stages_module._build_base_query_params(
+        proxmox_endpoint_ids=["1"],
+        netbox_endpoint_ids=None,
+    )
+
+    for field in DEVICE_OVERWRITE_FIELDS:
+        assert base_query.get(field) == "false", (
+            f"{field}=False not propagated to backend query string; "
+            "VM sync would let the backend default override the user's choice"
+        )


### PR DESCRIPTION
## Summary

Three independent streams bringing docs, tests, and CI back in sync with `develop` (`v0.0.13.post1`, certified against NetBox `4.6.0-beta2`, paired with `proxbox-api==0.0.9`). One commit per stream.

### Stream A — MkDocs docs (`414a6dc`)
- Bump version-drift pages (`index`, `release-notes`, `installation/*`, `upgrading`) from `0.0.12` / NetBox `4.5.x` to `0.0.13.post1` / `4.6.0-beta2`; rebuild the compatibility table and sync-action list against current models/views.
- New `docs/release-notes/version-0.0.13.md` covering the per-endpoint Settings tab, all `overwrite_*` flags surfaced in UI, VM-sync device-flag enforcement (#342), endpoint import/export page, `proxbox-api` 0.0.9 pairing, NetBox `4.6.0-beta2` certification, `_ensure_device` fix, and narrowed exception handling. `.post1` notes inline.
- Surface recently shipped features: link `sync-overwrite-flags` from configuration index, document the per-endpoint Settings tab + overwrite-flag fallback in `plugin-settings`, add a Proxmox Config tab feature page, and list `ProxmoxCluster` / `ProxmoxNode` / `ProxmoxStorage` in `models/others`. Rephrase `sync-overwrite-flags` so the device-flag enforcement reads as already-landed.
- Register the new release-note and feature pages in `mkdocs.yml` nav.

### Stream B — Tests (`5b9540e`)
- `test_vm_sync_device_flag_enforcement`: pin issue #342 contract — per-endpoint `overwrite_device_*` flags propagate into the SSE query parameters `proxbox-api` receives.
- `test_proxmox_endpoint_settings_view`: assert the Settings tab labels `overwrite_vm_tags` with the merge-semantics phrasing introduced in `66ec814`.
- `test_version`: pin `netbox_proxbox.config.version`, `min_version`, `max_version` so future bumps fail loudly.
- `test_signals`: AST-level contract for the three `@receiver(post_save)` handlers (`FastAPIEndpoint`, `ProxmoxEndpoint`, `NetBoxEndpoint`).
- Smoke coverage for previously untested modules:
  - `test_services_http_client`: requests/exception translation matrix via `unittest.mock`; `stream_get` cleanup; singleton accessor.
  - `test_views_error_utils`: `parse_requests_response_json`, `extract_backend_error_detail`, `extract_proxmox_backend_error_detail`.
  - `test_services_sync_backup_routines`: orchestration helpers loaded via `importlib` + `sys.modules` stubs (early-exit branches and HTTP error propagation).
  - `test_services_backend_context`: AST contract for the request-context resolver branches.
  - `test_views_vm_config` / `test_views_storage`: AST contracts pinning `register_model_view` wiring, `ViewTab` labels, permissions, and template paths without requiring a Django stack.
- `pyproject.toml`: add `[tool.coverage.run]` / `[tool.coverage.report]` so the existing `--cov` flag in `ci.yml` emits actionable coverage.
- `tests/CLAUDE.md`: document the new files, the AST-contract pattern, and the optional-dependency tests skipped outside nightly CI.

### Stream C — CI (`cb65f4b`)
- `ci.yml`: add `bandit -r netbox_proxbox proxbox_cli -ll`; expand the test job to a `[3.12, 3.13]` Python matrix; coverage upload kept on 3.12.
- `e2e-docker.yml`: bump `NETBOX_IMAGE` from `v4.6.0-beta1` → `v4.6.0-beta2` (reverses the temporary revert in `f98b9a1`); add a `workflow_dispatch` `netbox_image` input for future emergency overrides.
- `docs-screenshots.yml`: same `v4.6.0-beta2` bump; replace `pip install playwright requests` with `pip install -e ".[screenshot]"` so pinned versions in `pyproject.toml` are honored.
- `nightly-contracts.yml`: install `proxbox-api==0.0.9` and run the cross-repo contract mirrors (`test_sse_schema_mirror.py`, `test_overwrite_flags_contract.py`) so manifest drift is caught nightly instead of silently skipping in `ci.yml`.
- New `.github/dependabot.yml`: weekly updates for `github-actions` and `pip`, 5-PR cap, ignore `pydantic` semver-major bumps.

## Test plan
- [x] `python -m compileall netbox_proxbox proxbox_cli tests` — clean
- [x] `python -m pytest tests/ -q` — **429 passed, 2 skipped** (skips are the optional `proxbox-api` contract mirrors, run in nightly CI)
- [x] `ruff check .` — clean
- [x] `ruff format` — clean (pre-commit ran on commit)
- [x] `mkdocs build` — built
- [ ] CI on PR: lint + bandit + typecheck + test matrix (3.12 + 3.13) + e2e on workflow_dispatch
- [ ] Nightly contracts run includes SSE schema + overwrite-flags mirrors

## Out of scope
- No source-code refactors.
- No version bump or release.
- No changes to root `CLAUDE.md` / `AGENTS.md` (already current).