### PR TITLE
fix: support NetBox 4.5 legacy VM type filtering

### DIFF
--- a/docs/release-notes/version-0.0.15.md
+++ b/docs/release-notes/version-0.0.15.md
@@ -2,10 +2,11 @@
 
 ## Summary
 
-Version `0.0.15` fixes two issues and adds one new feature in pair with backend `proxbox-api 0.0.11`:
+Version `0.0.15` fixes three issues and adds one new feature in pair with backend `proxbox-api 0.0.11`:
 
 - [Issue #352](https://github.com/emersonfelipesp/netbox-proxbox/issues/352): the `FastAPIEndpoint` model could not express the combination "use HTTPS but skip certificate verification", which is the default state of the proxbox-api `*-nginx` image (TLS-only with a self-signed mkcert certificate).
 - [Issue #354](https://github.com/emersonfelipesp/netbox-proxbox/issues/354): IPAM `IPAddress` records created during virtualization sync had an empty `dns_name`, even though Proxmox knew the guest hostname. The plugin now exposes a new `overwrite_ip_address_dns_name` setting (global + per-endpoint) so operators can opt out of `dns_name` writes; the actual hostname resolution and write live in `proxbox-api 0.0.11`.
+- [Issue #391](https://github.com/emersonfelipesp/netbox-proxbox/issues/391): the Virtual Machines and LXC Containers plugin pages now auto-detect whether the installed NetBox has the 4.6 `VirtualMachineType` relation. NetBox 4.5.x stays on the legacy `proxmox_vm_type` custom-field path, while NetBox 4.6.x keeps native type support.
 - [Issue #243](https://github.com/emersonfelipesp/netbox-proxbox/issues/243): Proxmox cluster High-Availability state was not surfaced anywhere in NetBox. The plugin now ships a per-VM **HA tab** and a cluster-wide **HA Status** page, both backed by new read-only HA endpoints in `proxbox-api 0.0.11`.
 
 ## #352 — `Use HTTPS` toggle decoupled from `Verify SSL`

--- a/netbox_proxbox/api/ha.py
+++ b/netbox_proxbox/api/ha.py
@@ -28,8 +28,7 @@ from netbox_proxbox.services.backend_context import get_fastapi_request_context
 
 _BACKEND_NOT_CONFIGURED = "No FastAPI backend endpoint is configured."
 _BACKEND_TOO_OLD = (
-    "Backend does not support HA endpoints — "
-    "upgrade proxbox-api to v0.0.11 or later."
+    "Backend does not support HA endpoints — upgrade proxbox-api to v0.0.11 or later."
 )
 _HA_REQUEST_TIMEOUT = 15
 

--- a/netbox_proxbox/api/views.py
+++ b/netbox_proxbox/api/views.py
@@ -671,7 +671,11 @@ class _ProxboxVMListAPIView(APIView):
     @extend_schema(responses={200: OpenApiTypes.OBJECT})
     def get(self, request: Request) -> Response:
         from virtualization.models import VirtualMachine
-        from netbox_proxbox.utils import get_proxbox_tagged_object_ids
+        from netbox_proxbox.utils import (
+            filter_queryset_by_proxmox_vm_type,
+            get_proxbox_tagged_object_ids,
+            vm_type_select_related_fields,
+        )
 
         tagged_ids = get_proxbox_tagged_object_ids(VirtualMachine, limit=100)
         if not tagged_ids:
@@ -680,15 +684,16 @@ class _ProxboxVMListAPIView(APIView):
         base_qs = (
             VirtualMachine.objects.restrict(request.user, "view")
             .filter(id__in=tagged_ids)
-            .select_related("site", "cluster", "role", "tenant", "platform")
+            .select_related(*vm_type_select_related_fields(VirtualMachine))
             .prefetch_related("interfaces__ip_addresses")
         )
-        from django.db.models import Q
 
         vms = list(
-            base_qs.filter(
-                Q(virtual_machine_type__slug=self.vm_type_slug)
-                | Q(custom_field_data__proxmox_vm_type=self.vm_type)
+            filter_queryset_by_proxmox_vm_type(
+                base_qs,
+                VirtualMachine,
+                vm_type=self.vm_type,
+                vm_type_slug=self.vm_type_slug,
             )
         )
         results = [_serialize_vm(vm, request) for vm in vms]

--- a/netbox_proxbox/templatetags/proxbox_tags.py
+++ b/netbox_proxbox/templatetags/proxbox_tags.py
@@ -122,7 +122,8 @@ def inline_static_script(relative_path: str) -> str:
         payload = _read_static(relative_path)
     except (FileNotFoundError, ValueError):
         return ""
-    return mark_safe(payload.decode("utf-8"))
+    # Safe because payload is read from bundled plugin static files, not user input.
+    return mark_safe(payload.decode("utf-8"))  # nosec
 
 
 @register.filter

--- a/netbox_proxbox/utils.py
+++ b/netbox_proxbox/utils.py
@@ -169,6 +169,46 @@ def resolve_vm_type(vm: object) -> str:
     return str(cf.get("proxmox_vm_type") or cf.get("cf_proxmox_vm_type") or "qemu")
 
 
+def has_virtual_machine_type_field(model_class: type[object]) -> bool:
+    """Return True when the live NetBox VirtualMachine model has the 4.6 type FK."""
+    meta = getattr(model_class, "_meta", None)
+    if meta is None:
+        return bool(getattr(model_class, "virtual_machine_type", None))
+    try:
+        meta.get_field("virtual_machine_type")
+    except Exception:
+        return False
+    return True
+
+
+def vm_type_select_related_fields(model_class: type[object]) -> tuple[str, ...]:
+    """Return common VM select_related fields, adding VirtualMachineType only if present."""
+    fields = ["site", "cluster", "role", "tenant", "platform"]
+    if has_virtual_machine_type_field(model_class):
+        fields.append("virtual_machine_type")
+    return tuple(fields)
+
+
+def filter_queryset_by_proxmox_vm_type(
+    queryset: object,
+    model_class: type[object],
+    *,
+    vm_type: str,
+    vm_type_slug: str,
+) -> object:
+    """Filter a VirtualMachine queryset by Proxmox type across NetBox 4.5 and 4.6."""
+    from django.db.models import Q
+
+    legacy_filter = Q(custom_field_data__proxmox_vm_type=vm_type) | Q(
+        custom_field_data__cf_proxmox_vm_type=vm_type
+    )
+    if has_virtual_machine_type_field(model_class):
+        return queryset.filter(
+            Q(virtual_machine_type__slug=vm_type_slug) | legacy_filter
+        )
+    return queryset.filter(legacy_filter)
+
+
 def get_fastapi_url(endpoint: FastAPIUrlSource) -> dict[str, object]:
     """Compute HTTP/WebSocket URLs and TLS settings for a FastAPI endpoint model.
 

--- a/netbox_proxbox/views/backend_sync.py
+++ b/netbox_proxbox/views/backend_sync.py
@@ -29,7 +29,9 @@ def proxmox_backend_name(endpoint: ProxmoxEndpoint) -> str:
     return f"{base_name} (nb:{endpoint_id})" if endpoint_id is not None else base_name
 
 
-def _related_object_metadata(prefix: str, value: object | None) -> dict[str, object | None]:
+def _related_object_metadata(
+    prefix: str, value: object | None
+) -> dict[str, object | None]:
     """Return flat relation metadata for proxbox-api endpoint placement fields."""
     if value is None:
         return {

--- a/netbox_proxbox/views/resource_list_views.py
+++ b/netbox_proxbox/views/resource_list_views.py
@@ -8,8 +8,10 @@ from utilities.views import ConditionalLoginRequiredMixin
 from virtualization.models import Cluster, VirtualDisk, VirtualMachine, VMInterface
 
 from netbox_proxbox.utils import (
+    filter_queryset_by_proxmox_vm_type,
     get_fastapi_context_for_request,
     get_proxbox_tagged_object_ids,
+    vm_type_select_related_fields,
 )
 
 
@@ -106,22 +108,16 @@ class VirtualMachinesView(ConditionalLoginRequiredMixin, View):
             base_qs = (
                 VirtualMachine.objects.restrict(request.user, "view")
                 .filter(id__in=tagged_vm_ids)
-                .select_related(
-                    "site",
-                    "cluster",
-                    "role",
-                    "tenant",
-                    "platform",
-                    "virtual_machine_type",
-                )
+                .select_related(*vm_type_select_related_fields(VirtualMachine))
                 .prefetch_related("interfaces__ip_addresses")
             )
-            from django.db.models import Q
 
             virtual_machines = list(
-                base_qs.filter(
-                    Q(virtual_machine_type__slug="qemu-virtual-machine")
-                    | Q(custom_field_data__proxmox_vm_type="qemu")
+                filter_queryset_by_proxmox_vm_type(
+                    base_qs,
+                    VirtualMachine,
+                    vm_type="qemu",
+                    vm_type_slug="qemu-virtual-machine",
                 )
             )
 
@@ -174,22 +170,16 @@ class LXCContainersView(ConditionalLoginRequiredMixin, View):
             base_qs = (
                 VirtualMachine.objects.restrict(request.user, "view")
                 .filter(id__in=tagged_vm_ids)
-                .select_related(
-                    "site",
-                    "cluster",
-                    "role",
-                    "tenant",
-                    "platform",
-                    "virtual_machine_type",
-                )
+                .select_related(*vm_type_select_related_fields(VirtualMachine))
                 .prefetch_related("interfaces__ip_addresses")
             )
-            from django.db.models import Q
 
             lxc_containers = list(
-                base_qs.filter(
-                    Q(virtual_machine_type__slug="lxc-container")
-                    | Q(custom_field_data__proxmox_vm_type="lxc")
+                filter_queryset_by_proxmox_vm_type(
+                    base_qs,
+                    VirtualMachine,
+                    vm_type="lxc",
+                    vm_type_slug="lxc-container",
                 )
             )
 

--- a/tests/test_api_source_contracts.py
+++ b/tests/test_api_source_contracts.py
@@ -559,6 +559,14 @@ def test_proxmox_endpoint_export_requires_token_for_sensitive_payloads():
     assert 'allowed_formats = {"csv", "json", "yaml"}' in contents
 
 
+def test_resource_vm_api_views_gate_native_vm_type_field_for_netbox_45():
+    contents = VIEWS_PATH.read_text()
+    assert "filter_queryset_by_proxmox_vm_type(" in contents
+    assert "vm_type_select_related_fields(VirtualMachine)" in contents
+    assert "Q(virtual_machine_type__slug=self.vm_type_slug)" not in contents
+    assert '.select_related("site", "cluster", "role", "tenant", "platform")' not in contents
+
+
 # ---------------------------------------------------------------------------
 # Non-model API views (added alongside the model viewsets)
 # ---------------------------------------------------------------------------

--- a/tests/test_api_source_contracts.py
+++ b/tests/test_api_source_contracts.py
@@ -564,7 +564,10 @@ def test_resource_vm_api_views_gate_native_vm_type_field_for_netbox_45():
     assert "filter_queryset_by_proxmox_vm_type(" in contents
     assert "vm_type_select_related_fields(VirtualMachine)" in contents
     assert "Q(virtual_machine_type__slug=self.vm_type_slug)" not in contents
-    assert '.select_related("site", "cluster", "role", "tenant", "platform")' not in contents
+    assert (
+        '.select_related("site", "cluster", "role", "tenant", "platform")'
+        not in contents
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backend_sync_placement.py
+++ b/tests/test_backend_sync_placement.py
@@ -26,13 +26,20 @@ def _load_backend_sync_module(monkeypatch):
     monkeypatch.setitem(sys.modules, "netbox_proxbox.models", models_mod)
 
     utils_mod = types.ModuleType("netbox_proxbox.utils")
-    utils_mod.get_ip_address_host = lambda value: str(value).split("/")[0] if value else "127.0.0.1"
+    utils_mod.get_ip_address_host = lambda value: (
+        str(value).split("/")[0] if value else "127.0.0.1"
+    )
     monkeypatch.setitem(sys.modules, "netbox_proxbox.utils", utils_mod)
 
     error_utils_mod = types.ModuleType("netbox_proxbox.views.error_utils")
     error_utils_mod.extract_backend_error_detail = lambda exc: (str(exc), None)
-    error_utils_mod.parse_requests_response_json = lambda response, log_label=None: ({}, None)
-    monkeypatch.setitem(sys.modules, "netbox_proxbox.views.error_utils", error_utils_mod)
+    error_utils_mod.parse_requests_response_json = lambda response, log_label=None: (
+        {},
+        None,
+    )
+    monkeypatch.setitem(
+        sys.modules, "netbox_proxbox.views.error_utils", error_utils_mod
+    )
 
     spec = importlib.util.spec_from_file_location(
         "netbox_proxbox.views.backend_sync",

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -534,6 +534,20 @@ def test_lxc_and_storage_pages_are_wired_in_urls_navigation_and_templates():
     assert "class SyncStorageView(" in sync_view
 
 
+def test_vm_resource_pages_gate_native_vm_type_field_for_netbox_45():
+    utils = _read("netbox_proxbox/utils.py")
+    views = _read("netbox_proxbox/views/resource_list_views.py")
+
+    assert "def has_virtual_machine_type_field(" in utils
+    assert "def filter_queryset_by_proxmox_vm_type(" in utils
+    assert "def vm_type_select_related_fields(" in utils
+    assert "filter_queryset_by_proxmox_vm_type(" in views
+    assert "vm_type_select_related_fields(VirtualMachine)" in views
+    assert 'Q(virtual_machine_type__slug="qemu-virtual-machine")' not in views
+    assert 'Q(virtual_machine_type__slug="lxc-container")' not in views
+    assert '"virtual_machine_type",' not in views
+
+
 def test_replication_page_is_wired_in_urls_navigation_and_vm_tabs():
     urls = _read("netbox_proxbox/urls.py")
     navigation = _read("netbox_proxbox/navigation.py")


### PR DESCRIPTION
Fixes #391

What changed:
- Gates plugin VM/LXC queryset usage of the NetBox 4.6 virtual_machine_type relation on the live model field.
- Falls back to legacy proxmox_vm_type custom-field filtering for NetBox 4.5.x.
- Adds source-contract coverage for the plugin UI/API paths.

Validation:
- UV_CACHE_DIR=/tmp/uv-cache uv run --extra test pytest tests/test_frontend_contracts.py::test_vm_resource_pages_gate_native_vm_type_field_for_netbox_45 tests/test_api_source_contracts.py::test_resource_vm_api_views_gate_native_vm_type_field_for_netbox_45