### PR TITLE
feat(#366): add parse_description_metadata plugin setting

### DIFF
--- a/netbox_proxbox/forms/settings.py
+++ b/netbox_proxbox/forms/settings.py
@@ -191,6 +191,16 @@ class ProxboxPluginSettingsForm(forms.Form):
             "responses. Leave disabled in production."
         ),
     )
+    parse_description_metadata = forms.BooleanField(
+        required=False,
+        label="Parse description metadata",
+        help_text=(
+            "When enabled, proxbox-api reads each Proxmox object's description for a "
+            "fenced \"netbox-metadata\" JSON block and applies the parsed PK ids to the "
+            "matching NetBox fields. Per-field overwrite_* flags still gate keys they "
+            "cover. Disabled by default."
+        ),
+    )
     ssrf_protection_enabled = forms.BooleanField(
         required=False,
         label="Enable SSRF protection",

--- a/netbox_proxbox/forms/settings.py
+++ b/netbox_proxbox/forms/settings.py
@@ -196,7 +196,7 @@ class ProxboxPluginSettingsForm(forms.Form):
         label="Parse description metadata",
         help_text=(
             "When enabled, proxbox-api reads each Proxmox object's description for a "
-            "fenced \"netbox-metadata\" JSON block and applies the parsed PK ids to the "
+            'fenced "netbox-metadata" JSON block and applies the parsed PK ids to the '
             "matching NetBox fields. Per-field overwrite_* flags still gate keys they "
             "cover. Disabled by default."
         ),

--- a/netbox_proxbox/migrations/0040_pluginsettings_parse_description_metadata.py
+++ b/netbox_proxbox/migrations/0040_pluginsettings_parse_description_metadata.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+
+
+def _add_column(table: str, column: str, sql_type: str, default: str) -> migrations.RunSQL:
+    return migrations.RunSQL(
+        sql=(
+            f'ALTER TABLE "{table}" '
+            f'ADD COLUMN IF NOT EXISTS "{column}" {sql_type} NOT NULL DEFAULT {default};'
+        ),
+        reverse_sql=(
+            f'ALTER TABLE "{table}" DROP COLUMN IF EXISTS "{column}";'
+        ),
+    )
+
+
+TABLE = "netbox_proxbox_proxboxpluginsettings"
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_proxbox", "0039_pluginsettings_overwrite_ip_address_dns_name"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                _add_column(TABLE, "parse_description_metadata", "boolean", "FALSE"),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="parse_description_metadata",
+                    field=models.BooleanField(
+                        default=False,
+                        verbose_name="Parse description metadata",
+                        help_text=(
+                            "When enabled, proxbox-api reads each Proxmox object's "
+                            "description for a fenced ``netbox-metadata`` JSON block "
+                            "and applies the parsed PK ids to the matching NetBox "
+                            "fields. Per-field ``overwrite_*`` flags still gate keys "
+                            "they cover. Disabled by default."
+                        ),
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/netbox_proxbox/models/plugin_settings.py
+++ b/netbox_proxbox/models/plugin_settings.py
@@ -203,6 +203,16 @@ class ProxboxPluginSettings(NetBoxModel):
             "responses. Leave disabled in production to avoid leaking implementation details."
         ),
     )
+    parse_description_metadata = models.BooleanField(
+        default=False,
+        verbose_name=_("Parse description metadata"),
+        help_text=_(
+            "When enabled, proxbox-api reads each Proxmox object's description for a "
+            "fenced ``netbox-metadata`` JSON block and applies the parsed PK ids to the "
+            "matching NetBox fields. Per-field ``overwrite_*`` flags still gate keys "
+            "they cover. Disabled by default."
+        ),
+    )
     ssrf_protection_enabled = models.BooleanField(
         default=True,
         verbose_name=_("Enable SSRF protection"),

--- a/netbox_proxbox/sync_params.py
+++ b/netbox_proxbox/sync_params.py
@@ -70,6 +70,16 @@ def _primary_ip_preference_setting() -> str:
         return "ipv4"
 
 
+def _parse_description_metadata_setting() -> bool:
+    """Return plugin setting for description-metadata JSON parsing (opt-in)."""
+    try:
+        from netbox_proxbox.models import ProxboxPluginSettings
+
+        return bool(ProxboxPluginSettings.get_solo().parse_description_metadata)
+    except (ImportError, RuntimeError, AttributeError):
+        return False
+
+
 def _overwrite_device_role_setting() -> bool:
     """Return plugin setting for whether sync should overwrite the device role."""
     try:

--- a/netbox_proxbox/sync_stages.py
+++ b/netbox_proxbox/sync_stages.py
@@ -24,6 +24,7 @@ from netbox_proxbox.sync_params import (
     _resolve_vm_snapshot_batch_params,
     _resolve_storage_batch_params,
     _resolve_task_history_batch_params,
+    _parse_description_metadata_setting,
     _proxbox_fetch_max_concurrency_setting,
     _use_guest_agent_interface_name_setting,
     _ignore_ipv6_link_local_addresses_setting,
@@ -175,6 +176,9 @@ def _build_base_query_params(
         "true" if _ignore_ipv6_link_local_addresses_setting() else "false"
     )
     base_query["primary_ip_preference"] = _primary_ip_preference_setting()
+    base_query["parse_description_metadata"] = (
+        "true" if _parse_description_metadata_setting() else "false"
+    )
 
     single_endpoint_id = (
         proxmox_endpoint_ids[0]

--- a/netbox_proxbox/templates/netbox_proxbox/settings.html
+++ b/netbox_proxbox/templates/netbox_proxbox/settings.html
@@ -27,6 +27,7 @@
                     {% render_field form.proxbox_fetch_max_concurrency %}
                     {% render_field form.ignore_ipv6_link_local_addresses %}
                     {% render_field form.primary_ip_preference %}
+                    {% render_field form.parse_description_metadata %}
                     {% render_field form.backend_log_file_path %}
                 </div>
             </div>

--- a/netbox_proxbox/views/settings.py
+++ b/netbox_proxbox/views/settings.py
@@ -56,6 +56,7 @@ class SettingsView(
             "backend_log_file_path": settings_obj.backend_log_file_path,
             "debug_cache": settings_obj.debug_cache,
             "expose_internal_errors": settings_obj.expose_internal_errors,
+            "parse_description_metadata": settings_obj.parse_description_metadata,
             "ssrf_protection_enabled": settings_obj.ssrf_protection_enabled,
             "allow_private_ips": settings_obj.allow_private_ips,
             "additional_allowed_ip_ranges": settings_obj.additional_allowed_ip_ranges,
@@ -155,6 +156,9 @@ class SettingsView(
             settings_obj.expose_internal_errors = form.cleaned_data.get(
                 "expose_internal_errors", False
             )
+            settings_obj.parse_description_metadata = form.cleaned_data.get(
+                "parse_description_metadata", False
+            )
             settings_obj.backend_log_file_path = form.cleaned_data[
                 "backend_log_file_path"
             ]
@@ -213,6 +217,7 @@ class SettingsView(
                     "backend_log_file_path",
                     "debug_cache",
                     "expose_internal_errors",
+                    "parse_description_metadata",
                     "ssrf_protection_enabled",
                     "allow_private_ips",
                     "additional_allowed_ip_ranges",

--- a/tests/test_settings_view_encryption.py
+++ b/tests/test_settings_view_encryption.py
@@ -75,6 +75,7 @@ def _fake_settings_obj(encryption_key: str = "") -> SimpleNamespace:
         backend_log_file_path="/var/log/proxbox.log",
         debug_cache=False,
         expose_internal_errors=False,
+        parse_description_metadata=False,
         ssrf_protection_enabled=True,
         allow_private_ips=True,
         additional_allowed_ip_ranges="",

--- a/tests/test_sync_params_flag_flattening.py
+++ b/tests/test_sync_params_flag_flattening.py
@@ -200,3 +200,4 @@ def test_build_base_query_params_includes_other_runtime_settings(sync_stages_mod
     assert base_query["ignore_ipv6_link_local_addresses"] in {"true", "false"}
     assert base_query["fetch_max_concurrency"].isdigit()
     assert base_query["primary_ip_preference"] in {"ipv4", "ipv6"}
+    assert base_query["parse_description_metadata"] in {"true", "false"}


### PR DESCRIPTION
## Summary

Plugin half of [#366](https://github.com/emersonfelipesp/netbox-proxbox/issues/366) — adds the opt-in `parse_description_metadata` toggle on `ProxboxPluginSettings`. When on, the plugin forwards the flag to proxbox-api as a query parameter and the backend extracts a fenced ` ```netbox-metadata ` JSON block from each Proxmox object's description.

Backend half: [`emersonfelipesp/proxbox-api#67`](https://github.com/emersonfelipesp/proxbox-api/pull/67).

## What changes

- `ProxboxPluginSettings.parse_description_metadata` BooleanField (default `False`).
- Migration `0040_pluginsettings_parse_description_metadata` (`SeparateDatabaseAndState` + `ADD COLUMN IF NOT EXISTS`, matches the existing additive-schema pattern).
- `ProxboxPluginSettingsForm` field + `SettingsView` get/post + `update_fields`.
- `_parse_description_metadata_setting()` helper in `sync_params.py`.
- `_build_base_query_params` in `sync_stages.py` forwards the value as `"true"`/`"false"`.
- Settings UI toggle in the "Sync Settings" card.

The 23-entry `OVERWRITE_FIELDS` contract is **unchanged**: this is a sync behavior toggle, not an overwrite flag. The three contract-pinning tests (`test_overwrite_flags_contract.py`, `test_models_overwrites.py`, `test_sync_params_flag_flattening.py`) still pass at `len == 23`.

## Test plan

- [x] `python -m compileall netbox_proxbox tests` — clean
- [x] `ruff check .` — clean
- [x] `pytest tests/` — **504 passed, 2 skipped**
- [ ] Manual smoke: toggle the setting, run a sync, confirm the SSE query string includes `parse_description_metadata=true|false`
- [ ] E2E against the companion proxbox-api PR

## Notes for reviewers

- The new flag is **not** added to `OVERWRITE_FIELDS` / `OVERWRITE_FIELD_GROUPS` / `contracts/overwrite_flags.json`. It is a parallel sync behavior toggle. Per-field overwrite gating for keys the user puts in the JSON block still goes through the existing `overwrite_vm_*` flags on the backend side.
- Migration uses `ADD COLUMN IF NOT EXISTS` so it is safe to re-run against environments that already received the column out-of-band (consistent with `0037_pluginsettings_runtime_tunables.py` and `0039_pluginsettings_overwrite_ip_address_dns_name.py`).