### PR TITLE
chore: regenerate uv.lock for 0.0.13.post2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1467,7 +1467,7 @@ wheels = [
 
 [[package]]
 name = "netbox-proxbox"
-version = "0.0.13.post1"
+version = "0.0.13.post2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

The 0.0.13.post2 bump in #347 missed the `uv.lock` entry. `validate-testpypi` in the release pipeline runs `uv sync --locked` and fails with `lockfile needs to be updated`, blocking `publish-pypi`.

This commit regenerates `uv.lock` so its `netbox-proxbox` entry pins `0.0.13.post2`. No other content changes.

## Test plan

- [x] `uv lock` produces the one-line bump (`0.0.13.post1` → `0.0.13.post2`).
- [ ] Release pipeline must be re-run after the v0.0.13.post2 tag is moved to this commit (or a v0.0.13.post3 tag is cut).