### PR TITLE
feat(#368): mirror duplicate_name_resolved SSE event from proxbox-api

### DIFF
--- a/contracts/proxbox_api_sse_schema.json
+++ b/contracts/proxbox_api_sse_schema.json
@@ -25,7 +25,8 @@
       "phase_summary",
       "error_detail",
       "progress",
-      "bootstrap_done"
+      "bootstrap_done",
+      "duplicate_name_resolved"
     ]
   },
   "payload_fields": {
@@ -78,6 +79,15 @@
       "detail",
       "suggestion",
       "traceback"
+    ],
+    "DuplicateNameResolvedMessage": [
+      "event",
+      "cluster",
+      "original_name",
+      "resolved_name",
+      "vmid",
+      "suffix_index",
+      "operator_renamed"
     ]
   }
 }

--- a/netbox_proxbox/schemas/backend_proxy.py
+++ b/netbox_proxbox/schemas/backend_proxy.py
@@ -29,6 +29,7 @@ class SseEventType(str, Enum):
     PROGRESS = "progress"
     # Bootstrap status frame emitted as the first frame of each sync run
     BOOTSTRAP_DONE = "bootstrap_done"
+    DUPLICATE_NAME_RESOLVED = "duplicate_name_resolved"
 
 
 # ---------------------------------------------------------------------------
@@ -127,6 +128,24 @@ class SseErrorDetailPayload(ProxboxLenientModel):
     detail: str | None = None
     suggestion: str | None = None
     traceback: str | None = None
+
+
+class SseDuplicateNameResolvedPayload(ProxboxLenientModel):
+    """Payload of a ``duplicate_name_resolved`` event.
+
+    Mirrors proxbox_api DuplicateNameResolvedMessage. Emitted once per VM
+    whose name collided with another VM in the same NetBox cluster (suffix
+    applied) or whose NetBox record was manually renamed by an operator
+    (``operator_renamed=True``, no rename performed).
+    """
+
+    event: str = SseEventType.DUPLICATE_NAME_RESOLVED
+    cluster: str = ""
+    original_name: str = ""
+    resolved_name: str = ""
+    vmid: int = 0
+    suffix_index: int = 1
+    operator_renamed: bool = False
 
 
 class FastAPIUrlDict(ProxboxBaseModel):

--- a/tests/test_sse_schema_mirror.py
+++ b/tests/test_sse_schema_mirror.py
@@ -121,6 +121,11 @@ _PAYLOAD_PAIRS = [
         "netbox_proxbox.schemas.backend_proxy",
         "SseErrorDetailPayload",
     ),
+    (
+        "DuplicateNameResolvedMessage",
+        "netbox_proxbox.schemas.backend_proxy",
+        "SseDuplicateNameResolvedPayload",
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Mirrors the proxbox-api half of issue #368 on this side so the SSE schema canary continues to pass once both PRs land.

- `contracts/proxbox_api_sse_schema.json`: adds `duplicate_name_resolved` to `enum_values.StreamMessageType` and the `DuplicateNameResolvedMessage` field list to `payload_fields`.
- `netbox_proxbox/schemas/backend_proxy.py`: adds `SseEventType.DUPLICATE_NAME_RESOLVED` and `SseDuplicateNameResolvedPayload(ProxboxLenientModel)`.
- `tests/test_sse_schema_mirror.py`: adds the new payload pair to `_PAYLOAD_PAIRS`.

Companion PR: emersonfelipesp/proxbox-api#69.

No SSE consumer changes are required — the existing renderers (`sync_stages.py::_run_all_stages_sync.on_frame` and `static/.../job_log_view.js::parseProxboxMessage`) already surface unknown events generically. A typed UI badge can land in a follow-up sub-PR.

## Test plan

- [x] `python3 -m compileall netbox_proxbox tests`
- [x] `ruff check netbox_proxbox/schemas/backend_proxy.py tests/test_sse_schema_mirror.py`
- [x] `pytest tests/test_sse_schema_mirror.py` — 11 passed
- [ ] Manual: confirm `[proxbox-stream] duplicate_name_resolved: ...` lines appear in the proxbox job log once the proxbox-api PR is merged and deployed