### PR TITLE
fix(sync): per-endpoint overwrite flags + new overwrite_vm_type (issue #350)

### DIFF
--- a/contracts/overwrite_flags.json
+++ b/contracts/overwrite_flags.json
@@ -9,6 +9,7 @@
     "overwrite_device_description",
     "overwrite_device_custom_fields",
     "overwrite_vm_role",
+    "overwrite_vm_type",
     "overwrite_vm_tags",
     "overwrite_vm_description",
     "overwrite_vm_custom_fields",

--- a/netbox_proxbox/constants.py
+++ b/netbox_proxbox/constants.py
@@ -18,6 +18,7 @@ OVERWRITE_FIELD_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
         "Virtual Machine",
         (
             "overwrite_vm_role",
+            "overwrite_vm_type",
             "overwrite_vm_tags",
             "overwrite_vm_description",
             "overwrite_vm_custom_fields",

--- a/netbox_proxbox/jobs.py
+++ b/netbox_proxbox/jobs.py
@@ -237,14 +237,10 @@ class ProxboxSyncJob(JobRunner):
         params = {
             "sync_types": normalized,
             "proxmox_endpoint_ids": [
-                str(x)
-                for x in list(kwargs.get("proxmox_endpoint_ids") or [])
-                if str(x)
+                str(x) for x in list(kwargs.get("proxmox_endpoint_ids") or []) if str(x)
             ],
             "netbox_endpoint_ids": [
-                str(x)
-                for x in list(kwargs.get("netbox_endpoint_ids") or [])
-                if str(x)
+                str(x) for x in list(kwargs.get("netbox_endpoint_ids") or []) if str(x)
             ],
             "netbox_vm_ids": [
                 str(x) for x in list(kwargs.get("netbox_vm_ids") or []) if str(x)

--- a/netbox_proxbox/jobs.py
+++ b/netbox_proxbox/jobs.py
@@ -236,8 +236,16 @@ class ProxboxSyncJob(JobRunner):
 
         params = {
             "sync_types": normalized,
-            "proxmox_endpoint_ids": list(kwargs.get("proxmox_endpoint_ids") or []),
-            "netbox_endpoint_ids": list(kwargs.get("netbox_endpoint_ids") or []),
+            "proxmox_endpoint_ids": [
+                str(x)
+                for x in list(kwargs.get("proxmox_endpoint_ids") or [])
+                if str(x)
+            ],
+            "netbox_endpoint_ids": [
+                str(x)
+                for x in list(kwargs.get("netbox_endpoint_ids") or [])
+                if str(x)
+            ],
             "netbox_vm_ids": [
                 str(x) for x in list(kwargs.get("netbox_vm_ids") or []) if str(x)
             ],
@@ -294,8 +302,12 @@ class ProxboxSyncJob(JobRunner):
 
             params: dict[str, object] = {
                 "sync_types": types,
-                "proxmox_endpoint_ids": list(proxmox_endpoint_ids or []),
-                "netbox_endpoint_ids": list(netbox_endpoint_ids or []),
+                "proxmox_endpoint_ids": [
+                    str(x) for x in list(proxmox_endpoint_ids or []) if str(x)
+                ],
+                "netbox_endpoint_ids": [
+                    str(x) for x in list(netbox_endpoint_ids or []) if str(x)
+                ],
                 "netbox_vm_ids": [str(x) for x in list(netbox_vm_ids or []) if str(x)],
                 "batch_object_type": batch_object_type,
                 "batch_object_ids": batch_object_ids,

--- a/netbox_proxbox/migrations/0036_add_overwrite_vm_type.py
+++ b/netbox_proxbox/migrations/0036_add_overwrite_vm_type.py
@@ -1,0 +1,64 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_proxbox", "0035_overwrite_fields_expansion"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        'ALTER TABLE "netbox_proxbox_proxboxpluginsettings" '
+                        'ADD COLUMN IF NOT EXISTS "overwrite_vm_type" boolean NOT NULL DEFAULT TRUE;'
+                    ),
+                    reverse_sql=(
+                        'ALTER TABLE "netbox_proxbox_proxboxpluginsettings" '
+                        'DROP COLUMN IF EXISTS "overwrite_vm_type";'
+                    ),
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="overwrite_vm_type",
+                    field=models.BooleanField(
+                        default=True,
+                        verbose_name="Overwrite VM type",
+                        help_text=(
+                            "When disabled, sync never changes the type on existing NetBox virtual machines "
+                            "that already have a type assigned. The type is still set when the VM is first created."
+                        ),
+                    ),
+                ),
+            ],
+        ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        'ALTER TABLE "netbox_proxbox_proxmoxendpoint" '
+                        'ADD COLUMN IF NOT EXISTS "overwrite_vm_type" boolean NULL;'
+                    ),
+                    reverse_sql=(
+                        'ALTER TABLE "netbox_proxbox_proxmoxendpoint" '
+                        'DROP COLUMN IF EXISTS "overwrite_vm_type";'
+                    ),
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="proxmoxendpoint",
+                    name="overwrite_vm_type",
+                    field=models.BooleanField(
+                        blank=True,
+                        null=True,
+                        verbose_name="Overwrite VM type",
+                        help_text="Per-endpoint override for the global Proxbox setting. Leave blank to inherit.",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/netbox_proxbox/models/plugin_settings.py
+++ b/netbox_proxbox/models/plugin_settings.py
@@ -236,6 +236,14 @@ class ProxboxPluginSettings(NetBoxModel):
             "that already have a role assigned. The role is still set when the VM is first created."
         ),
     )
+    overwrite_vm_type = models.BooleanField(
+        default=True,
+        verbose_name=_("Overwrite VM type"),
+        help_text=_(
+            "When disabled, sync never changes the type on existing NetBox virtual machines "
+            "that already have a type assigned. The type is still set when the VM is first created."
+        ),
+    )
     overwrite_vm_tags = models.BooleanField(
         default=True,
         verbose_name=_("Merge VM tags"),

--- a/netbox_proxbox/models/proxmox_endpoint.py
+++ b/netbox_proxbox/models/proxmox_endpoint.py
@@ -170,6 +170,14 @@ class ProxmoxEndpoint(EndpointBase):
             "Per-endpoint override for the global Proxbox setting. Leave blank to inherit."
         ),
     )
+    overwrite_vm_type = models.BooleanField(
+        null=True,
+        blank=True,
+        verbose_name=_("Overwrite VM type"),
+        help_text=_(
+            "Per-endpoint override for the global Proxbox setting. Leave blank to inherit."
+        ),
+    )
     overwrite_vm_tags = models.BooleanField(
         null=True,
         blank=True,

--- a/netbox_proxbox/sync_stages.py
+++ b/netbox_proxbox/sync_stages.py
@@ -296,6 +296,27 @@ def _execute_stage_sync(
     raise RuntimeError(user_detail)
 
 
+def _proxmox_endpoint_scopes(
+    proxmox_endpoint_ids: object,
+) -> list[list[str]]:
+    """Return one flat-query endpoint scope per backend SSE run."""
+    requested = [str(value) for value in list(proxmox_endpoint_ids or []) if str(value)]
+    if requested:
+        return [[endpoint_id] for endpoint_id in requested]
+
+    try:
+        from netbox_proxbox.models import ProxmoxEndpoint
+
+        endpoint_ids = [
+            str(pk) for pk in ProxmoxEndpoint.objects.values_list("pk", flat=True)
+        ]
+    except (ImportError, RuntimeError, AttributeError):
+        endpoint_ids = []
+    if not endpoint_ids:
+        return [[]]
+    return [[endpoint_id] for endpoint_id in endpoint_ids]
+
+
 def _run_all_stages_sync(
     job: "ProxboxSyncJob",
     stages: list[str],
@@ -303,12 +324,7 @@ def _run_all_stages_sync(
     run_started: float,
 ) -> list[dict[str, object]]:
     """Run all sync stages in order and return stage results."""
-    from netbox_proxbox.services import run_sync_stream
-
-    base_query = _build_base_query_params(
-        params.get("proxmox_endpoint_ids"),
-        params.get("netbox_endpoint_ids"),
-    )
+    endpoint_scopes = _proxmox_endpoint_scopes(params.get("proxmox_endpoint_ids"))
 
     flush_interval = 2.0
     log_throttle = 1.5
@@ -339,29 +355,41 @@ def _run_all_stages_sync(
         or SyncTypeChoices.IP_ADDRESSES in stages
     )
 
-    for st in stages:
-        query_params = _build_stage_query_params(
-            base_query,
-            st,
-            target_vm_ids,
-            disable_vm_network_on_vm_stage=disable_vm_network_on_vm_stage,
+    for endpoint_scope in endpoint_scopes:
+        if endpoint_scope:
+            job.logger.info(
+                "Running SSE sync for Proxmox endpoint %s", endpoint_scope[0]
+            )
+        else:
+            job.logger.info("Running SSE sync with no Proxmox endpoint filter")
+        base_query = _build_base_query_params(
+            endpoint_scope,
+            params.get("netbox_endpoint_ids"),
         )
-        stage_paths = _sync_stream_paths_for_stage(st, target_vm_ids)
 
-        for stream_path in stage_paths:
-            payload, stage_runtime = _execute_stage_sync(
-                job, st, stream_path, query_params, on_frame, fastapi_endpoint_id
+        for st in stages:
+            query_params = _build_stage_query_params(
+                base_query,
+                st,
+                target_vm_ids,
+                disable_vm_network_on_vm_stage=disable_vm_network_on_vm_stage,
             )
-            response = payload.get("response") or {}
-            stages_out.append(
-                {
-                    "sync_type": st,
-                    "runtime_seconds": stage_runtime,
-                    "result_summary": {
-                        "path": payload.get("path"),
-                        "ok": response.get("ok"),
-                    },
-                }
-            )
+            stage_paths = _sync_stream_paths_for_stage(st, target_vm_ids)
+
+            for stream_path in stage_paths:
+                payload, stage_runtime = _execute_stage_sync(
+                    job, st, stream_path, query_params, on_frame, fastapi_endpoint_id
+                )
+                response = payload.get("response") or {}
+                stages_out.append(
+                    {
+                        "sync_type": st,
+                        "runtime_seconds": stage_runtime,
+                        "result_summary": {
+                            "path": payload.get("path"),
+                            "ok": response.get("ok"),
+                        },
+                    }
+                )
 
     return stages_out

--- a/netbox_proxbox/views/endpoints/proxmox.py
+++ b/netbox_proxbox/views/endpoints/proxmox.py
@@ -303,7 +303,7 @@ class ProxmoxEndpointSettingsView(generic.ObjectEditView):
     template_name = "netbox_proxbox/proxmoxendpoint_settings.html"
     tab = ViewTab(
         label="Settings",
-        permission="netbox_proxbox.change_proxmoxendpoint",
+        permission="netbox_proxbox.view_proxmoxendpoint",
         weight=900,
     )
 

--- a/netbox_proxbox/views/sync.py
+++ b/netbox_proxbox/views/sync.py
@@ -12,10 +12,16 @@ from django.utils.translation import gettext_lazy as _
 
 from netbox_proxbox.choices import SyncTypeChoices
 from netbox_proxbox.jobs import PROXBOX_SYNC_QUEUE_NAME, ProxboxSyncJob
+from netbox_proxbox.models import ProxmoxEndpoint
 from netbox_proxbox.views.sync_helpers import (
     _ProxboxSyncViewBase,
     build_job_name,
 )
+
+
+def _all_proxmox_endpoint_ids() -> list[int]:
+    """Return explicit endpoint IDs for sync jobs started from broad UI actions."""
+    return list(ProxmoxEndpoint.objects.values_list("pk", flat=True))
 
 
 def notify_sync_enqueued(request: HttpRequest, job, message: str) -> None:
@@ -65,6 +71,7 @@ class _ProxboxSyncEnqueueView(_ProxboxSyncViewBase):
                 queue_name=PROXBOX_SYNC_QUEUE_NAME,
                 name=self._job_name(),
                 sync_types=list(self.sync_types),
+                proxmox_endpoint_ids=_all_proxmox_endpoint_ids(),
             )
             notify_sync_enqueued(
                 request,
@@ -190,6 +197,7 @@ class _ProxboxSelectedSyncView(_ProxboxSyncViewBase):
                 sync_types=[SyncTypeChoices.ALL],
                 batch_object_type=self.batch_object_type,
                 batch_object_ids=selected_ids,
+                proxmox_endpoint_ids=_all_proxmox_endpoint_ids(),
             )
             notify_sync_enqueued(
                 request,

--- a/netbox_proxbox/views/vm_sync_now.py
+++ b/netbox_proxbox/views/vm_sync_now.py
@@ -20,6 +20,7 @@ from netbox_proxbox.jobs import (
     PROXBOX_SYNC_QUEUE_NAME,
     ProxboxSyncJob,
 )
+from netbox_proxbox.models import ProxmoxEndpoint
 from netbox_proxbox.views.proxbox_access import permission_enqueue_proxbox_sync
 
 __all__ = ("VirtualMachineSyncNowView",)
@@ -58,6 +59,9 @@ class VirtualMachineSyncNowView(
             name=str(_("Proxbox Sync: Virtual machine {}")).format(vm.pk),
             sync_types=list(_VM_SYNC_NOW_SYNC_TYPES),
             netbox_vm_ids=[str(vm.pk)],
+            proxmox_endpoint_ids=list(
+                ProxmoxEndpoint.objects.values_list("pk", flat=True)
+            ),
         )
         messages.success(
             request,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,7 +158,9 @@ def _manager(*, first=None, objects_by_pk=None, does_not_exist=None):
         def values_list(self, field_name, flat=False):
             values = []
             if objects_by_pk:
-                values = [getattr(obj, field_name, pk) for pk, obj in objects_by_pk.items()]
+                values = [
+                    getattr(obj, field_name, pk) for pk, obj in objects_by_pk.items()
+                ]
             elif first is not None:
                 values = [getattr(first, field_name, getattr(first, "pk", None))]
             if flat:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,16 @@ def _manager(*, first=None, objects_by_pk=None, does_not_exist=None):
         def filter(self, *args, **kwargs):
             return self
 
+        def values_list(self, field_name, flat=False):
+            values = []
+            if objects_by_pk:
+                values = [getattr(obj, field_name, pk) for pk, obj in objects_by_pk.items()]
+            elif first is not None:
+                values = [getattr(first, field_name, getattr(first, "pk", None))]
+            if flat:
+                return values
+            return [(value,) for value in values]
+
         def count(self):
             return 0
 

--- a/tests/e2e/stack_setup.py
+++ b/tests/e2e/stack_setup.py
@@ -213,7 +213,7 @@ def assert_plugin_routes(
             )
 
     # Settings tab smoke check: confirm the page renders and at least one of
-    # the 21 overwrite_* form fields is present (regression for issue #343).
+    # the 22 overwrite_* form fields is present (regression for issue #343).
     # The settings view is a NetBox ObjectEditView, which only honors session
     # auth — Token auth on a UI route redirects to /login/. Use a Django login
     # session (admin/admin from the e2e-docker workflow superuser env) so the

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1100,3 +1100,93 @@ def test_proxbox_sync_job_query_flag_primary_ip_preference_setting(
     st = proxbox_sync_job_module.SyncTypeChoices
     ProxboxSyncJob.run(job, sync_type=st.DEVICES)
     assert captured["query_params"]["primary_ip_preference"] == "ipv6"
+
+
+def test_proxbox_sync_job_full_update_uses_single_endpoint_overrides(
+    monkeypatch, proxbox_sync_job_module
+):
+    """A full-update scoped to one endpoint must send that endpoint's flags."""
+    captured: list[dict[str, object]] = []
+    services_mod = types.ModuleType("netbox_proxbox.services")
+
+    def run_sync_stream(path, query_params=None, **stream_kwargs):
+        captured.append(dict(query_params or {}))
+        return ({"stream": True, "response": {"ok": True}}, 200)
+
+    services_mod.run_sync_stream = run_sync_stream
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.services", services_mod)
+
+    overwrite_fields = tuple(
+        proxbox_sync_job_module.sync_stages.effective_overwrites_for_endpoint(None)
+    )
+
+    def effective_overwrites_for_endpoint(endpoint_id):
+        return {
+            name: name != "overwrite_device_role"
+            for name in overwrite_fields
+        }
+
+    monkeypatch.setattr(
+        proxbox_sync_job_module.sync_stages,
+        "effective_overwrites_for_endpoint",
+        effective_overwrites_for_endpoint,
+    )
+
+    ProxboxSyncJob = proxbox_sync_job_module.ProxboxSyncJob
+    job = ProxboxSyncJob()
+    job.logger = logging.getLogger("test_proxbox_job_endpoint_overrides")
+    job.job = MagicMock()
+    job.job.data = None
+
+    st = proxbox_sync_job_module.SyncTypeChoices
+    ProxboxSyncJob.run(job, sync_types=[st.ALL], proxmox_endpoint_ids=["1"])
+
+    assert captured
+    assert {query["proxmox_endpoint_ids"] for query in captured} == {"1"}
+    assert {query["overwrite_device_role"] for query in captured} == {"false"}
+
+
+def test_proxbox_sync_job_loops_multiple_endpoint_scopes_with_distinct_overrides(
+    monkeypatch, proxbox_sync_job_module
+):
+    """Multiple endpoint syncs run one SSE request per endpoint with flat flags."""
+    captured: list[dict[str, object]] = []
+    services_mod = types.ModuleType("netbox_proxbox.services")
+
+    def run_sync_stream(path, query_params=None, **stream_kwargs):
+        captured.append(dict(query_params or {}))
+        return ({"stream": True, "response": {"ok": True}}, 200)
+
+    services_mod.run_sync_stream = run_sync_stream
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.services", services_mod)
+
+    overwrite_fields = tuple(
+        proxbox_sync_job_module.sync_stages.effective_overwrites_for_endpoint(None)
+    )
+
+    def effective_overwrites_for_endpoint(endpoint_id):
+        return {
+            name: not (str(endpoint_id) == "2" and name == "overwrite_device_role")
+            for name in overwrite_fields
+        }
+
+    monkeypatch.setattr(
+        proxbox_sync_job_module.sync_stages,
+        "effective_overwrites_for_endpoint",
+        effective_overwrites_for_endpoint,
+    )
+
+    ProxboxSyncJob = proxbox_sync_job_module.ProxboxSyncJob
+    job = ProxboxSyncJob()
+    job.logger = logging.getLogger("test_proxbox_job_multi_endpoint_overrides")
+    job.job = MagicMock()
+    job.job.data = None
+
+    st = proxbox_sync_job_module.SyncTypeChoices
+    ProxboxSyncJob.run(job, sync_types=[st.DEVICES], proxmox_endpoint_ids=["1", "2"])
+
+    assert [query["proxmox_endpoint_ids"] for query in captured] == ["1", "2"]
+    assert [query["overwrite_device_role"] for query in captured] == [
+        "true",
+        "false",
+    ]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1121,10 +1121,7 @@ def test_proxbox_sync_job_full_update_uses_single_endpoint_overrides(
     )
 
     def effective_overwrites_for_endpoint(endpoint_id):
-        return {
-            name: name != "overwrite_device_role"
-            for name in overwrite_fields
-        }
+        return {name: name != "overwrite_device_role" for name in overwrite_fields}
 
     monkeypatch.setattr(
         proxbox_sync_job_module.sync_stages,

--- a/tests/test_models_overwrites.py
+++ b/tests/test_models_overwrites.py
@@ -265,4 +265,4 @@ def test_effective_overwrites_keys_match_canonical_field_set(
 ):
     result = sync_params_module.effective_overwrites_for_endpoint(None)
     assert tuple(result.keys()) == tuple(overwrite_fields)
-    assert len(result) == 21
+    assert len(result) == 22

--- a/tests/test_overwrite_flags_contract.py
+++ b/tests/test_overwrite_flags_contract.py
@@ -1,7 +1,7 @@
 """Cross-repo drift detector for the overwrite_* flag set.
 
 The plugin (`netbox-proxbox`) and the backend (`proxbox-api`) each carry the
-same canonical 21-flag list as a single source of truth:
+same canonical 22-flag list as a single source of truth:
 
 - Plugin: `netbox_proxbox.constants.OVERWRITE_FIELDS`
 - Backend: `proxbox_api.schemas.sync.SyncOverwriteFlags.model_fields`
@@ -9,7 +9,7 @@ same canonical 21-flag list as a single source of truth:
 A copy of the canonical names + order is committed to BOTH repos as
 `contracts/overwrite_flags.json`. This test asserts that the local source of
 truth on this side matches the manifest exactly. The mirror repo runs the same
-test against its own source of truth. Any developer who adds a 22nd flag to
+test against its own source of truth. Any developer who changes flags on
 either side must update both manifests; CI on both repos fails otherwise.
 """
 
@@ -57,10 +57,10 @@ def test_manifest_matches_constants_overwrite_fields() -> None:
     )
 
 
-def test_manifest_field_count_is_canonical_21() -> None:
+def test_manifest_field_count_is_canonical_22() -> None:
     """Sanity check: any change to flag count is intentional and reviewed."""
     manifest_fields = _load_manifest_fields()
-    assert len(manifest_fields) == 21
+    assert len(manifest_fields) == 22
 
 
 def test_manifest_has_no_duplicate_fields() -> None:

--- a/tests/test_overwrite_vm_type_contract.py
+++ b/tests/test_overwrite_vm_type_contract.py
@@ -1,0 +1,55 @@
+"""Contract coverage for the overwrite_vm_type flag added for issue #350."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_constants():
+    spec = importlib.util.spec_from_file_location(
+        "_constants_for_overwrite_vm_type",
+        REPO_ROOT / "netbox_proxbox" / "constants.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_overwrite_vm_type_order_matches_backend_contract():
+    fields = _load_constants().OVERWRITE_FIELDS
+
+    assert fields[fields.index("overwrite_vm_role") + 1] == "overwrite_vm_type"
+    assert fields[fields.index("overwrite_vm_type") + 1] == "overwrite_vm_tags"
+
+
+def test_overwrite_vm_type_model_fields_exist():
+    plugin_settings = (REPO_ROOT / "netbox_proxbox/models/plugin_settings.py").read_text(
+        encoding="utf-8"
+    )
+    proxmox_endpoint = (REPO_ROOT / "netbox_proxbox/models/proxmox_endpoint.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "overwrite_vm_type = models.BooleanField(" in plugin_settings
+    assert "default=True" in plugin_settings
+    assert "overwrite_vm_type = models.BooleanField(" in proxmox_endpoint
+    assert "null=True" in proxmox_endpoint
+    assert "blank=True" in proxmox_endpoint
+
+
+def test_overwrite_vm_type_migration_adds_global_and_endpoint_columns():
+    path = REPO_ROOT / "netbox_proxbox/migrations/0036_add_overwrite_vm_type.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    source = ast.unparse(tree)
+
+    assert "0035_overwrite_fields_expansion" in source
+    assert "netbox_proxbox_proxboxpluginsettings" in source
+    assert "netbox_proxbox_proxmoxendpoint" in source
+    assert "overwrite_vm_type" in source
+    assert "boolean NOT NULL DEFAULT TRUE" in source
+    assert "boolean NULL" in source

--- a/tests/test_overwrite_vm_type_contract.py
+++ b/tests/test_overwrite_vm_type_contract.py
@@ -28,12 +28,12 @@ def test_overwrite_vm_type_order_matches_backend_contract():
 
 
 def test_overwrite_vm_type_model_fields_exist():
-    plugin_settings = (REPO_ROOT / "netbox_proxbox/models/plugin_settings.py").read_text(
-        encoding="utf-8"
-    )
-    proxmox_endpoint = (REPO_ROOT / "netbox_proxbox/models/proxmox_endpoint.py").read_text(
-        encoding="utf-8"
-    )
+    plugin_settings = (
+        REPO_ROOT / "netbox_proxbox/models/plugin_settings.py"
+    ).read_text(encoding="utf-8")
+    proxmox_endpoint = (
+        REPO_ROOT / "netbox_proxbox/models/proxmox_endpoint.py"
+    ).read_text(encoding="utf-8")
 
     assert "overwrite_vm_type = models.BooleanField(" in plugin_settings
     assert "default=True" in plugin_settings

--- a/tests/test_proxmox_endpoint_settings_view.py
+++ b/tests/test_proxmox_endpoint_settings_view.py
@@ -88,7 +88,7 @@ def test_settings_view_tab_metadata(view_module_ast):
         and keywords["label"].value == "Settings"
     )
     assert isinstance(keywords["permission"], ast.Constant)
-    assert keywords["permission"].value == "netbox_proxbox.change_proxmoxendpoint"
+    assert keywords["permission"].value == "netbox_proxbox.view_proxmoxendpoint"
     assert isinstance(keywords["weight"], ast.Constant)
     assert isinstance(keywords["weight"].value, int)
 
@@ -143,7 +143,7 @@ def test_get_extra_context_exposes_overwrite_field_groups():
     )
     flat = tuple(field for _name, fields in groups for field in fields)
     assert flat == mod.OVERWRITE_FIELDS
-    assert len(flat) == 21
+    assert len(flat) == 22
 
 
 # ── Form-level label semantics ───────────────────────────────────────────────

--- a/tests/test_settings_view_encryption.py
+++ b/tests/test_settings_view_encryption.py
@@ -72,6 +72,7 @@ def _fake_settings_obj(encryption_key: str = "") -> SimpleNamespace:
         overwrite_device_description=True,
         overwrite_device_custom_fields=True,
         overwrite_vm_role=True,
+        overwrite_vm_type=True,
         overwrite_vm_tags=True,
         overwrite_vm_description=True,
         overwrite_vm_custom_fields=True,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -174,3 +174,20 @@ def test_sync_selected_virtual_machines_enqueues_batch_job(
     assert len(calls) == 1
     assert calls[0]["batch_object_type"] == "virtual-machine"
     assert calls[0]["batch_object_ids"] == ["11", "22"]
+
+
+def test_sync_full_update_forwards_explicit_proxmox_endpoint_ids(
+    monkeypatch, fastapi_endpoint, proxmox_endpoint
+):
+    module = load_plugin_module(
+        "netbox_proxbox.views.sync",
+        monkeypatch=monkeypatch,
+        fastapi_endpoint=fastapi_endpoint,
+        proxmox_endpoint=proxmox_endpoint,
+    )
+    calls = _enqueue_spy(monkeypatch, module)
+
+    module.sync_full_update(_post_request())
+
+    assert calls[0]["sync_types"] == [ST_ALL]
+    assert calls[0]["proxmox_endpoint_ids"] == [proxmox_endpoint.pk]

--- a/tests/test_sync_params_flag_flattening.py
+++ b/tests/test_sync_params_flag_flattening.py
@@ -1,4 +1,4 @@
-"""Tests that ``sync_stages._build_base_query_params`` flattens 21 overwrite flags.
+"""Tests that ``sync_stages._build_base_query_params`` flattens 22 overwrite flags.
 
 The plugin sends overwrite flags to the FastAPI backend as flat query string
 keys (one ``overwrite_*`` key per field, value ``"true"`` / ``"false"``). This
@@ -142,7 +142,7 @@ def sync_stages_module(monkeypatch):
     return module
 
 
-def test_build_base_query_params_includes_all_21_overwrite_keys(sync_stages_module):
+def test_build_base_query_params_includes_all_22_overwrite_keys(sync_stages_module):
     fields = _load_overwrite_fields()
 
     base_query = sync_stages_module._build_base_query_params(
@@ -153,7 +153,7 @@ def test_build_base_query_params_includes_all_21_overwrite_keys(sync_stages_modu
     for name in fields:
         assert name in base_query, f"missing flag {name} in flattened query"
     overwrite_keys = [k for k in base_query if k.startswith("overwrite_")]
-    assert len(overwrite_keys) == 21
+    assert len(overwrite_keys) == 22
 
 
 def test_build_base_query_params_serializes_true_false_strings(sync_stages_module):


### PR DESCRIPTION
Fixes #350.

## Summary

- **RC-1** — per-endpoint overwrite overrides were silently dropped when sync scope was not exactly one endpoint. `sync_stages.py` now resolves the per-endpoint scope list via the new `_proxmox_endpoint_scopes()` helper and runs the SSE sync once per endpoint. Each iteration calls `_build_base_query_params([endpoint_id], ...)` so the flat `overwrite_*` query string carries that endpoint's effective flags. View enqueue sites (`views/sync.py`, `views/vm_sync_now.py`) now pass an explicit `proxmox_endpoint_ids` list to `ProxboxSyncJob.enqueue(...)`.
- **RC-3** — added `overwrite_vm_type` flag (default `True`) to `OVERWRITE_FIELD_GROUPS`, `ProxboxPluginSettings` (NOT NULL), and `ProxmoxEndpoint` (nullable for inheritance), with migration `0036_add_overwrite_vm_type` using `SeparateDatabaseAndState` + `IF NOT EXISTS` SQL guards.
- **RC-4** — `ProxmoxEndpointSettingsView` `ViewTab` permission relaxed `change_proxmoxendpoint` → `view_proxmoxendpoint` so view-only operators can see the per-endpoint Sync Overwrite Behavior tab.
- Cross-repo manifest `contracts/overwrite_flags.json` updated to 22 fields in matching order with the proxbox-api companion PR.

## Test plan

- [x] `rtk pytest tests/` → 435 passed, 2 skipped
- [x] Migration applies cleanly on fresh + existing DB
- [x] Per-endpoint flag flattening covered by new tests (`test_sync_params_flag_flattening.py`, `test_jobs.py`)
- [x] Cross-repo contract test renamed `canonical_21` → `canonical_22`
- [ ] Pair with proxbox-api companion PR before merge

Companion: emersonfelipesp/proxbox-api PR for `fix/issue-350-overwrite-flags`.