### PR TITLE
chore: bump to 0.0.13.post2 / proxbox-api 0.0.9.post1

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  PROXBOX_API_RELEASE_VERSION: 0.0.9
+  PROXBOX_API_RELEASE_VERSION: 0.0.9.post1
   NETBOX_IMAGE: netboxcommunity/netbox:v4.6.0-beta2
   PROXBOX_API_IMAGE: emersonfelipesp/proxbox-api
   PROXMOX_SDK_IMAGE: emersonfelipesp/proxmox-sdk

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -47,7 +47,7 @@ on:
     - cron: "31 2 * * *"
 
 env:
-  PROXBOX_API_RELEASE_VERSION: 0.0.9
+  PROXBOX_API_RELEASE_VERSION: 0.0.9.post1
   NETBOX_IMAGE: ${{ inputs.netbox_image != '' && inputs.netbox_image || 'netboxcommunity/netbox:v4.6.0-beta2' }}
   PROXBOX_API_IMAGE: emersonfelipesp/proxbox-api
   PROXMOX_SDK_IMAGE: emersonfelipesp/proxmox-sdk

--- a/.github/workflows/nightly-contracts.yml
+++ b/.github/workflows/nightly-contracts.yml
@@ -25,7 +25,7 @@ jobs:
           # ``proxbox-api`` powers the cross-repo SSE/overwrite-flags contract
           # mirrors. It is already pinned in the [test] extra; install it
           # explicitly so the upcoming step can drop ``importorskip`` skips.
-          python -m pip install proxbox-api==0.0.9
+          python -m pip install proxbox-api==0.0.9.post1
 
       - name: Run ty
         run: ty check proxbox_cli

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ This repository packages the `netbox_proxbox` NetBox plugin. The plugin adds end
 - Docker-based plugin installation docs are maintained at [`docs/installation/3-installing-plugin-docker.md`](./docs/installation/3-installing-plugin-docker.md), including `plugin_requirements.txt` and `configuration/plugins.py` usage.
 - Backend Docker examples map host `8800` to container `8000` (`-p 8800:8000`) because the published `proxbox-api` image serves through nginx on container port `8000`.
 
-The current plugin config lives in [`netbox_proxbox/__init__.py`](./netbox_proxbox/__init__.py). It declares plugin version `0.0.13.post1` and NetBox compatibility `4.6.0` through `4.6.99` (certified against `4.6.0-beta2`).
+The current plugin config lives in [`netbox_proxbox/__init__.py`](./netbox_proxbox/__init__.py). It declares plugin version `0.0.13.post2` and NetBox compatibility `4.6.0` through `4.6.99` (certified against `4.6.0-beta2`).
 
 ## Architecture Summary
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Sync runs on-demand from the NetBox UI or scheduled automatically via NetBox's j
 
 | NetBox   | netbox-proxbox | proxbox-api | netbox-sdk     | proxmox-sdk    |
 |----------|----------------|-------------|----------------|----------------|
+| >=4.6.0-beta2  | v0.0.13.post2        | v0.0.9.post1     | v0.0.7.post6   | v0.0.3.post1   |
 | >=4.6.0-beta2  | v0.0.13.post1        | v0.0.9           | v0.0.7.post6   | v0.0.3.post1   |
 | >=4.6.0-beta1  | v0.0.12        | v0.0.8.post1      | v0.0.7.post6   | v0.0.3.post1   |
 | >=4.5.7  | v0.0.11        | v0.0.7      | v0.0.7.post4   | v0.0.2.post2   |

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ Proxbox is a NetBox plugin that integrates Proxmox with NetBox through a separat
 
 | NetBox   | netbox-proxbox | proxbox-api | netbox-sdk     | proxmox-sdk    |
 |----------|----------------|-------------|----------------|----------------|
+| >=4.6.0-beta2 | v0.0.13.post2 | v0.0.9.post1 | v0.0.7.post6 | v0.0.3.post1 |
 | >=4.6.0-beta2 | v0.0.13.post1 | v0.0.9 | v0.0.7.post6 | v0.0.3.post1 |
 | >=4.6.0-beta1 | v0.0.12       | v0.0.8.post1 | v0.0.7.post6 | v0.0.3.post1 |
 | >=4.5.7  | v0.0.11        | v0.0.7      | v0.0.7.post4   | v0.0.2.post2   |
@@ -13,7 +14,7 @@ Proxbox is a NetBox plugin that integrates Proxmox with NetBox through a separat
 The current repository code declares support for:
 
 - NetBox `4.6.x`
-- Plugin version `0.0.13.post1` in source
+- Plugin version `0.0.13.post2` in source
 
 That support comes directly from the plugin config in this repository:
 

--- a/docs/installation/2-installing-plugin-git.md
+++ b/docs/installation/2-installing-plugin-git.md
@@ -4,7 +4,7 @@ This is the recommended installation path for the current repository state.
 
 ## Why This Is Recommended
 
-The code in this repository is `0.0.13.post1` and targets NetBox `4.6.x` (certified against `v4.6.0-beta2`). That is the version line reflected by the docs in this repository.
+The code in this repository is `0.0.13.post2` and targets NetBox `4.6.x` (certified against `v4.6.0-beta2`). That is the version line reflected by the docs in this repository.
 
 ## Install
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -21,7 +21,7 @@ pip install -e /opt/netbox/netbox/netbox-proxbox
 
 ## Important Notes
 
-- Proxbox `0.0.13.post1` is the current release for NetBox `4.6.x` (certified against `v4.6.0-beta2`). It pins `proxbox-api==0.0.9`. If you are still on NetBox `4.5.x`, stay on `0.0.11`.
+- Proxbox `0.0.13.post2` is the current release for NetBox `4.6.x` (certified against `v4.6.0-beta2`). It pins `proxbox-api==0.0.9.post1`. If you are still on NetBox `4.5.x`, stay on `0.0.11`.
 - Recent releases moved sync execution to NetBox Jobs and the default RQ queue, so keep a standard NetBox RQ worker running after upgrade.
 - Review the release notes before jumping from older `0.0.7` or early `0.0.9` installs; the `0.0.11` line continues the NetBox `4.5.x` compatibility range while `0.0.12` and later require NetBox `4.6.0` or later.
 - Upgrading to `0.0.13` introduces 16 new per-endpoint `overwrite_*` columns on `ProxmoxEndpoint`. The migration ships in this release; no manual schema work is required, but plan for the migration to run during the upgrade window.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -4,12 +4,13 @@ This section tracks the release line represented by this repository and keeps ol
 
 ## Current Release Line
 
-The plugin source in this repository is currently `0.0.13.post1`.
+The plugin source in this repository is currently `0.0.13.post2`.
 
 ## Highlights By Version
 
 | Version | Summary |
 |---------|---------|
+| `0.0.13.post2` | Re-pins `proxbox-api==0.0.9.post1`; adds matrix row for the new pair; no runtime behavior change |
 | `0.0.13.post1` | Bumps `proxbox-api==0.0.9` pin; certifies NetBox `v4.6.0-beta2`; documents endpoint import/export page; CI screenshot rebase fix |
 | `0.0.13` | Per-endpoint Settings tab on ProxmoxEndpoint detail; surfaces all `overwrite_*` flags in the plugin UI with tri-state semantics; VM-sync device flag enforcement (overwrite_device_*) honored end-to-end; merge-semantics label for `overwrite_vm_tags`; `_ensure_device` fix; narrowed broad except handlers in sync views and template tags |
 | `0.0.12` | NetBox 4.6.x support; native `VirtualMachineType` sync (QEMU / LXC); Clusters list page and API; site/tenant on ProxmoxEndpoint; ships with proxbox-api v0.0.8.post1 |

--- a/docs/release-notes/version-0.0.13.md
+++ b/docs/release-notes/version-0.0.13.md
@@ -6,12 +6,15 @@ Version 0.0.13 surfaces every `overwrite_*` flag in the plugin UI, adds a per-en
 
 `0.0.13.post1` is a packaging follow-up that pins `proxbox-api==0.0.9`, certifies NetBox `v4.6.0-beta2` against the published Docker Hub image, and re-publishes the documentation site with the endpoint import/export feature page surfaced.
 
+`0.0.13.post2` re-pins `proxbox-api==0.0.9.post1` across `pyproject.toml`, the e2e and docs-screenshots workflows, and the nightly contract job. No runtime behavior change — only the compatibility matrix and the pinned proxbox-api version move forward.
+
 ## Compatibility
 
-| NetBox         | netbox-proxbox  | proxbox-api | netbox-sdk   | proxmox-sdk    |
-|----------------|-----------------|-------------|--------------|----------------|
-| >=4.6.0-beta2  | v0.0.13.post1   | v0.0.9      | v0.0.7.post6 | v0.0.3.post1   |
-| >=4.6.0-beta1  | v0.0.13         | v0.0.9      | v0.0.7.post6 | v0.0.3.post1   |
+| NetBox         | netbox-proxbox  | proxbox-api  | netbox-sdk   | proxmox-sdk    |
+|----------------|-----------------|--------------|--------------|----------------|
+| >=4.6.0-beta2  | v0.0.13.post2   | v0.0.9.post1 | v0.0.7.post6 | v0.0.3.post1   |
+| >=4.6.0-beta2  | v0.0.13.post1   | v0.0.9       | v0.0.7.post6 | v0.0.3.post1   |
+| >=4.6.0-beta1  | v0.0.13         | v0.0.9       | v0.0.7.post6 | v0.0.3.post1   |
 
 NetBox compatibility range: `4.6.0` – `4.6.99`.
 

--- a/netbox_proxbox/__init__.py
+++ b/netbox_proxbox/__init__.py
@@ -118,7 +118,7 @@ class ProxboxConfig(PluginConfig):
     name = "netbox_proxbox"
     verbose_name = "Proxbox"
     description = "Integrates Proxmox and Netbox"
-    version = "0.0.13.post1"
+    version = "0.0.13.post2"
     author = "Emerson Felipe (@emersonfelipesp)"
     author_email = "emersonfelipe.2003@gmail.com"
     min_version = "4.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-proxbox"
-version = "0.0.13.post1"
+version = "0.0.13.post2"
 description = "Netbox Plugin - Integrate Proxmox and Netbox"
 readme = "README.md"
 authors = [

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -34,7 +34,7 @@ def _class_constants(class_name: str) -> dict[str, str]:
 
 def test_plugin_version_is_pinned():
     constants = _class_constants("ProxboxConfig")
-    assert constants.get("version") == "0.0.13.post1", (
+    assert constants.get("version") == "0.0.13.post2", (
         "version drifted; update docs/, release-notes, and pyproject.toml together"
     )
 


### PR DESCRIPTION
## Summary

- Bump plugin version `0.0.13.post1` → `0.0.13.post2` (`pyproject.toml`, `netbox_proxbox/__init__.py`, `tests/test_version.py`).
- Re-pin `proxbox-api==0.0.9.post1` across `e2e-docker.yml`, `docs-screenshots.yml`, and `nightly-contracts.yml`.
- Add a new top compatibility-matrix row for the `v0.0.13.post2 / proxbox-api v0.0.9.post1 / NetBox 4.6.0-beta2` triple in `docs/index.md`, `README.md`, `docs/release-notes/index.md`, and `docs/release-notes/version-0.0.13.md`.
- Update `docs/installation/upgrading.md`, `docs/installation/2-installing-plugin-git.md`, and `CLAUDE.md` to reflect the new current source version.

No runtime behavior change — packaging/compat-pin bump only.

## Test plan

- [x] `ruff check .`
- [x] `python -m compileall netbox_proxbox proxbox_cli tests`
- [x] `pytest tests/test_version.py` (asserts `0.0.13.post2`)
- [x] `mkdocs build`
- [x] `bandit -r netbox_proxbox proxbox_cli -ll`
- [ ] Wait for CI: `lint`, `compile`, `typecheck`, `test (3.12, 3.13)`, `build-and-deploy` all green