### PR TITLE
feat(#360): proxbox_sync Django management command

### DIFF
--- a/docs/operations/headless-sync.md
+++ b/docs/operations/headless-sync.md
@@ -1,0 +1,133 @@
+# Headless sync — `proxbox_sync` management command
+
+The `proxbox_sync` Django management command triggers a full Proxmox→NetBox
+sync from the NetBox shell. It is the headless equivalent of clicking the
+**Full Update** button on the plugin home page and is the supported entry
+point for cron jobs, systemd timers, Kubernetes `CronJob`s, CI smoke tests,
+and runbook automation.
+
+## What it does
+
+`proxbox_sync` enqueues the same `ProxboxSyncJob` that the UI's
+**Full Update** button enqueues:
+
+- Queue: NetBox's default RQ queue (`default`).
+- Sync types: `[SyncTypeChoices.ALL]` — all stages.
+- Endpoints: every configured `ProxmoxEndpoint`.
+- Job timeout: `PROXBOX_SYNC_JOB_TIMEOUT` (7200 seconds).
+
+The job appears under **Background Jobs** in NetBox identical to a
+UI-triggered sync, so the existing job-detail page, log stream, and
+**Cancel job** / **Run now** controls all work unchanged.
+
+## Usage
+
+```bash
+python manage.py proxbox_sync
+```
+
+Common variants:
+
+```bash
+# Block until the job finishes; exit code mirrors the job's terminal status.
+python manage.py proxbox_sync --wait
+
+# Run as a specific user (overrides the default oldest active superuser).
+python manage.py proxbox_sync --user automation
+
+# Bound the wait loop (default: 7200s).
+python manage.py proxbox_sync --wait --timeout 1800
+
+# Poll less aggressively while waiting (default: 2.0s).
+python manage.py proxbox_sync --wait --poll-interval 5
+
+# Fail fast if no RQ worker is consuming the default queue (default: 30s).
+python manage.py proxbox_sync --wait --worker-grace 10
+```
+
+## Flags
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--user USERNAME` | oldest active superuser | Username to attribute the job to. Used for audit and job ownership. |
+| `--wait` | off | Block until the job reaches a terminal state; exit code mirrors the job's status. |
+| `--timeout SECONDS` | `7200` | Upper bound on the `--wait` loop. Matches `PROXBOX_SYNC_JOB_TIMEOUT`. |
+| `--poll-interval SECONDS` | `2.0` | Seconds between job-status polls while `--wait` is set. |
+| `--worker-grace SECONDS` | `30.0` | Maximum seconds the job may stay pending before the command checks for an active RQ worker and fast-fails if none is found. |
+
+## Exit codes
+
+| Exit code | Condition |
+|---|---|
+| `0` | Job enqueued (and, with `--wait`, finished with status `completed`). |
+| non-zero | Any of: no `FastAPIEndpoint` configured · `proxbox-api` unreachable on `/health` · no usable user · `ProxboxSyncJob.enqueue` raised · with `--wait`, job ended in `errored` / `failed` or timed out / no worker available. |
+
+All failure paths emit an actionable message to stderr via Django's
+`CommandError` so cron / systemd capture useful logs.
+
+## RQ worker requirement
+
+`proxbox_sync` only **enqueues** the job. An RQ worker on the `default`
+queue must be running for the job to actually execute. With `--wait`,
+the command probes `django_rq.get_queue("default").workers` after
+`--worker-grace` seconds and fails fast if no worker is consuming the
+queue — useful in CI and during deployment-window automation.
+
+Without `--wait`, the command returns the moment the job is enqueued.
+A long-pending job in the **Background Jobs** UI usually means the
+worker is not running.
+
+See the
+[Backend integration notes in the top-level `CLAUDE.md`](../../CLAUDE.md#backend-integration-notes)
+for the full RQ queue / timeout model.
+
+## Example: cron
+
+Run a full sync every six hours:
+
+```cron
+0 */6 * * * cd /opt/netbox && /opt/netbox/venv/bin/python manage.py proxbox_sync --wait --timeout 7200
+```
+
+## Example: systemd timer
+
+`/etc/systemd/system/proxbox-sync.service`:
+
+```ini
+[Unit]
+Description=ProxBox full sync (headless)
+After=netbox-rq.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/netbox
+ExecStart=/opt/netbox/venv/bin/python manage.py proxbox_sync --wait --timeout 7200
+```
+
+`/etc/systemd/system/proxbox-sync.timer`:
+
+```ini
+[Unit]
+Description=Run proxbox-sync every 6 hours
+
+[Timer]
+OnCalendar=0/6:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable:
+
+```bash
+systemctl daemon-reload
+systemctl enable --now proxbox-sync.timer
+```
+
+## Related
+
+- UI equivalent: **Full Update** button on the plugin home page
+  (`SyncFullUpdateView` in `netbox_proxbox/views/sync.py`).
+- Token-status diagnostics: `python manage.py proxbox_fix_tokens`.
+- Sync internals: [`netbox_proxbox/jobs.py`](../../netbox_proxbox/jobs.py).

--- a/netbox_proxbox/management/commands/CLAUDE.md
+++ b/netbox_proxbox/management/commands/CLAUDE.md
@@ -6,11 +6,12 @@ This directory contains Django management commands for the ProxBox plugin.
 
 - [`__init__.py`](./__init__.py): package marker.
 - [`proxbox_fix_tokens.py`](./proxbox_fix_tokens.py): management command to check and fix FastAPIEndpoint tokens. Lists all endpoints and their token status; with `--fix`, attempts to register unregistered tokens with the proxbox-api backend.
+- [`proxbox_sync.py`](./proxbox_sync.py): management command that enqueues a full Proxmox→NetBox `ProxboxSyncJob` from the shell — the headless equivalent of clicking **Full Update** in the plugin UI. Supports `--user`, `--wait`, `--timeout`, `--poll-interval`, and `--worker-grace`. See [`docs/operations/headless-sync.md`](../../../docs/operations/headless-sync.md).
 
 ## Dependencies
 
-- Inbound: Django's `manage.py` CLI imports this command when `netbox_proxbox` is installed.
-- Outbound: `netbox_proxbox.models.FastAPIEndpoint`, `netbox_proxbox.signals._get_backend_url`, `netbox_proxbox.signals._register_token_with_backend`.
+- Inbound: Django's `manage.py` CLI imports these commands when `netbox_proxbox` is installed.
+- Outbound: `netbox_proxbox.models` (`FastAPIEndpoint`, `ProxmoxEndpoint`), `netbox_proxbox.jobs.ProxboxSyncJob`, `netbox_proxbox.services.backend_auth.wait_for_backend_ready`, `netbox_proxbox.services.backend_context.get_fastapi_request_context`, `netbox_proxbox.signals._get_backend_url`, `netbox_proxbox.signals._register_token_with_backend`.
 
 ## Usage
 
@@ -20,12 +21,18 @@ python manage.py proxbox_fix_tokens
 
 # Check and attempt to register unregistered tokens
 python manage.py proxbox_fix_tokens --fix
+
+# Enqueue a full Proxmox→NetBox sync (cron / systemd / CI entry point)
+python manage.py proxbox_sync
+
+# Same, but block until the job finishes and mirror its exit code
+python manage.py proxbox_sync --wait --timeout 7200
 ```
 
 ## Notes
 
-- This command is useful when tokens need to be re-registered after backend restarts or configuration changes.
-- The `--fix` flag is a best-effort operation; failures are logged but do not raise exceptions.
+- `proxbox_fix_tokens --fix` is best-effort; failures are logged but do not raise.
+- `proxbox_sync` raises `CommandError` (exit non-zero) when `proxbox-api` is unreachable, no `FastAPIEndpoint` is configured, no usable user is found, or — with `--wait` — the job ends in a non-success terminal state. The job appears under **Background Jobs** identical to a UI-triggered sync.
 
 ## Links
 

--- a/netbox_proxbox/management/commands/proxbox_sync.py
+++ b/netbox_proxbox/management/commands/proxbox_sync.py
@@ -100,11 +100,15 @@ class Command(BaseCommand):
             timeout = PROXBOX_SYNC_JOB_TIMEOUT
         poll_interval_raw = options.get("poll_interval")
         poll_interval = (
-            DEFAULT_POLL_INTERVAL if poll_interval_raw is None else float(poll_interval_raw)
+            DEFAULT_POLL_INTERVAL
+            if poll_interval_raw is None
+            else float(poll_interval_raw)
         )
         worker_grace_raw = options.get("worker_grace")
         worker_grace = (
-            DEFAULT_WORKER_GRACE if worker_grace_raw is None else float(worker_grace_raw)
+            DEFAULT_WORKER_GRACE
+            if worker_grace_raw is None
+            else float(worker_grace_raw)
         )
 
         user = self._resolve_user(username)
@@ -220,9 +224,7 @@ class Command(BaseCommand):
             if status in TERMINAL_JOB_STATUSES:
                 if status in SUCCESS_JOB_STATUSES:
                     self.stdout.write(
-                        self.style.SUCCESS(
-                            f"Proxbox sync job (pk={job_pk}) completed."
-                        )
+                        self.style.SUCCESS(f"Proxbox sync job (pk={job_pk}) completed.")
                     )
                     return
                 raise CommandError(

--- a/netbox_proxbox/management/commands/proxbox_sync.py
+++ b/netbox_proxbox/management/commands/proxbox_sync.py
@@ -1,0 +1,263 @@
+"""Django management command to enqueue a full Proxmox→NetBox sync.
+
+Usage:
+    python manage.py proxbox_sync [--user USERNAME] [--wait] [--timeout SECONDS]
+                                  [--poll-interval SECONDS] [--worker-grace SECONDS]
+
+This is the headless equivalent of clicking "Full Update" in the plugin UI:
+it enqueues the same ``ProxboxSyncJob`` (on NetBox's default RQ queue) with
+``sync_types=[SyncTypeChoices.ALL]`` and all configured Proxmox endpoint IDs.
+
+Exit codes:
+    0  job enqueued (and, with --wait, completed successfully)
+    non-zero  proxbox-api unreachable, misconfiguration, or the job ended in
+              a non-completed terminal state
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from argparse import ArgumentParser
+
+from django.core.management.base import BaseCommand, CommandError
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_POLL_INTERVAL = 2.0
+DEFAULT_WORKER_GRACE = 30.0
+TERMINAL_JOB_STATUSES = {"completed", "errored", "failed"}
+SUCCESS_JOB_STATUSES = {"completed"}
+
+
+class Command(BaseCommand):
+    """Command implementation."""
+
+    help = (
+        "Enqueue a full Proxmox→NetBox sync, equivalent to the plugin UI's "
+        '"Full Update" button. Suitable for cron, systemd timers, and CI.'
+    )
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        """Handle add arguments."""
+        parser.add_argument(
+            "--user",
+            dest="username",
+            default=None,
+            help=(
+                "Username to attribute the enqueued job to. "
+                "Defaults to the oldest active superuser."
+            ),
+        )
+        parser.add_argument(
+            "--wait",
+            action="store_true",
+            help="Block until the job reaches a terminal state and mirror its exit code.",
+        )
+        parser.add_argument(
+            "--timeout",
+            type=int,
+            default=None,
+            help=(
+                "Maximum seconds to wait when --wait is set. "
+                "Defaults to PROXBOX_SYNC_JOB_TIMEOUT (7200)."
+            ),
+        )
+        parser.add_argument(
+            "--poll-interval",
+            type=float,
+            default=DEFAULT_POLL_INTERVAL,
+            help=f"Seconds between job-status polls when --wait is set (default: {DEFAULT_POLL_INTERVAL}).",
+        )
+        parser.add_argument(
+            "--worker-grace",
+            type=float,
+            default=DEFAULT_WORKER_GRACE,
+            help=(
+                "When --wait is set, fast-fail if the job stays pending for this many "
+                f"seconds with no RQ worker on the default queue (default: {DEFAULT_WORKER_GRACE})."
+            ),
+        )
+
+    def handle(self, *args: object, **options: object) -> None:
+        """Handle handle."""
+        from netbox_proxbox.choices import SyncTypeChoices
+        from netbox_proxbox.jobs import (
+            PROXBOX_SYNC_JOB_TIMEOUT,
+            PROXBOX_SYNC_QUEUE_NAME,
+            ProxboxSyncJob,
+        )
+        from netbox_proxbox.models import ProxmoxEndpoint
+        from netbox_proxbox.services.backend_auth import wait_for_backend_ready
+        from netbox_proxbox.services.backend_context import (
+            get_fastapi_request_context,
+        )
+
+        username = options.get("username")
+        wait = bool(options.get("wait"))
+        timeout = options.get("timeout")
+        if timeout is None:
+            timeout = PROXBOX_SYNC_JOB_TIMEOUT
+        poll_interval_raw = options.get("poll_interval")
+        poll_interval = (
+            DEFAULT_POLL_INTERVAL if poll_interval_raw is None else float(poll_interval_raw)
+        )
+        worker_grace_raw = options.get("worker_grace")
+        worker_grace = (
+            DEFAULT_WORKER_GRACE if worker_grace_raw is None else float(worker_grace_raw)
+        )
+
+        user = self._resolve_user(username)
+
+        context = get_fastapi_request_context()
+        if context is None or not context.http_url:
+            raise CommandError(
+                "No FastAPIEndpoint configured. Create one under "
+                "Plugins > ProxBox > Endpoints > FastAPI before running proxbox_sync."
+            )
+
+        # Snappy pre-flight: 5 retries is enough for a CLI. The job itself will
+        # use the standard reachability helpers internally.
+        ok, msg = wait_for_backend_ready(context, max_retries=5)
+        if not ok:
+            raise CommandError(
+                f"proxbox-api backend not reachable at {context.http_url}: {msg}"
+            )
+
+        proxmox_endpoint_ids = list(
+            ProxmoxEndpoint.objects.values_list("pk", flat=True)
+        )
+        if not proxmox_endpoint_ids:
+            self.stdout.write(
+                self.style.WARNING(
+                    "No ProxmoxEndpoint records configured; nothing to sync."
+                )
+            )
+            return
+
+        try:
+            job = ProxboxSyncJob.enqueue(
+                instance=None,
+                user=user,
+                queue_name=PROXBOX_SYNC_QUEUE_NAME,
+                name="Proxbox Sync: Full update (CLI)",
+                sync_types=[SyncTypeChoices.ALL],
+                proxmox_endpoint_ids=proxmox_endpoint_ids,
+            )
+        except Exception as exc:  # noqa: BLE001 — surface any enqueue failure
+            raise CommandError(f"Failed to enqueue ProxboxSyncJob: {exc}") from exc
+
+        job_pk = getattr(job, "pk", None)
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Enqueued ProxboxSyncJob (pk={job_pk}) on queue "
+                f"'{PROXBOX_SYNC_QUEUE_NAME}' for {len(proxmox_endpoint_ids)} "
+                f"Proxmox endpoint(s), attributed to user '{user}'."
+            )
+        )
+
+        if not wait:
+            return
+
+        self._wait_for_job(
+            job=job,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            worker_grace=worker_grace,
+        )
+
+    def _resolve_user(self, username: str | None):
+        """Look up the requested user or fall back to the oldest active superuser."""
+        from django.contrib.auth import get_user_model
+
+        user_model = get_user_model()
+
+        if username:
+            user = user_model.objects.filter(username=username).first()
+            if user is None:
+                raise CommandError(f"User '{username}' does not exist.")
+            return user
+
+        user = (
+            user_model.objects.filter(is_active=True, is_superuser=True)
+            .order_by("pk")
+            .first()
+        )
+        if user is None:
+            raise CommandError(
+                "No active superuser found. Create one with "
+                "`python manage.py createsuperuser` or pass --user USERNAME."
+            )
+        return user
+
+    def _wait_for_job(
+        self,
+        *,
+        job,
+        timeout: int,
+        poll_interval: float,
+        worker_grace: float,
+    ) -> None:
+        """Poll the Job row until terminal and mirror its status to the exit code."""
+        from netbox.jobs import Job
+
+        job_pk = getattr(job, "pk", None)
+        deadline = time.monotonic() + timeout
+        worker_deadline = time.monotonic() + worker_grace
+        worker_checked = False
+
+        while True:
+            now = time.monotonic()
+            if now >= deadline:
+                raise CommandError(
+                    f"Timed out after {timeout}s waiting for Proxbox sync job "
+                    f"(pk={job_pk}) to finish."
+                )
+
+            current = Job.objects.get(pk=job_pk)
+            status = str(getattr(current, "status", "") or "").lower()
+
+            if status in TERMINAL_JOB_STATUSES:
+                if status in SUCCESS_JOB_STATUSES:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f"Proxbox sync job (pk={job_pk}) completed."
+                        )
+                    )
+                    return
+                raise CommandError(
+                    f"Proxbox sync job (pk={job_pk}) ended with status '{status}'."
+                )
+
+            if (
+                not worker_checked
+                and status in {"pending", "scheduled"}
+                and now >= worker_deadline
+            ):
+                worker_checked = True
+                if not self._default_queue_has_workers():
+                    raise CommandError(
+                        "No RQ worker is consuming the 'default' queue. "
+                        "Start a worker with `python manage.py rqworker default` "
+                        "or via the netbox-rq service, then re-run."
+                    )
+
+            time.sleep(poll_interval)
+
+    def _default_queue_has_workers(self) -> bool:
+        """Best-effort probe for active workers on the default RQ queue."""
+        try:
+            import django_rq  # noqa: PLC0415
+
+            queue = django_rq.get_queue("default")
+            workers = getattr(queue, "workers", None)
+            if workers is None:
+                # Older django-rq versions don't expose .workers — assume workers exist.
+                return True
+            try:
+                return len(list(workers)) > 0
+            except TypeError:
+                return bool(workers)
+        except Exception:  # noqa: BLE001 — probe is best-effort
+            logger.debug("Could not probe RQ workers; assuming workers exist.")
+            return True

--- a/tests/management/conftest.py
+++ b/tests/management/conftest.py
@@ -1,0 +1,73 @@
+"""Shared django/management stubs for tests under tests/management/.
+
+The plugin's management commands import ``from django.core.management.base
+import BaseCommand, CommandError`` at module load. Tests here do not
+bootstrap Django, so we install minimal stubs at conftest import time —
+before pytest collects the test files — so the imports resolve to
+lightweight Python classes.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def _install_django_management_stubs() -> None:
+    if "django.core.management.base" in sys.modules:
+        return
+
+    django_module = sys.modules.setdefault("django", types.ModuleType("django"))
+    django_core = sys.modules.setdefault(
+        "django.core", types.ModuleType("django.core")
+    )
+    django_core_management = sys.modules.setdefault(
+        "django.core.management", types.ModuleType("django.core.management")
+    )
+
+    base_mod = types.ModuleType("django.core.management.base")
+
+    class CommandError(Exception):
+        """Stub mirroring django.core.management.base.CommandError."""
+
+    class BaseCommand:
+        """Stub mirroring django.core.management.base.BaseCommand."""
+
+        help: str = ""
+
+        def add_arguments(self, parser) -> None:  # pragma: no cover - overridden
+            return None
+
+        def handle(self, *args, **kwargs) -> None:  # pragma: no cover - overridden
+            raise NotImplementedError
+
+    base_mod.BaseCommand = BaseCommand
+    base_mod.CommandError = CommandError
+
+    sys.modules["django.core.management.base"] = base_mod
+
+    django_core_management.base = base_mod
+    django_core.management = django_core_management
+    django_module.core = django_core
+
+    # django.contrib.auth — populated with a placeholder get_user_model so
+    # monkeypatch.setattr("django.contrib.auth.get_user_model", ...) can resolve
+    # the dotted path. Tests override get_user_model per case.
+    django_contrib = sys.modules.setdefault(
+        "django.contrib", types.ModuleType("django.contrib")
+    )
+    django_auth = sys.modules.setdefault(
+        "django.contrib.auth", types.ModuleType("django.contrib.auth")
+    )
+
+    def _placeholder_get_user_model():  # pragma: no cover - overridden per test
+        raise RuntimeError("django.contrib.auth.get_user_model not stubbed for this test")
+
+    if not hasattr(django_auth, "get_user_model"):
+        django_auth.get_user_model = _placeholder_get_user_model
+
+    django_contrib.auth = django_auth
+    django_module.contrib = django_contrib
+
+
+_install_django_management_stubs()

--- a/tests/management/conftest.py
+++ b/tests/management/conftest.py
@@ -18,9 +18,7 @@ def _install_django_management_stubs() -> None:
         return
 
     django_module = sys.modules.setdefault("django", types.ModuleType("django"))
-    django_core = sys.modules.setdefault(
-        "django.core", types.ModuleType("django.core")
-    )
+    django_core = sys.modules.setdefault("django.core", types.ModuleType("django.core"))
     django_core_management = sys.modules.setdefault(
         "django.core.management", types.ModuleType("django.core.management")
     )
@@ -61,7 +59,9 @@ def _install_django_management_stubs() -> None:
     )
 
     def _placeholder_get_user_model():  # pragma: no cover - overridden per test
-        raise RuntimeError("django.contrib.auth.get_user_model not stubbed for this test")
+        raise RuntimeError(
+            "django.contrib.auth.get_user_model not stubbed for this test"
+        )
 
     if not hasattr(django_auth, "get_user_model"):
         django_auth.get_user_model = _placeholder_get_user_model

--- a/tests/management/test_proxbox_sync.py
+++ b/tests/management/test_proxbox_sync.py
@@ -1,0 +1,317 @@
+"""Tests for the proxbox_sync Django management command."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from django.core.management.base import CommandError
+
+
+@pytest.fixture
+def proxbox_sync_command(monkeypatch):
+    """Load proxbox_sync.py with stubs for plugin internals.
+
+    Mirrors the stub pattern used by tests/test_jobs.py — we don't bootstrap
+    Django/NetBox; we inject just enough of the plugin's modules to let the
+    command import and run.
+    """
+    # netbox_proxbox.choices
+    choices_mod = types.ModuleType("netbox_proxbox.choices")
+    choices_mod.SyncTypeChoices = SimpleNamespace(ALL="all")
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.choices", choices_mod)
+
+    # netbox_proxbox.jobs — only the symbols the command imports
+    jobs_mod = types.ModuleType("netbox_proxbox.jobs")
+    jobs_mod.PROXBOX_SYNC_QUEUE_NAME = "default"
+    jobs_mod.PROXBOX_SYNC_JOB_TIMEOUT = 7200
+
+    enqueue_calls: list[dict] = []
+
+    class _ProxboxSyncJob:
+        last_kwargs: dict = {}
+        raise_on_enqueue: Exception | None = None
+        next_job_pk: int = 42
+
+        @classmethod
+        def enqueue(cls, **kwargs):
+            cls.last_kwargs = kwargs
+            enqueue_calls.append(kwargs)
+            if cls.raise_on_enqueue is not None:
+                raise cls.raise_on_enqueue
+            return SimpleNamespace(pk=cls.next_job_pk)
+
+    jobs_mod.ProxboxSyncJob = _ProxboxSyncJob
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.jobs", jobs_mod)
+
+    # netbox_proxbox.models — only ProxmoxEndpoint is needed
+    models_mod = types.ModuleType("netbox_proxbox.models")
+
+    class _ValuesList:
+        def __init__(self, rows):
+            self._rows = list(rows)
+
+        def __iter__(self):
+            return iter(self._rows)
+
+    class _ProxmoxEndpointObjects:
+        rows: list[int] = [1, 2]
+
+        @classmethod
+        def values_list(cls, *args, **kwargs):
+            return _ValuesList(cls.rows)
+
+    class _ProxmoxEndpoint:
+        objects = _ProxmoxEndpointObjects
+
+    models_mod.ProxmoxEndpoint = _ProxmoxEndpoint
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.models", models_mod)
+
+    # netbox_proxbox.services.backend_auth
+    backend_auth_mod = types.ModuleType("netbox_proxbox.services.backend_auth")
+    backend_auth_mod.wait_for_backend_ready_result = (True, "Backend is reachable")
+
+    def _wait_for_backend_ready(context, max_retries: int = 30, **kwargs):
+        return backend_auth_mod.wait_for_backend_ready_result
+
+    backend_auth_mod.wait_for_backend_ready = _wait_for_backend_ready
+    monkeypatch.setitem(
+        sys.modules, "netbox_proxbox.services.backend_auth", backend_auth_mod
+    )
+
+    # netbox_proxbox.services.backend_context
+    backend_context_mod = types.ModuleType("netbox_proxbox.services.backend_context")
+    backend_context_mod.context_result = SimpleNamespace(http_url="http://backend.test")
+    backend_context_mod.get_fastapi_request_context = lambda **kw: (
+        backend_context_mod.context_result
+    )
+    monkeypatch.setitem(
+        sys.modules, "netbox_proxbox.services.backend_context", backend_context_mod
+    )
+
+    # netbox.jobs — for the --wait Job polling
+    netbox_jobs_mod = types.ModuleType("netbox.jobs")
+
+    class _JobObjects:
+        status_sequence: list[str] = ["completed"]
+        _idx = 0
+
+        @classmethod
+        def reset(cls):
+            cls._idx = 0
+
+        @classmethod
+        def get(cls, pk):
+            idx = min(cls._idx, len(cls.status_sequence) - 1)
+            status = cls.status_sequence[idx]
+            cls._idx += 1
+            return SimpleNamespace(pk=pk, status=status)
+
+    class _Job:
+        objects = _JobObjects
+
+    netbox_jobs_mod.Job = _Job
+    monkeypatch.setitem(sys.modules, "netbox.jobs", netbox_jobs_mod)
+
+    # django.contrib.auth.get_user_model
+    fake_user = SimpleNamespace(username="admin", pk=1)
+
+    class _UserQS:
+        users: list = [fake_user]
+        return_first: SimpleNamespace | None = fake_user
+
+        @classmethod
+        def filter(cls, **kwargs):
+            qs = cls()
+            qs._kwargs = kwargs
+            return qs
+
+        def order_by(self, *_):
+            return self
+
+        def first(self):
+            kwargs = getattr(self, "_kwargs", {})
+            if "username" in kwargs:
+                for u in _UserQS.users:
+                    if u.username == kwargs["username"]:
+                        return u
+                return None
+            return _UserQS.return_first
+
+    class _UserModel:
+        objects = _UserQS
+
+    def _get_user_model():
+        return _UserModel
+
+    monkeypatch.setattr(
+        "django.contrib.auth.get_user_model", _get_user_model, raising=True
+    )
+
+    # django_rq stub (worker probe)
+    django_rq_mod = types.ModuleType("django_rq")
+    django_rq_mod.worker_count = 1
+
+    def _get_queue(_name):
+        return SimpleNamespace(workers=[object()] * django_rq_mod.worker_count)
+
+    django_rq_mod.get_queue = _get_queue
+    monkeypatch.setitem(sys.modules, "django_rq", django_rq_mod)
+
+    # Load the command module fresh
+    root = Path(__file__).resolve().parents[2]
+    path = (
+        root
+        / "netbox_proxbox"
+        / "management"
+        / "commands"
+        / "proxbox_sync.py"
+    )
+    sys.modules.pop("netbox_proxbox.management.commands.proxbox_sync", None)
+    spec = importlib.util.spec_from_file_location(
+        "netbox_proxbox.management.commands.proxbox_sync", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["netbox_proxbox.management.commands.proxbox_sync"] = module
+    spec.loader.exec_module(module)
+
+    return SimpleNamespace(
+        module=module,
+        enqueue_calls=enqueue_calls,
+        jobs_mod=jobs_mod,
+        models_mod=models_mod,
+        backend_auth_mod=backend_auth_mod,
+        backend_context_mod=backend_context_mod,
+        netbox_jobs_mod=netbox_jobs_mod,
+        django_rq_mod=django_rq_mod,
+        user_model=_UserModel,
+        user_qs=_UserQS,
+        fake_user=fake_user,
+        job_objects=_JobObjects,
+        proxbox_sync_job=_ProxboxSyncJob,
+        proxmox_endpoint=_ProxmoxEndpoint,
+    )
+
+
+def _run(command_module, **options):
+    """Invoke Command().handle with full defaults populated."""
+    defaults = {
+        "username": None,
+        "wait": False,
+        "timeout": None,
+        "poll_interval": 0.0,
+        "worker_grace": 0.0,
+    }
+    defaults.update(options)
+    cmd = command_module.Command()
+    cmd.stdout = MagicMock()
+    cmd.stderr = MagicMock()
+    cmd.style = SimpleNamespace(
+        SUCCESS=lambda x: x,
+        WARNING=lambda x: x,
+        ERROR=lambda x: x,
+        NOTICE=lambda x: x,
+    )
+    cmd.handle(**defaults)
+    return cmd
+
+
+def test_healthy_enqueue_path(proxbox_sync_command):
+    """Healthy path enqueues a job with ALL sync types and all endpoint IDs."""
+    proxbox_sync_command.proxbox_sync_job.raise_on_enqueue = None
+    proxbox_sync_command.user_qs.return_first = proxbox_sync_command.fake_user
+
+    _run(proxbox_sync_command.module)
+
+    assert len(proxbox_sync_command.enqueue_calls) == 1
+    call = proxbox_sync_command.enqueue_calls[0]
+    assert call["sync_types"] == ["all"]
+    assert call["proxmox_endpoint_ids"] == [1, 2]
+    assert call["queue_name"] == "default"
+    assert call["user"] is proxbox_sync_command.fake_user
+    assert "CLI" in call["name"]
+
+
+def test_backend_unreachable_raises_command_error(proxbox_sync_command):
+    """A failed reachability probe must surface as a non-zero exit."""
+    proxbox_sync_command.backend_auth_mod.wait_for_backend_ready_result = (
+        False,
+        "Backend not reachable after 5 attempts",
+    )
+    with pytest.raises(CommandError, match="not reachable"):
+        _run(proxbox_sync_command.module)
+    assert proxbox_sync_command.enqueue_calls == []
+
+
+def test_no_fastapi_endpoint_raises_command_error(proxbox_sync_command):
+    """Missing FastAPIEndpoint config must hard-fail before enqueuing."""
+    proxbox_sync_command.backend_context_mod.context_result = None
+    with pytest.raises(CommandError, match="No FastAPIEndpoint"):
+        _run(proxbox_sync_command.module)
+    assert proxbox_sync_command.enqueue_calls == []
+
+
+def test_no_proxmox_endpoints_exits_zero_without_enqueue(proxbox_sync_command):
+    """Zero ProxmoxEndpoint rows is a warning, not an error."""
+    proxbox_sync_command.proxmox_endpoint.objects.rows = []
+    _run(proxbox_sync_command.module)
+    assert proxbox_sync_command.enqueue_calls == []
+
+
+def test_unknown_user_raises_command_error(proxbox_sync_command):
+    """--user must resolve to an existing user."""
+    with pytest.raises(CommandError, match="ghost"):
+        _run(proxbox_sync_command.module, username="ghost")
+    assert proxbox_sync_command.enqueue_calls == []
+
+
+def test_no_active_superuser_raises_command_error(proxbox_sync_command):
+    """If no --user is given and no superuser exists, hard-fail."""
+    proxbox_sync_command.user_qs.return_first = None
+    with pytest.raises(CommandError, match="superuser"):
+        _run(proxbox_sync_command.module)
+
+
+def test_wait_happy_path_returns_on_completion(proxbox_sync_command):
+    """--wait blocks until completion; success exits cleanly."""
+    proxbox_sync_command.job_objects.status_sequence = ["pending", "running", "completed"]
+    proxbox_sync_command.job_objects.reset()
+    _run(proxbox_sync_command.module, wait=True, timeout=5, poll_interval=0.0)
+    assert len(proxbox_sync_command.enqueue_calls) == 1
+
+
+def test_wait_failed_status_raises_command_error(proxbox_sync_command):
+    """A terminal non-success status must surface as a non-zero exit."""
+    proxbox_sync_command.job_objects.status_sequence = ["running", "errored"]
+    proxbox_sync_command.job_objects.reset()
+    with pytest.raises(CommandError, match="errored"):
+        _run(proxbox_sync_command.module, wait=True, timeout=5, poll_interval=0.0)
+
+
+def test_wait_no_worker_fast_fails(proxbox_sync_command):
+    """--wait with no RQ worker and job stuck pending must fast-fail."""
+    proxbox_sync_command.job_objects.status_sequence = ["pending"]
+    proxbox_sync_command.job_objects.reset()
+    proxbox_sync_command.django_rq_mod.worker_count = 0
+    with pytest.raises(CommandError, match="No RQ worker"):
+        _run(
+            proxbox_sync_command.module,
+            wait=True,
+            timeout=5,
+            poll_interval=0.0,
+            worker_grace=0.0,
+        )
+
+
+def test_enqueue_failure_surfaces_as_command_error(proxbox_sync_command):
+    """If ProxboxSyncJob.enqueue raises, the command must exit non-zero."""
+    proxbox_sync_command.proxbox_sync_job.raise_on_enqueue = RuntimeError("boom")
+    with pytest.raises(CommandError, match="boom"):
+        _run(proxbox_sync_command.module)

--- a/tests/management/test_proxbox_sync.py
+++ b/tests/management/test_proxbox_sync.py
@@ -166,13 +166,7 @@ def proxbox_sync_command(monkeypatch):
 
     # Load the command module fresh
     root = Path(__file__).resolve().parents[2]
-    path = (
-        root
-        / "netbox_proxbox"
-        / "management"
-        / "commands"
-        / "proxbox_sync.py"
-    )
+    path = root / "netbox_proxbox" / "management" / "commands" / "proxbox_sync.py"
     sys.modules.pop("netbox_proxbox.management.commands.proxbox_sync", None)
     spec = importlib.util.spec_from_file_location(
         "netbox_proxbox.management.commands.proxbox_sync", path
@@ -281,7 +275,11 @@ def test_no_active_superuser_raises_command_error(proxbox_sync_command):
 
 def test_wait_happy_path_returns_on_completion(proxbox_sync_command):
     """--wait blocks until completion; success exits cleanly."""
-    proxbox_sync_command.job_objects.status_sequence = ["pending", "running", "completed"]
+    proxbox_sync_command.job_objects.status_sequence = [
+        "pending",
+        "running",
+        "completed",
+    ]
     proxbox_sync_command.job_objects.reset()
     _run(proxbox_sync_command.module, wait=True, timeout=5, poll_interval=0.0)
     assert len(proxbox_sync_command.enqueue_calls) == 1


### PR DESCRIPTION
Closes #360.

## Summary

- Adds `python manage.py proxbox_sync` — the headless equivalent of clicking **Full Update** in the plugin UI. Enqueues the same `ProxboxSyncJob` (queue `default`, `sync_types=[SyncTypeChoices.ALL]`, all `ProxmoxEndpoint` rows) so cron, systemd timers, Kubernetes `CronJob`s, and CI smoke checks have a supported entry point.
- Flags: `--user` (defaults to oldest active superuser), `--wait`, `--timeout` (default `PROXBOX_SYNC_JOB_TIMEOUT` = 7200s), `--poll-interval` (default 2s), `--worker-grace` (default 30s). All failure paths raise `CommandError` so exit codes are non-zero for cron/systemd.
- With `--wait`, the command polls the `Job` row until terminal and mirrors the status to the exit code. If the job stays `pending`/`scheduled` past `--worker-grace` and `django_rq.get_queue("default").workers` is empty, the command fast-fails with an actionable "No RQ worker" message.

## Files

| Path | Change |
|---|---|
| `netbox_proxbox/management/commands/proxbox_sync.py` | new — the command |
| `tests/management/__init__.py` | new — package marker |
| `tests/management/conftest.py` | new — `django.core.management.base` + `django.contrib.auth` stubs so tests run without bootstrapping Django |
| `tests/management/test_proxbox_sync.py` | new — 10 tests covering enqueue, errors, and `--wait` paths |
| `docs/operations/headless-sync.md` | new — usage, flags, exit codes, cron + systemd timer examples |
| `netbox_proxbox/management/commands/CLAUDE.md` | updated — entry for the new command |

## Test plan

- [x] `python -m compileall netbox_proxbox tests` — clean
- [x] `ruff check .` — clean
- [x] `pytest tests/management/test_proxbox_sync.py -v` — 10 passing
- [x] `pytest tests/` — 504 passing, 2 skipped (no regressions)
- [ ] Live smoke on `10.0.30.207`: `python manage.py proxbox_sync` shows the job under Background Jobs identical to a UI-triggered sync
- [ ] Live negative: `systemctl stop proxbox-api` then re-run → non-zero exit with "backend not reachable"
- [ ] Live `--wait` no-worker: `systemctl stop netbox-rq` then `proxbox_sync --wait --worker-grace 5` → non-zero exit with "No RQ worker"

## Notes

- No edits to existing runtime modules; the command is a thin wrapper around the existing UI enqueue path, so the blast radius is contained to one new file.
- `proxbox-api` is reached via `wait_for_backend_ready(context, max_retries=5)` — snappy pre-flight only; the job itself uses the standard reachability helpers internally.
- Pinned upstream `proxbox-api` is unchanged (`v0.0.11`).