### PR TITLE
feat(#365): opt-in, multi-pattern, per-endpoint tenant-name regex

### DIFF
--- a/docs/operations/tenant-mapping.md
+++ b/docs/operations/tenant-mapping.md
@@ -1,0 +1,95 @@
+# Tenant assignment by VM-name regex
+
+Tracking issue: [#365](https://github.com/emersonfelipesp/netbox-proxbox/issues/365).
+
+The plugin can resolve a NetBox `tenancy.Tenant` for newly-synced VMs by
+matching the VM name against a list of operator-defined regex patterns. The
+feature is **disabled by default**; operators opt in globally and may
+override the toggle and/or the rule list on a per-`ProxmoxEndpoint` basis.
+
+## Configuration
+
+Two model fields, present at both scopes:
+
+| Field | Scope | Default | Inherit semantics |
+|---|---|---|---|
+| `enable_tenant_name_regex` | `ProxboxPluginSettings` | `False` | — |
+| `tenant_name_regex_rules` | `ProxboxPluginSettings` | `[]` | — |
+| `enable_tenant_name_regex` | `ProxmoxEndpoint` | `None` (inherit) | `None` → use global; `True`/`False` → override |
+| `tenant_name_regex_rules` | `ProxmoxEndpoint` | `None` (inherit) | `None` → use global; non-null list → **replaces** global list |
+
+Resolution helper: `netbox_proxbox.sync_params.effective_tenant_regex_for_endpoint(endpoint_id)`.
+
+### Rule shape
+
+Each rule is a JSON object with two required keys and one optional key:
+
+```json
+[
+  {"pattern": "^cust-acme-",  "tenant_slug": "acme",  "label": "Acme Corp"},
+  {"pattern": "^cust-bigco-", "tenant_slug": "bigco", "label": "BigCo"},
+  {"pattern": "^infra-",      "tenant_slug": "internal"}
+]
+```
+
+- `pattern` — Python regex compiled at save time. Matched with `re.search`.
+- `tenant_slug` — slug of an existing `tenancy.Tenant`. Verified on save.
+- `label` — optional operator-facing label, not used during resolution.
+
+The list is **ordered**. Resolution is **first-match-wins** — put more
+specific patterns before less specific ones (e.g. `^cust-acme-` before
+`^cust-`).
+
+## Resolution semantics
+
+- The resolver runs **after** the proxbox-api sync writes the VM, in two
+  places: per-VM "Sync Now" (`VirtualMachineSyncNowView.post`) and batch
+  selected sync (`sync_stages._run_batch_selected_sync`). It does not run
+  inside proxbox-api itself — proxbox-api never writes the `tenant` field.
+- The resolver **never overwrites** an existing `vm.tenant` assignment. If
+  an operator has set the tenant manually (or a prior run assigned it), the
+  resolver leaves it alone.
+- If a rule's `tenant_slug` no longer resolves to a NetBox tenant at sync
+  time, the resolver logs a warning via `logging.warning` and **stops**
+  (it does not fall through to the next rule — operator intent was specific).
+- An unmatched VM is a no-op.
+
+## Per-endpoint override examples
+
+| Global enabled? | Global rules | Endpoint `enable` | Endpoint `rules` | Effective behavior |
+|---|---|---|---|---|
+| `False` | any | `None` | `None` | No-op (default) |
+| `True` | `[A]` | `None` | `None` | Uses `[A]` |
+| `True` | `[A]` | `False` | `None` | No-op on this endpoint |
+| `False` | `[]` | `True` | `[B]` | Uses `[B]` on this endpoint only |
+| `True` | `[A]` | `None` | `[B]` | Uses `[B]` (endpoint list **replaces** `[A]`) |
+| `True` | `[A]` | `None` | `[]` | No rules on this endpoint (explicit override) |
+
+## Form validation
+
+Both the global plugin settings form and the per-endpoint settings form
+accept the rule list as JSON entered into a `<textarea>`. Validation runs
+at save time and rejects:
+
+- Uncompilable regex (`re.error`).
+- `tenant_slug` that does not resolve to a `tenancy.Tenant`.
+- Duplicate patterns within the same list.
+- Non-list JSON (e.g. `{}`, scalars).
+
+On the per-endpoint form:
+
+- Empty / whitespace-only input → stored as `None` (inherit global).
+- Literal `[]` → stored as empty list (explicit override: disable all
+  global rules for this endpoint).
+- Any other valid JSON list → validated and stored.
+
+## Operational notes
+
+- Tenant assignment is a single SQL update per matched VM
+  (`vm.save(update_fields=["tenant"])`).
+- proxbox-api requires no changes — the `tenant` field is excluded from
+  `_compute_vm_patchable_fields` on the proxbox-api side and is not present
+  in the VM create body, so the plugin's assignment is stable across
+  subsequent re-syncs.
+- Warnings about missing tenant slugs land in the standard NetBox plugin
+  logger; they do not surface as a dedicated SSE frame.

--- a/netbox_proxbox/forms/proxmox.py
+++ b/netbox_proxbox/forms/proxmox.py
@@ -22,6 +22,7 @@ from django.utils.translation import gettext as _
 from ..constants import OVERWRITE_FIELDS
 from ..models import ProxmoxEndpoint
 from ..choices import ProxmoxModeChoices
+from .settings import _parse_tenant_regex_rules
 
 from .import_utils import validate_endpoint_import_headers
 
@@ -137,6 +138,8 @@ class ProxmoxEndpointSettingsForm(NetBoxModelForm):
             "timeout",
             "max_retries",
             "retry_backoff",
+            "enable_tenant_name_regex",
+            "tenant_name_regex_rules",
             *OVERWRITE_FIELDS,
         )
 
@@ -154,6 +157,40 @@ class ProxmoxEndpointSettingsForm(NetBoxModelForm):
                     "Leave blank to inherit the global Proxbox plugin setting."
                 ),
             )
+        self.fields["enable_tenant_name_regex"] = forms.NullBooleanField(
+            required=False,
+            widget=forms.NullBooleanSelect,
+            label=_("Enable tenant regex (override)"),
+            help_text=_(
+                "Per-endpoint override for the global tenant-regex toggle. "
+                "Leave blank to inherit."
+            ),
+        )
+        # Render the JSON list as a Textarea; empty input => inherit, "[]" => override.
+        import json as _json
+
+        instance = kwargs.get("instance") or getattr(self, "instance", None)
+        existing = (
+            getattr(instance, "tenant_name_regex_rules", None) if instance else None
+        )
+        initial = "" if existing is None else _json.dumps(existing, indent=2)
+        self.fields["tenant_name_regex_rules"] = forms.CharField(
+            required=False,
+            widget=forms.Textarea(attrs={"rows": 6, "cols": 60}),
+            initial=initial,
+            label=_("Tenant regex rules (override, JSON)"),
+            help_text=_(
+                "JSON list. Leave blank to inherit the global list. Use '[]' to "
+                "explicitly disable all global rules for this endpoint."
+            ),
+        )
+
+    def clean_tenant_name_regex_rules(self) -> list[dict] | None:
+        """Empty → None (inherit); '[]' → [] (explicit override)."""
+        return _parse_tenant_regex_rules(
+            self.cleaned_data.get("tenant_name_regex_rules"),
+            allow_none=True,
+        )
 
 
 class ProxmoxEndpointFilterForm(NetBoxModelFilterSetForm):

--- a/netbox_proxbox/forms/settings.py
+++ b/netbox_proxbox/forms/settings.py
@@ -1,11 +1,87 @@
 """Forms for plugin-level ProxBox settings."""
 
+import json
+import re
 from pathlib import PurePosixPath
 
 from django import forms
 
 from netbox_proxbox.constants import OVERWRITE_FIELDS
 from netbox_proxbox.models.plugin_settings import DEFAULT_BACKEND_LOG_FILE_PATH
+
+
+def _parse_tenant_regex_rules(
+    raw: object,
+    *,
+    allow_none: bool,
+) -> list[dict] | None:
+    """Validate and normalize tenant regex rules.
+
+    When ``allow_none`` is True, empty/whitespace input returns ``None``
+    (the per-endpoint "inherit" sentinel). Otherwise empty input returns
+    ``[]`` (the global "no rules configured" state).
+
+    Each rule must be an object with non-empty string ``pattern`` and
+    ``tenant_slug``. ``pattern`` must compile as a regex. ``tenant_slug``
+    must reference an existing ``tenancy.Tenant``. ``label`` is optional.
+    Duplicate patterns are rejected.
+    """
+    if isinstance(raw, list):
+        rules = raw
+    else:
+        text = (raw or "").strip() if isinstance(raw, str) else ""
+        if not text:
+            return None if allow_none else []
+        try:
+            rules = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise forms.ValidationError(f"Invalid JSON: {exc}") from exc
+
+    if not isinstance(rules, list):
+        raise forms.ValidationError("Expected a JSON list of rule objects.")
+    if allow_none and rules == []:
+        # Explicit "override with empty" stays as [], distinct from None.
+        return []
+
+    from tenancy.models import Tenant
+
+    errors: list[str] = []
+    cleaned: list[dict] = []
+    seen: set[str] = set()
+    for i, rule in enumerate(rules, start=1):
+        if not isinstance(rule, dict):
+            errors.append(f"Rule #{i}: must be an object.")
+            continue
+        pattern = rule.get("pattern")
+        slug = rule.get("tenant_slug")
+        if not isinstance(pattern, str) or not pattern:
+            errors.append(f"Rule #{i}: 'pattern' must be a non-empty string.")
+            continue
+        if not isinstance(slug, str) or not slug:
+            errors.append(f"Rule #{i}: 'tenant_slug' must be a non-empty string.")
+            continue
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            errors.append(f"Rule #{i}: invalid regex {pattern!r} — {exc}.")
+            continue
+        rule_ok = True
+        if not Tenant.objects.filter(slug=slug).exists():
+            errors.append(f"Rule #{i}: tenant slug '{slug}' does not exist.")
+            rule_ok = False
+        if pattern in seen:
+            errors.append(f"Rule #{i}: duplicate pattern '{pattern}'.")
+            rule_ok = False
+        seen.add(pattern)
+        if rule_ok:
+            entry: dict = {"pattern": pattern, "tenant_slug": slug}
+            label = rule.get("label")
+            if isinstance(label, str) and label:
+                entry["label"] = label
+            cleaned.append(entry)
+    if errors:
+        raise forms.ValidationError(errors)
+    return cleaned
 
 
 class ProxboxPluginSettingsForm(forms.Form):
@@ -279,6 +355,25 @@ class ProxboxPluginSettingsForm(forms.Form):
         label="Proxmox retry back-off (seconds)",
         help_text="Default exponential back-off base delay in seconds between Proxmox retries. Individual endpoints can override this.",
     )
+    enable_tenant_name_regex = forms.BooleanField(
+        required=False,
+        label="Enable tenant assignment by VM-name regex",
+        help_text=(
+            "When enabled, sync resolves a NetBox Tenant for VMs by matching the VM "
+            "name against the rules below. Disabled by default. Existing tenant "
+            "assignments are never overwritten."
+        ),
+    )
+    tenant_name_regex_rules = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 6, "cols": 60}),
+        label="Tenant name regex rules (JSON)",
+        help_text=(
+            "JSON list of {pattern, tenant_slug, [label]} objects. First match wins; "
+            "order more specific patterns first. Patterns are compiled and tenant "
+            "slugs are verified on save."
+        ),
+    )
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)
@@ -295,6 +390,16 @@ class ProxboxPluginSettingsForm(forms.Form):
                     "It is still set when the object is first created."
                 ),
             )
+
+    def clean_tenant_name_regex_rules(self) -> list[dict]:
+        """Normalize tenant regex rules JSON; empty input means no rules."""
+        return (
+            _parse_tenant_regex_rules(
+                self.cleaned_data.get("tenant_name_regex_rules"),
+                allow_none=False,
+            )
+            or []
+        )
 
     def clean_backend_log_file_path(self) -> str:
         """Require an absolute log file path including a filename."""

--- a/netbox_proxbox/migrations/0042_tenant_name_regex.py
+++ b/netbox_proxbox/migrations/0042_tenant_name_regex.py
@@ -1,0 +1,118 @@
+from django.db import migrations, models
+
+
+SETTINGS_TABLE = "netbox_proxbox_proxboxpluginsettings"
+ENDPOINT_TABLE = "netbox_proxbox_proxmoxendpoint"
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_proxbox", "0041_run_proxmox_action_permission"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        f'ALTER TABLE "{SETTINGS_TABLE}" '
+                        f'ADD COLUMN IF NOT EXISTS "enable_tenant_name_regex" '
+                        f'boolean NOT NULL DEFAULT FALSE;'
+                    ),
+                    reverse_sql=(
+                        f'ALTER TABLE "{SETTINGS_TABLE}" '
+                        f'DROP COLUMN IF EXISTS "enable_tenant_name_regex";'
+                    ),
+                ),
+                migrations.RunSQL(
+                    sql=(
+                        f'ALTER TABLE "{SETTINGS_TABLE}" '
+                        f'ADD COLUMN IF NOT EXISTS "tenant_name_regex_rules" '
+                        f"jsonb NOT NULL DEFAULT '[]'::jsonb;"
+                    ),
+                    reverse_sql=(
+                        f'ALTER TABLE "{SETTINGS_TABLE}" '
+                        f'DROP COLUMN IF EXISTS "tenant_name_regex_rules";'
+                    ),
+                ),
+                migrations.RunSQL(
+                    sql=(
+                        f'ALTER TABLE "{ENDPOINT_TABLE}" '
+                        f'ADD COLUMN IF NOT EXISTS "enable_tenant_name_regex" boolean NULL;'
+                    ),
+                    reverse_sql=(
+                        f'ALTER TABLE "{ENDPOINT_TABLE}" '
+                        f'DROP COLUMN IF EXISTS "enable_tenant_name_regex";'
+                    ),
+                ),
+                migrations.RunSQL(
+                    sql=(
+                        f'ALTER TABLE "{ENDPOINT_TABLE}" '
+                        f'ADD COLUMN IF NOT EXISTS "tenant_name_regex_rules" jsonb NULL;'
+                    ),
+                    reverse_sql=(
+                        f'ALTER TABLE "{ENDPOINT_TABLE}" '
+                        f'DROP COLUMN IF EXISTS "tenant_name_regex_rules";'
+                    ),
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="enable_tenant_name_regex",
+                    field=models.BooleanField(
+                        default=False,
+                        verbose_name="Enable tenant assignment by VM-name regex",
+                        help_text=(
+                            "When enabled, sync resolves a NetBox Tenant for VMs by matching the "
+                            "VM name against the rules below. Disabled by default. Existing "
+                            "tenant assignments are never overwritten."
+                        ),
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="tenant_name_regex_rules",
+                    field=models.JSONField(
+                        blank=True,
+                        default=list,
+                        verbose_name="Tenant name regex rules",
+                        help_text=(
+                            "Ordered list of {pattern, tenant_slug, [label]} dicts. First match "
+                            "wins; specificity-first ordering is recommended (e.g. '^cust-acme-' "
+                            "before '^cust-'). Patterns are compiled and tenant slugs are verified "
+                            "at save time."
+                        ),
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="proxmoxendpoint",
+                    name="enable_tenant_name_regex",
+                    field=models.BooleanField(
+                        blank=True,
+                        null=True,
+                        verbose_name="Enable tenant regex (override)",
+                        help_text=(
+                            "Per-endpoint override for the global tenant-regex toggle. "
+                            "Leave blank to inherit."
+                        ),
+                    ),
+                ),
+                migrations.AddField(
+                    model_name="proxmoxendpoint",
+                    name="tenant_name_regex_rules",
+                    field=models.JSONField(
+                        blank=True,
+                        null=True,
+                        default=None,
+                        verbose_name="Tenant regex rules (override)",
+                        help_text=(
+                            "Per-endpoint override for the global rule list. Leave null to "
+                            "inherit. When set (even to an empty list), replaces the global "
+                            "list for this endpoint."
+                        ),
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/netbox_proxbox/models/plugin_settings.py
+++ b/netbox_proxbox/models/plugin_settings.py
@@ -453,6 +453,26 @@ class ProxboxPluginSettings(NetBoxModel):
             "When disabled, sync never changes the dns_name field on existing IP addresses; dns_name is still populated when an IP is created."
         ),
     )
+    enable_tenant_name_regex = models.BooleanField(
+        default=False,
+        verbose_name=_("Enable tenant assignment by VM-name regex"),
+        help_text=_(
+            "When enabled, sync resolves a NetBox Tenant for VMs by matching the "
+            "VM name against the rules below. Disabled by default. Existing "
+            "tenant assignments are never overwritten."
+        ),
+    )
+    tenant_name_regex_rules = models.JSONField(
+        default=list,
+        blank=True,
+        verbose_name=_("Tenant name regex rules"),
+        help_text=_(
+            "Ordered list of {pattern, tenant_slug, [label]} dicts. First match "
+            "wins; specificity-first ordering is recommended (e.g. '^cust-acme-' "
+            "before '^cust-'). Patterns are compiled and tenant slugs are verified "
+            "at save time."
+        ),
+    )
 
     class Meta:
         verbose_name = _("Proxbox plugin settings")

--- a/netbox_proxbox/models/proxmox_endpoint.py
+++ b/netbox_proxbox/models/proxmox_endpoint.py
@@ -298,6 +298,24 @@ class ProxmoxEndpoint(EndpointBase):
             "Per-endpoint override for the global Proxbox setting. Leave blank to inherit."
         ),
     )
+    enable_tenant_name_regex = models.BooleanField(
+        null=True,
+        blank=True,
+        verbose_name=_("Enable tenant regex (override)"),
+        help_text=_(
+            "Per-endpoint override for the global tenant-regex toggle. Leave blank to inherit."
+        ),
+    )
+    tenant_name_regex_rules = models.JSONField(
+        null=True,
+        blank=True,
+        default=None,
+        verbose_name=_("Tenant regex rules (override)"),
+        help_text=_(
+            "Per-endpoint override for the global rule list. Leave null to inherit. "
+            "When set (even to an empty list), replaces the global list for this endpoint."
+        ),
+    )
     site = models.ForeignKey(
         to="dcim.Site",
         on_delete=models.SET_NULL,

--- a/netbox_proxbox/services/tenant_assignment.py
+++ b/netbox_proxbox/services/tenant_assignment.py
@@ -1,0 +1,100 @@
+"""Post-sync VM tenant assignment driven by operator-defined regex rules.
+
+The feature is disabled by default. Operators opt in globally via
+``ProxboxPluginSettings.enable_tenant_name_regex`` and may override the toggle
+and the rule list per ``ProxmoxEndpoint``. Existing tenant assignments are
+never overwritten — the resolver only fills the field when it is currently
+empty.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from netbox_proxbox.sync_params import effective_tenant_regex_for_endpoint
+
+
+def _endpoint_id_for_vm(vm: object) -> int | None:
+    """Resolve the ProxmoxEndpoint pk for a given VirtualMachine.
+
+    Chain: vm.cluster → ProxmoxCluster(netbox_cluster=vm.cluster).endpoint_id.
+    Returns ``None`` if the VM is not tied to a known Proxmox cluster.
+    """
+    cluster = getattr(vm, "cluster", None)
+    if cluster is None:
+        return None
+    try:
+        from netbox_proxbox.models import ProxmoxCluster
+    except (ImportError, RuntimeError):
+        return None
+    proxmox_cluster = ProxmoxCluster.objects.filter(netbox_cluster=cluster).first()
+    if proxmox_cluster is None:
+        return None
+    return getattr(proxmox_cluster, "endpoint_id", None)
+
+
+def maybe_assign_tenant_from_regex(
+    vm: object,
+    *,
+    endpoint_id: int | None = None,
+    logger: logging.Logger | None = None,
+) -> bool:
+    """Apply first-match-wins tenant regex resolution to ``vm``.
+
+    Returns ``True`` when a tenant was assigned, ``False`` otherwise.
+
+    Semantics:
+    - Resolver is a no-op when disabled at the effective scope.
+    - Resolver never overwrites an existing ``vm.tenant`` assignment.
+    - If a rule matches but the tenant slug is no longer present in NetBox,
+      a warning is logged and resolution stops (operator intent was specific).
+    """
+    log = logger or logging.getLogger(__name__)
+    if endpoint_id is None:
+        endpoint_id = _endpoint_id_for_vm(vm)
+    enabled, rules = effective_tenant_regex_for_endpoint(endpoint_id)
+    if not enabled or not rules:
+        return False
+    if getattr(vm, "tenant_id", None) is not None:
+        return False
+    name = getattr(vm, "name", "") or ""
+    try:
+        from tenancy.models import Tenant
+    except (ImportError, RuntimeError):
+        return False
+    for rule in rules:
+        pattern = rule.get("pattern") if isinstance(rule, dict) else None
+        slug = rule.get("tenant_slug") if isinstance(rule, dict) else None
+        if not isinstance(pattern, str) or not isinstance(slug, str):
+            continue
+        try:
+            if not re.search(pattern, name):
+                continue
+        except re.error:
+            log.warning(
+                "[tenant-regex] vm=%s rule pattern=%r is not a valid regex; skipping.",
+                name,
+                pattern,
+            )
+            continue
+        tenant = Tenant.objects.filter(slug=slug).first()
+        if tenant is None:
+            log.warning(
+                "[tenant-regex] vm=%s matched pattern=%r but tenant_slug=%r "
+                "no longer exists; skipping.",
+                name,
+                pattern,
+                slug,
+            )
+            return False
+        vm.tenant = tenant
+        vm.save(update_fields=["tenant"])
+        log.info(
+            "[tenant-regex] vm=%s → tenant=%s (pattern=%r)",
+            name,
+            tenant.slug,
+            pattern,
+        )
+        return True
+    return False

--- a/netbox_proxbox/sync_params.py
+++ b/netbox_proxbox/sync_params.py
@@ -155,6 +155,47 @@ def effective_overwrites_for_endpoint(
     }
 
 
+def effective_tenant_regex_for_endpoint(
+    proxmox_endpoint_id: int | str | None,
+) -> tuple[bool, list[dict]]:
+    """Resolve (enabled, rules) for tenant-regex assignment on a given endpoint.
+
+    The endpoint can override both the toggle and the rule list. When an
+    endpoint's rule list is non-null it **replaces** the global list. Any
+    failure to load returns the global values, mirroring
+    ``effective_overwrites_for_endpoint``.
+    """
+    try:
+        from netbox_proxbox.models import ProxboxPluginSettings
+    except (ImportError, RuntimeError):
+        return False, []
+    try:
+        settings_obj = ProxboxPluginSettings.get_solo()
+    except Exception:
+        return False, []
+    enabled = bool(getattr(settings_obj, "enable_tenant_name_regex", False))
+    rules_value = getattr(settings_obj, "tenant_name_regex_rules", None) or []
+    rules: list[dict] = list(rules_value) if isinstance(rules_value, list) else []
+
+    if proxmox_endpoint_id in (None, "", 0, "0"):
+        return enabled, rules
+    try:
+        from netbox_proxbox.models import ProxmoxEndpoint
+
+        endpoint = ProxmoxEndpoint.objects.filter(pk=int(proxmox_endpoint_id)).first()
+    except (ImportError, RuntimeError, ValueError, TypeError):
+        return enabled, rules
+    if endpoint is None:
+        return enabled, rules
+    ep_enabled = getattr(endpoint, "enable_tenant_name_regex", None)
+    if ep_enabled is not None:
+        enabled = bool(ep_enabled)
+    ep_rules = getattr(endpoint, "tenant_name_regex_rules", None)
+    if ep_rules is not None:
+        rules = list(ep_rules) if isinstance(ep_rules, list) else []
+    return enabled, rules
+
+
 def _serialize_sync_params(
     *,
     sync_types: list[str],

--- a/netbox_proxbox/sync_stages.py
+++ b/netbox_proxbox/sync_stages.py
@@ -131,6 +131,18 @@ async def _run_batch_selected_sync(
                 return sync_individual_with_dependencies(path, query_params)
 
             response, status, dependencies = await asyncio.to_thread(_call_sync)
+
+            if batch_object_type == "virtual-machine" and 200 <= int(status) < 300:
+                from netbox_proxbox.services.tenant_assignment import (
+                    maybe_assign_tenant_from_regex,
+                )
+
+                def _post_sync_assign() -> None:
+                    obj.refresh_from_db()
+                    maybe_assign_tenant_from_regex(obj)
+
+                await asyncio.to_thread(_post_sync_assign)
+
             return {
                 "batch_object_type": batch_object_type,
                 "object_id": str(object_id),

--- a/netbox_proxbox/views/settings.py
+++ b/netbox_proxbox/views/settings.py
@@ -1,5 +1,7 @@
 """Plugin settings page for feature toggles."""
 
+import json
+
 from django.contrib import messages
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
@@ -65,6 +67,11 @@ class SettingsView(
             "proxmox_timeout": settings_obj.proxmox_timeout,
             "proxmox_max_retries": settings_obj.proxmox_max_retries,
             "proxmox_retry_backoff": settings_obj.proxmox_retry_backoff,
+            "enable_tenant_name_regex": settings_obj.enable_tenant_name_regex,
+            "tenant_name_regex_rules": json.dumps(
+                settings_obj.tenant_name_regex_rules or [],
+                indent=2,
+            ),
         }
         for name in OVERWRITE_FIELDS:
             initial[name] = getattr(settings_obj, name)
@@ -182,6 +189,12 @@ class SettingsView(
             settings_obj.proxmox_retry_backoff = form.cleaned_data[
                 "proxmox_retry_backoff"
             ]
+            settings_obj.enable_tenant_name_regex = form.cleaned_data.get(
+                "enable_tenant_name_regex", False
+            )
+            settings_obj.tenant_name_regex_rules = form.cleaned_data.get(
+                "tenant_name_regex_rules", []
+            )
             for _overwrite_field in OVERWRITE_FIELDS:
                 setattr(
                     settings_obj,
@@ -229,6 +242,8 @@ class SettingsView(
                     "proxmox_timeout",
                     "proxmox_max_retries",
                     "proxmox_retry_backoff",
+                    "enable_tenant_name_regex",
+                    "tenant_name_regex_rules",
                     *OVERWRITE_FIELDS,
                 ]
             )

--- a/netbox_proxbox/views/sync_now/vm.py
+++ b/netbox_proxbox/views/sync_now/vm.py
@@ -16,6 +16,7 @@ from virtualization.models import VirtualMachine
 from netbox_proxbox.models import ProxmoxCluster
 from netbox_proxbox.utils import resolve_vm_type
 from netbox_proxbox.services.individual_sync import sync_individual_with_dependencies
+from netbox_proxbox.services.tenant_assignment import maybe_assign_tenant_from_regex
 from netbox_proxbox.views.proxbox_access import permission_enqueue_proxbox_sync
 from netbox_proxbox.views.sync_now import _handle_sync_response
 
@@ -81,6 +82,11 @@ class VirtualMachineSyncNowView(
                 "vmid": vmid,
             },
         )
+
+        if 200 <= status < 300:
+            vm.refresh_from_db()
+            endpoint_id = proxmox_cluster.endpoint_id if proxmox_cluster else None
+            maybe_assign_tenant_from_regex(vm, endpoint_id=endpoint_id)
 
         return _handle_sync_response(
             request,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -601,6 +601,7 @@ def load_plugin_module(
         DEVICES = "devices"
         NETWORK_INTERFACES = "network-interfaces"
         IP_ADDRESSES = "ip-addresses"
+        VM_INTERFACES = "vm-interfaces"
         ALL = "all"
 
     nbp_choices.SyncTypeChoices = _SyncTypeChoices

--- a/tests/test_settings_view_encryption.py
+++ b/tests/test_settings_view_encryption.py
@@ -108,6 +108,8 @@ def _fake_settings_obj(encryption_key: str = "") -> SimpleNamespace:
         overwrite_ip_tags=True,
         overwrite_ip_custom_fields=True,
         overwrite_ip_address_dns_name=True,
+        enable_tenant_name_regex=False,
+        tenant_name_regex_rules=[],
         save=_save,
         _saved=saved,
     )

--- a/tests/test_tenant_name_regex.py
+++ b/tests/test_tenant_name_regex.py
@@ -1,0 +1,509 @@
+"""Tests for the optional, multi-pattern, per-endpoint tenant regex resolver.
+
+The feature is disabled by default. These tests pin:
+
+- The global/endpoint inherit-vs-override semantics for both the toggle and
+  the rule list (the endpoint list **replaces** the global list when set).
+- The first-match-wins rule with operator-set tenant assignments never
+  overwritten.
+- The form-level JSON validator: bad regex, missing slug, duplicate pattern,
+  non-list JSON.
+
+Tests use isolated module stubs (no live NetBox/Django imports) — same shape
+as ``test_models_overwrites.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# sync_params.effective_tenant_regex_for_endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sync_params_module(monkeypatch):
+    """Load sync_params.py with stubbed model + dependency imports."""
+    state: dict[str, object] = {
+        "global_enabled": False,
+        "global_rules": [],
+        "endpoints_by_pk": {},
+    }
+
+    class _ProxboxPluginSettings:
+        @classmethod
+        def get_solo(cls):
+            return SimpleNamespace(
+                enable_tenant_name_regex=state["global_enabled"],
+                tenant_name_regex_rules=state["global_rules"],
+            )
+
+    class _Manager:
+        def filter(self, **kwargs):
+            self._pk = kwargs.get("pk")
+            return self
+
+        def first(self):
+            return state["endpoints_by_pk"].get(self._pk)
+
+    class _ProxmoxEndpoint:
+        objects = _Manager()
+
+    pkg = types.ModuleType("netbox_proxbox")
+    pkg.__path__ = [str(REPO_ROOT / "netbox_proxbox")]
+    monkeypatch.setitem(sys.modules, "netbox_proxbox", pkg)
+
+    constants_mod = types.ModuleType("netbox_proxbox.constants")
+    constants_mod.OVERWRITE_FIELDS = ()
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.constants", constants_mod)
+
+    choices_mod = types.ModuleType("netbox_proxbox.choices")
+    choices_mod.SyncTypeChoices = SimpleNamespace(
+        ALL="all", VIRTUAL_MACHINES="virtual-machines"
+    )
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.choices", choices_mod)
+
+    sync_types_mod = types.ModuleType("netbox_proxbox.sync_types")
+    import re
+
+    sync_types_mod._TARGETED_VM_JOB_NAME_RE = re.compile(r"^Sync VM (\d+)")
+    sync_types_mod._TARGETED_VM_SYNC_TYPES = ("virtual-machines",)
+    sync_types_mod.normalize_sync_types = lambda x: list(x or [])
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.sync_types", sync_types_mod)
+
+    models_mod = types.ModuleType("netbox_proxbox.models")
+    models_mod.ProxboxPluginSettings = _ProxboxPluginSettings
+    models_mod.ProxmoxEndpoint = _ProxmoxEndpoint
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.models", models_mod)
+
+    sys.modules.pop("netbox_proxbox.sync_params", None)
+    path = REPO_ROOT / "netbox_proxbox" / "sync_params.py"
+    spec = importlib.util.spec_from_file_location("netbox_proxbox.sync_params", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["netbox_proxbox.sync_params"] = module
+    spec.loader.exec_module(module)
+    module._stubs = state  # type: ignore[attr-defined]
+    return module
+
+
+def _endpoint(*, enable=None, rules=None):
+    return SimpleNamespace(
+        enable_tenant_name_regex=enable,
+        tenant_name_regex_rules=rules,
+    )
+
+
+def test_disabled_by_default(sync_params_module):
+    enabled, rules = sync_params_module.effective_tenant_regex_for_endpoint(None)
+    assert enabled is False
+    assert rules == []
+
+
+def test_global_enabled_endpoint_inherits(sync_params_module):
+    sync_params_module._stubs["global_enabled"] = True
+    sync_params_module._stubs["global_rules"] = [
+        {"pattern": "^acme-", "tenant_slug": "acme"}
+    ]
+    sync_params_module._stubs["endpoints_by_pk"] = {3: _endpoint()}
+
+    enabled, rules = sync_params_module.effective_tenant_regex_for_endpoint(3)
+
+    assert enabled is True
+    assert rules == [{"pattern": "^acme-", "tenant_slug": "acme"}]
+
+
+def test_endpoint_disable_overrides_global_enable(sync_params_module):
+    sync_params_module._stubs["global_enabled"] = True
+    sync_params_module._stubs["global_rules"] = [{"pattern": "^x-", "tenant_slug": "x"}]
+    sync_params_module._stubs["endpoints_by_pk"] = {3: _endpoint(enable=False)}
+
+    enabled, rules = sync_params_module.effective_tenant_regex_for_endpoint(3)
+
+    assert enabled is False
+    # rules list is still inherited but the toggle is what gates resolution.
+    assert rules == [{"pattern": "^x-", "tenant_slug": "x"}]
+
+
+def test_endpoint_rules_replace_global_list(sync_params_module):
+    sync_params_module._stubs["global_enabled"] = True
+    sync_params_module._stubs["global_rules"] = [
+        {"pattern": "^global-", "tenant_slug": "global-tenant"},
+    ]
+    sync_params_module._stubs["endpoints_by_pk"] = {
+        9: _endpoint(rules=[{"pattern": "^ep-", "tenant_slug": "ep-tenant"}])
+    }
+
+    enabled, rules = sync_params_module.effective_tenant_regex_for_endpoint(9)
+
+    assert enabled is True
+    assert rules == [{"pattern": "^ep-", "tenant_slug": "ep-tenant"}]
+
+
+def test_endpoint_empty_list_explicitly_replaces(sync_params_module):
+    sync_params_module._stubs["global_enabled"] = True
+    sync_params_module._stubs["global_rules"] = [
+        {"pattern": "^global-", "tenant_slug": "global-tenant"},
+    ]
+    sync_params_module._stubs["endpoints_by_pk"] = {9: _endpoint(rules=[])}
+
+    enabled, rules = sync_params_module.effective_tenant_regex_for_endpoint(9)
+
+    assert enabled is True
+    assert rules == []
+
+
+def test_endpoint_missing_returns_global(sync_params_module):
+    sync_params_module._stubs["global_enabled"] = True
+    sync_params_module._stubs["global_rules"] = [{"pattern": "^g-", "tenant_slug": "g"}]
+    sync_params_module._stubs["endpoints_by_pk"] = {}
+
+    enabled, rules = sync_params_module.effective_tenant_regex_for_endpoint(42)
+
+    assert enabled is True
+    assert rules == [{"pattern": "^g-", "tenant_slug": "g"}]
+
+
+# ---------------------------------------------------------------------------
+# services.tenant_assignment.maybe_assign_tenant_from_regex
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tenant_assignment_module(monkeypatch, sync_params_module):
+    """Load tenant_assignment.py with a stubbed tenancy.Tenant model."""
+    tenants: dict[str, object] = {}
+
+    class _Tenant:
+        def __init__(self, slug):
+            self.slug = slug
+            self.pk = id(self)
+
+    class _TenantManager:
+        @staticmethod
+        def filter(**kwargs):
+            slug = kwargs.get("slug")
+            return SimpleNamespace(
+                first=lambda: tenants.get(slug),
+                exists=lambda: slug in tenants,
+            )
+
+    tenancy_models = types.ModuleType("tenancy.models")
+    tenancy_models.Tenant = SimpleNamespace(objects=_TenantManager)
+    tenancy_pkg = types.ModuleType("tenancy")
+    tenancy_pkg.models = tenancy_models
+    monkeypatch.setitem(sys.modules, "tenancy", tenancy_pkg)
+    monkeypatch.setitem(sys.modules, "tenancy.models", tenancy_models)
+
+    # Provide ProxmoxCluster used by _endpoint_id_for_vm.
+    models_mod = sys.modules["netbox_proxbox.models"]
+
+    class _ClusterManager:
+        @staticmethod
+        def filter(**kwargs):
+            return SimpleNamespace(first=lambda: None)
+
+    models_mod.ProxmoxCluster = SimpleNamespace(objects=_ClusterManager)
+
+    sys.modules.pop("netbox_proxbox.services", None)
+    sys.modules.pop("netbox_proxbox.services.tenant_assignment", None)
+    services_pkg = types.ModuleType("netbox_proxbox.services")
+    services_pkg.__path__ = [str(REPO_ROOT / "netbox_proxbox" / "services")]
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.services", services_pkg)
+
+    path = REPO_ROOT / "netbox_proxbox" / "services" / "tenant_assignment.py"
+    spec = importlib.util.spec_from_file_location(
+        "netbox_proxbox.services.tenant_assignment", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["netbox_proxbox.services.tenant_assignment"] = module
+    spec.loader.exec_module(module)
+    module._tenants = tenants  # type: ignore[attr-defined]
+    return module
+
+
+class _FakeVM:
+    def __init__(self, name, tenant_id=None):
+        self.name = name
+        self.tenant = None
+        self.tenant_id = tenant_id
+        self.saved_with: list[list[str]] = []
+
+    def save(self, update_fields=None):
+        self.saved_with.append(list(update_fields or []))
+
+
+def test_assign_no_op_when_disabled(tenant_assignment_module, sync_params_module):
+    sync_params_module._stubs["global_enabled"] = False
+    sync_params_module._stubs["global_rules"] = [
+        {"pattern": "^cust-acme-", "tenant_slug": "acme"}
+    ]
+    tenant_assignment_module._tenants["acme"] = object()
+    vm = _FakeVM("cust-acme-001")
+
+    assigned = tenant_assignment_module.maybe_assign_tenant_from_regex(
+        vm, endpoint_id=None
+    )
+
+    assert assigned is False
+    assert vm.tenant is None
+    assert vm.saved_with == []
+
+
+def test_first_match_wins(tenant_assignment_module, sync_params_module):
+    sync_params_module._stubs["global_enabled"] = True
+    sync_params_module._stubs["global_rules"] = [
+        {"pattern": "^cust-acme-", "tenant_slug": "acme"},
+        {"pattern": "^cust-", "tenant_slug": "generic"},
+    ]
+    acme = SimpleNamespace(slug="acme", pk=1)
+    generic = SimpleNamespace(slug="generic", pk=2)
+    tenant_assignment_module._tenants["acme"] = acme
+    tenant_assignment_module._tenants["generic"] = generic
+
+    vm = _FakeVM("cust-acme-prod-01")
+    assigned = tenant_assignment_module.maybe_assign_tenant_from_regex(
+        vm, endpoint_id=None
+    )
+
+    assert assigned is True
+    assert vm.tenant is acme
+    assert vm.saved_with == [["tenant"]]
+
+
+def test_operator_set_tenant_preserved(tenant_assignment_module, sync_params_module):
+    sync_params_module._stubs["global_enabled"] = True
+    sync_params_module._stubs["global_rules"] = [
+        {"pattern": "^cust-", "tenant_slug": "generic"}
+    ]
+    tenant_assignment_module._tenants["generic"] = SimpleNamespace(slug="generic")
+
+    vm = _FakeVM("cust-bigco-001", tenant_id=99)
+    assigned = tenant_assignment_module.maybe_assign_tenant_from_regex(
+        vm, endpoint_id=None
+    )
+
+    assert assigned is False
+    assert vm.tenant is None
+    assert vm.saved_with == []
+
+
+def test_unknown_slug_logs_and_stops(
+    tenant_assignment_module, sync_params_module, caplog
+):
+    sync_params_module._stubs["global_enabled"] = True
+    sync_params_module._stubs["global_rules"] = [
+        {"pattern": "^cust-acme-", "tenant_slug": "acme"},
+        {"pattern": "^cust-", "tenant_slug": "generic"},
+    ]
+    # acme tenant is missing entirely; generic is present.
+    tenant_assignment_module._tenants["generic"] = SimpleNamespace(slug="generic")
+
+    vm = _FakeVM("cust-acme-prod-01")
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        assigned = tenant_assignment_module.maybe_assign_tenant_from_regex(
+            vm, endpoint_id=None
+        )
+
+    assert assigned is False
+    assert vm.tenant is None
+    assert vm.saved_with == []
+    assert any("acme" in rec.getMessage() for rec in caplog.records)
+
+
+def test_no_match_leaves_vm_alone(tenant_assignment_module, sync_params_module):
+    sync_params_module._stubs["global_enabled"] = True
+    sync_params_module._stubs["global_rules"] = [
+        {"pattern": "^cust-acme-", "tenant_slug": "acme"}
+    ]
+    tenant_assignment_module._tenants["acme"] = SimpleNamespace(slug="acme")
+
+    vm = _FakeVM("infra-monitoring-01")
+    assigned = tenant_assignment_module.maybe_assign_tenant_from_regex(
+        vm, endpoint_id=None
+    )
+
+    assert assigned is False
+    assert vm.tenant is None
+
+
+# ---------------------------------------------------------------------------
+# forms.settings._parse_tenant_regex_rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def parser_module(monkeypatch):
+    """Load just the parser helper from forms/settings.py.
+
+    The full forms module pulls in Django; we extract and exec only the
+    helper function with stubbed ``tenancy.models.Tenant`` and ``django.forms``.
+    """
+    tenants: set[str] = set()
+
+    class _TenantManager:
+        @staticmethod
+        def filter(slug):
+            return SimpleNamespace(exists=lambda: slug in tenants)
+
+    # The helper imports tenancy.Tenant lazily inside the function, so we set
+    # it on a module-level Tenant attribute access; mimic Django manager API.
+    class _Tenant:
+        class objects:
+            @staticmethod
+            def filter(slug):
+                return SimpleNamespace(exists=lambda: slug in tenants)
+
+    tenancy_models = types.ModuleType("tenancy.models")
+    tenancy_models.Tenant = _Tenant
+    tenancy_pkg = types.ModuleType("tenancy")
+    tenancy_pkg.models = tenancy_models
+    monkeypatch.setitem(sys.modules, "tenancy", tenancy_pkg)
+    monkeypatch.setitem(sys.modules, "tenancy.models", tenancy_models)
+
+    # Stub django.forms.ValidationError minimally.
+    django_pkg = types.ModuleType("django")
+    forms_mod = types.ModuleType("django.forms")
+
+    class _ValidationError(Exception):
+        def __init__(self, messages):
+            self.messages = messages if isinstance(messages, list) else [messages]
+            super().__init__(messages)
+
+    forms_mod.ValidationError = _ValidationError
+
+    class _Textarea:
+        def __init__(self, *a, **kw):
+            pass
+
+    forms_mod.Textarea = _Textarea
+
+    class _Field:
+        def __init__(self, *a, **kw):
+            pass
+
+    forms_mod.CharField = _Field
+    forms_mod.BooleanField = _Field
+    forms_mod.IntegerField = _Field
+    forms_mod.DecimalField = _Field
+    forms_mod.ChoiceField = _Field
+    forms_mod.PasswordInput = _Field
+    forms_mod.NullBooleanField = _Field
+    forms_mod.NullBooleanSelect = _Field
+
+    class _Form:
+        pass
+
+    forms_mod.Form = _Form
+    django_pkg.forms = forms_mod
+    monkeypatch.setitem(sys.modules, "django", django_pkg)
+    monkeypatch.setitem(sys.modules, "django.forms", forms_mod)
+
+    # Stub the relative imports that forms/settings.py performs.
+    constants_mod = types.ModuleType("netbox_proxbox.constants")
+    constants_mod.OVERWRITE_FIELDS = ()
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.constants", constants_mod)
+
+    plugin_settings_mod = types.ModuleType("netbox_proxbox.models.plugin_settings")
+    plugin_settings_mod.DEFAULT_BACKEND_LOG_FILE_PATH = "/var/log/proxbox.log"
+    monkeypatch.setitem(
+        sys.modules,
+        "netbox_proxbox.models.plugin_settings",
+        plugin_settings_mod,
+    )
+
+    pkg = types.ModuleType("netbox_proxbox")
+    pkg.__path__ = [str(REPO_ROOT / "netbox_proxbox")]
+    monkeypatch.setitem(sys.modules, "netbox_proxbox", pkg)
+    models_pkg = types.ModuleType("netbox_proxbox.models")
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.models", models_pkg)
+    forms_pkg = types.ModuleType("netbox_proxbox.forms")
+    forms_pkg.__path__ = [str(REPO_ROOT / "netbox_proxbox" / "forms")]
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.forms", forms_pkg)
+
+    sys.modules.pop("netbox_proxbox.forms.settings", None)
+    path = REPO_ROOT / "netbox_proxbox" / "forms" / "settings.py"
+    spec = importlib.util.spec_from_file_location("netbox_proxbox.forms.settings", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["netbox_proxbox.forms.settings"] = module
+    spec.loader.exec_module(module)
+    module._tenants = tenants  # type: ignore[attr-defined]
+    module._ValidationError = _ValidationError  # type: ignore[attr-defined]
+    return module
+
+
+def test_parser_empty_string_allow_none_returns_none(parser_module):
+    result = parser_module._parse_tenant_regex_rules("", allow_none=True)
+    assert result is None
+
+
+def test_parser_empty_string_disallow_none_returns_empty(parser_module):
+    result = parser_module._parse_tenant_regex_rules("", allow_none=False)
+    assert result == []
+
+
+def test_parser_explicit_empty_list_with_allow_none_returns_empty(parser_module):
+    result = parser_module._parse_tenant_regex_rules("[]", allow_none=True)
+    assert result == []
+
+
+def test_parser_invalid_json(parser_module):
+    with pytest.raises(parser_module._ValidationError):
+        parser_module._parse_tenant_regex_rules("not json", allow_none=False)
+
+
+def test_parser_non_list_json(parser_module):
+    with pytest.raises(parser_module._ValidationError):
+        parser_module._parse_tenant_regex_rules("{}", allow_none=False)
+
+
+def test_parser_bad_regex(parser_module):
+    parser_module._tenants.add("acme")
+    with pytest.raises(parser_module._ValidationError) as excinfo:
+        parser_module._parse_tenant_regex_rules(
+            '[{"pattern": "(", "tenant_slug": "acme"}]', allow_none=False
+        )
+    assert any("invalid regex" in m for m in excinfo.value.messages)
+
+
+def test_parser_missing_tenant(parser_module):
+    with pytest.raises(parser_module._ValidationError) as excinfo:
+        parser_module._parse_tenant_regex_rules(
+            '[{"pattern": "^x-", "tenant_slug": "ghost"}]', allow_none=False
+        )
+    assert any("ghost" in m for m in excinfo.value.messages)
+
+
+def test_parser_duplicate_pattern(parser_module):
+    parser_module._tenants.add("acme")
+    parser_module._tenants.add("bigco")
+    with pytest.raises(parser_module._ValidationError) as excinfo:
+        parser_module._parse_tenant_regex_rules(
+            '[{"pattern": "^x-", "tenant_slug": "acme"},'
+            ' {"pattern": "^x-", "tenant_slug": "bigco"}]',
+            allow_none=False,
+        )
+    assert any("duplicate" in m for m in excinfo.value.messages)
+
+
+def test_parser_happy_path_with_label(parser_module):
+    parser_module._tenants.add("acme")
+    result = parser_module._parse_tenant_regex_rules(
+        '[{"pattern": "^acme-", "tenant_slug": "acme", "label": "Acme"}]',
+        allow_none=False,
+    )
+    assert result == [{"pattern": "^acme-", "tenant_slug": "acme", "label": "Acme"}]


### PR DESCRIPTION
## Summary

Implements [emersonfelipesp/netbox-proxbox#365](https://github.com/emersonfelipesp/netbox-proxbox/issues/365): optional, multi-pattern, per-endpoint tenant assignment by VM-name regex.

- **Disabled by default.** `ProxboxPluginSettings.enable_tenant_name_regex=False`. Operators opt in globally; per-`ProxmoxEndpoint` tri-state override (`None` inherit / `True` / `False`).
- **Operator-defined rule list.** `tenant_name_regex_rules` JSONField holds an ordered list of `{pattern, tenant_slug, [label]}` dicts. First-match-wins. Validated at save time: regex must compile, tenant_slug must resolve to an existing `tenancy.Tenant`, no duplicate patterns.
- **Per-endpoint replaces global.** When `ProxmoxEndpoint.tenant_name_regex_rules` is non-null, it replaces (not appends to) the global list for that endpoint.
- **Never overwrites.** The resolver leaves an existing `vm.tenant` alone (operator manual assignment, prior run, or proxbox-api endpoint-default all win).
- **Resolver fires post-sync** in `VirtualMachineSyncNowView.post` (per-VM "Sync Now") and `sync_stages._run_batch_selected_sync` (batch).
- Pair PR on proxbox-api: emersonfelipesp/proxbox-api#TBD — excludes `tenant` from `_compute_vm_patchable_fields` so the plugin's write isn't stomped on re-sync.

## Changes

- `netbox_proxbox/models/plugin_settings.py` — `enable_tenant_name_regex`, `tenant_name_regex_rules`.
- `netbox_proxbox/models/proxmox_endpoint.py` — nullable per-endpoint overrides.
- `netbox_proxbox/migrations/0042_tenant_name_regex.py` — `SeparateDatabaseAndState` + `IF NOT EXISTS` on both tables.
- `netbox_proxbox/sync_params.py` — `effective_tenant_regex_for_endpoint()` helper (mirrors `effective_overwrites_for_endpoint`).
- `netbox_proxbox/forms/settings.py` + `forms/proxmox.py` — Textarea + JSON `clean_*` validator.
- `netbox_proxbox/views/settings.py` — GET/POST plumbing for the two new fields.
- `netbox_proxbox/services/tenant_assignment.py` — `maybe_assign_tenant_from_regex()` resolver.
- `netbox_proxbox/views/sync_now/vm.py` + `sync_stages.py` — call sites after upsert returns.
- `tests/test_tenant_name_regex.py` — 20 unit tests covering disabled-by-default, endpoint override, inherit, replace, first-match, preservation, unknown slug, form validation.
- `docs/operations/tenant-mapping.md` — operator-facing reference.

## Test plan

- [ ] CI green
- [ ] `pytest tests/test_tenant_name_regex.py -v` locally passes (20 tests)
- [ ] Migration `0042_tenant_name_regex` applies cleanly with `IF NOT EXISTS` (idempotent on existing dev DBs)
- [ ] Global settings form: rule-list JSON validates (bad regex, missing slug, duplicate pattern, non-list each surface a field error)
- [ ] Per-endpoint form: empty textarea → `None` (inherit); `[]` → empty list override; non-empty list validates
- [ ] With `enable_tenant_name_regex=False` (default) and any rule list configured, a sync does **not** touch `vm.tenant`
- [ ] With global enabled + endpoint override `False`, sync on that endpoint is a no-op
- [ ] Endpoint-level rules replace (not append) the global list
- [ ] Operator-set tenant preserved across re-syncs
- [ ] Unknown slug at sync time → `logger.warning(...)`, no exception, run continues
