### PR TITLE
feat(#371): docker-compose-single-exec.yml one-shot pattern

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -405,6 +405,42 @@ jobs:
         run: |
           python tests/e2e/e2e_stack_check.py
 
+      - name: Smoke test single-exec compose (issue #371)
+        # Run only against the local install source: published wheels on
+        # v0.0.14 and earlier do not yet ship `proxbox_sync`. Other install
+        # sources start exercising this once v0.0.15 is on PyPI.
+        if: matrix.install_source == 'local'
+        env:
+          NETBOX_IMAGE: ${{ matrix.netbox_image }}
+        run: |
+          set -eux
+          # 1. Parse the compose file end-to-end. Catches YAML / env-var errors.
+          docker compose -f docs/installation/docker-compose-single-exec.yml config --quiet
+
+          # 2. Run it for real, attached to the live e2e stack via env-var overrides.
+          # Mount the in-tree source at /tmp/netbox-proxbox so the script's
+          # `uv pip install /tmp/netbox-proxbox` resolves to the branch being tested.
+          SECRET_KEY='proxbox-e2e-secret-key-proxbox-e2e-secret-key-proxbox-e2e-secret-key'
+          NETBOX_ENV_FILE=/dev/null \
+          NETBOX_NETWORK=proxbox-e2e \
+          PROXBOX_SYNC_TIMEOUT=600 \
+          NETBOX_PROXBOX_PIP_SPEC=/tmp/netbox-proxbox \
+          docker compose -f docs/installation/docker-compose-single-exec.yml run --rm \
+            -v "$PWD:/tmp/netbox-proxbox:ro" \
+            -e DB_HOST=netbox-e2e-postgres \
+            -e DB_NAME=netbox \
+            -e DB_USER=netbox \
+            -e DB_PASSWORD=netbox \
+            -e REDIS_HOST=netbox-e2e-redis \
+            -e REDIS_DATABASE=0 \
+            -e REDIS_CACHE_HOST=netbox-e2e-redis \
+            -e REDIS_CACHE_DATABASE=1 \
+            -e REDIS_TASK_HOST=netbox-e2e-redis \
+            -e REDIS_TASK_DATABASE=2 \
+            -e SECRET_KEY="$SECRET_KEY" \
+            -e ALLOWED_HOSTS="* localhost 127.0.0.1 ::1 netbox" \
+            netbox
+
       - name: Dump container logs on failure
         if: failure()
         run: |

--- a/docs/installation/3-installing-plugin-docker.md
+++ b/docs/installation/3-installing-plugin-docker.md
@@ -61,6 +61,16 @@ docker compose exec netbox /opt/netbox/netbox/manage.py showmigrations netbox_pr
 
 All plugin migrations should be marked as applied.
 
+## Scheduled sync deployments
+
+After the long-lived stack is up, you usually want syncs to run on a
+schedule without a human clicking **Full Update**. The recommended
+one-shot pattern ships next to this page as
+[`docker-compose-single-exec.yml`](./docker-compose-single-exec.yml) and
+is documented in
+[Scheduled sync — one-shot `docker compose` pattern](../operations/single-exec.md),
+with worked crontab and systemd-timer examples.
+
 ## Next Step
 
 The plugin requires the separate FastAPI backend service. Continue with [Proxbox Backend Setup](./backend-setup.md).

--- a/docs/installation/docker-compose-single-exec.yml
+++ b/docs/installation/docker-compose-single-exec.yml
@@ -1,0 +1,43 @@
+# docker-compose-single-exec.yml — one-shot scheduled sync container.
+#
+# Drop this file next to your existing netbox-docker stack and invoke it from a
+# host crontab or systemd timer. It runs `manage.py proxbox_sync --wait` once
+# and exits. See `docs/operations/single-exec.md` for end-to-end examples.
+#
+# Quick start (defaults assume the upstream netbox-docker compose project):
+#
+#   docker compose -f docs/installation/docker-compose-single-exec.yml run --rm netbox
+#
+# All NetBox-side config (DB_HOST, REDIS_HOST, REDIS_TASK_HOST, SECRET_KEY,
+# ALLOWED_HOSTS, ...) is read from the env_file you point this at — by default
+# the same `./env/netbox.env` that netbox-docker ships. Only the sync-specific
+# overrides live in the `environment:` block below. The boot script lives next
+# to this file as `proxbox-single-exec.sh` and is bind-mounted in read-only.
+
+name: netbox-proxbox-single-exec
+
+services:
+  netbox:
+    image: ${NETBOX_IMAGE:-netboxcommunity/netbox:v4.6.0}
+    restart: "no"
+    pull_policy: missing
+    env_file:
+      - path: ${NETBOX_ENV_FILE:-./env/netbox.env}
+        required: false
+    environment:
+      NETBOX_PROXBOX_PIP_SPEC: ${NETBOX_PROXBOX_PIP_SPEC:-netbox-proxbox}
+      PROXBOX_SYNC_TIMEOUT: ${PROXBOX_SYNC_TIMEOUT:-7200}
+      PROXBOX_SYNC_USER: ${PROXBOX_SYNC_USER:-}
+    entrypoint: ["/usr/local/bin/proxbox-single-exec.sh"]
+    volumes:
+      - type: bind
+        source: ${PROXBOX_SINGLE_EXEC_SCRIPT:-./proxbox-single-exec.sh}
+        target: /usr/local/bin/proxbox-single-exec.sh
+        read_only: true
+    networks:
+      - default
+
+networks:
+  default:
+    name: ${NETBOX_NETWORK:-netbox-docker_default}
+    external: true

--- a/docs/installation/proxbox-single-exec.sh
+++ b/docs/installation/proxbox-single-exec.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Entrypoint for docker-compose-single-exec.yml.
+#
+# Installs netbox-proxbox into the container, registers it in PLUGINS,
+# and runs `manage.py proxbox_sync --wait`. Exits with the job's status.
+#
+# Environment:
+#   NETBOX_PROXBOX_PIP_SPEC   PEP 508 spec for `uv pip install`. Default: netbox-proxbox.
+#   PROXBOX_SYNC_TIMEOUT      Seconds. Forwarded to --timeout. Default: 7200.
+#   PROXBOX_SYNC_USER         Optional. Forwarded to --user when set.
+
+set -euo pipefail
+
+PIP_SPEC="${NETBOX_PROXBOX_PIP_SPEC:-netbox-proxbox}"
+TIMEOUT="${PROXBOX_SYNC_TIMEOUT:-7200}"
+USER_ARG="${PROXBOX_SYNC_USER:-}"
+
+i=0
+until uv pip install --upgrade "$PIP_SPEC"; do
+  i=$((i + 1))
+  [ "$i" -ge 30 ] && exit 1
+  sleep 5
+done
+
+mkdir -p /etc/netbox/config
+if ! grep -q '"netbox_proxbox"' /etc/netbox/config/plugins.py 2>/dev/null; then
+  printf 'PLUGINS = ["netbox_proxbox"]\n' > /etc/netbox/config/plugins.py
+fi
+
+cmd=(/opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py proxbox_sync --wait --timeout "$TIMEOUT")
+[ -n "$USER_ARG" ] && cmd+=(--user "$USER_ARG")
+
+exec "${cmd[@]}"

--- a/docs/operations/single-exec.md
+++ b/docs/operations/single-exec.md
@@ -1,0 +1,153 @@
+# Scheduled sync — one-shot `docker compose` pattern
+
+This page documents `docs/installation/docker-compose-single-exec.yml`, a
+single-container Docker Compose file that runs one full Proxmox→NetBox sync
+and exits. It is the lightest of the three supported scheduled-sync
+topologies — the others being the long-lived plugin worker (UI-triggered
+syncs) and the standalone scheduler container (tracked as a separate
+follow-up).
+
+The compose file is a thin wrapper around the [`proxbox_sync`
+management command][headless-sync]. For the command's full flag reference,
+exit codes, and RQ-worker requirements, read that page first.
+
+[headless-sync]: ./headless-sync.md
+
+## When to use it
+
+- You already run NetBox via [`netbox-docker`][netbox-docker] and you want
+  scheduled syncs without standing up a second long-lived plugin process.
+- You drive the schedule from a host crontab, a systemd timer, a
+  Kubernetes `CronJob`, or any other one-shot launcher.
+- You want each invocation to leave **no residue** — `--rm` deletes the
+  container as soon as the sync finishes.
+
+[netbox-docker]: https://github.com/netbox-community/netbox-docker
+
+## How it works
+
+Each invocation:
+
+1. Spins up a single short-lived container from the same NetBox image
+   used by your long-lived stack.
+2. Installs `netbox-proxbox` into the container (or upgrades it if a newer
+   wheel is available).
+3. Joins your existing netbox-docker network so it can reach the same
+   PostgreSQL, Redis, and RQ workers.
+4. Runs `python manage.py proxbox_sync --wait --timeout 7200`.
+5. Exits with the job's terminal status — `0` on success, non-zero on
+   `proxbox-api` unreachable, errored job, missing endpoint
+   configuration, missing user, or no RQ worker on the `default` queue.
+6. The `--rm` flag on `docker compose run` deletes the container.
+
+The container does **not** run an RQ worker — it relies on the worker
+already running in your long-lived stack to actually execute the enqueued
+job. Without a healthy worker on the `default` queue, the command
+fast-fails after `PROXBOX_SYNC_WORKER_GRACE` seconds.
+
+## Configuration
+
+The container reads all NetBox-side config (`SECRET_KEY`, `ALLOWED_HOSTS`,
+`DB_*`, `REDIS_*`, `REDIS_TASK_*`, ...) from the env file you point it at.
+The default path is `./env/netbox.env`, which matches the bundled file in
+the upstream `netbox-docker` compose project. Tune the wrapper itself via
+the small set of variables below — everything else lives in the env file.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NETBOX_IMAGE` | `netboxcommunity/netbox:v4.6.0` | Image tag to run. Use the **same tag** as your long-lived stack so the migrations and schema match. |
+| `NETBOX_ENV_FILE` | `./env/netbox.env` | env file consumed by the container. Set to a non-existent path (or `/dev/null`) to disable env_file loading entirely and pass everything via `-e` on the command line. |
+| `NETBOX_NETWORK` | `netbox-docker_default` | External Docker network that already hosts your NetBox, PostgreSQL, and Redis. Matches netbox-docker's compose-generated network name. |
+| `NETBOX_PROXBOX_PIP_SPEC` | `netbox-proxbox` | PEP 508 spec passed to `uv pip install`. Pin a version (e.g. `netbox-proxbox==0.0.15`) to make scheduled runs reproducible. |
+| `PROXBOX_SYNC_TIMEOUT` | `7200` | Forwarded to `--timeout`. Matches `PROXBOX_SYNC_JOB_TIMEOUT`. |
+| `PROXBOX_SYNC_USER` | _(unset)_ | Forwarded to `--user`. Defaults to the oldest active superuser. |
+
+## Crontab example
+
+Run a full sync every six hours and append output to a log file:
+
+```cron
+0 */6 * * * cd /opt/netbox-docker && docker compose -f /opt/netbox-proxbox/docs/installation/docker-compose-single-exec.yml run --rm netbox >> /var/log/proxbox-sync.log 2>&1
+```
+
+Notes:
+
+- `cd /opt/netbox-docker` puts the compose project in the directory whose
+  `env/netbox.env` is the operative one. Adjust to wherever your
+  long-lived stack lives.
+- The redirect to a log file is mandatory in practice — `--rm` deletes the
+  container so its stdout disappears with it. The crontab line is the
+  only place this output is captured.
+
+## systemd timer example
+
+`/etc/systemd/system/proxbox-sync.service`:
+
+```ini
+[Unit]
+Description=ProxBox full sync (single-exec compose)
+After=docker.service netbox-docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/netbox-docker
+Environment=NETBOX_PROXBOX_PIP_SPEC=netbox-proxbox==0.0.15
+ExecStart=/usr/bin/docker compose -f /opt/netbox-proxbox/docs/installation/docker-compose-single-exec.yml run --rm netbox
+StandardOutput=append:/var/log/proxbox-sync.log
+StandardError=append:/var/log/proxbox-sync.log
+```
+
+`/etc/systemd/system/proxbox-sync.timer`:
+
+```ini
+[Unit]
+Description=Run proxbox-sync every 6 hours
+
+[Timer]
+OnCalendar=0/6:00
+Persistent=true
+RandomizedDelaySec=10m
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable:
+
+```bash
+systemctl daemon-reload
+systemctl enable --now proxbox-sync.timer
+```
+
+## Concurrent invocations — read this
+
+Two `docker compose run` invocations launched simultaneously will both
+enqueue full syncs. The plugin does **not** currently coalesce concurrent
+sync jobs, and `proxbox-api` runs them in parallel with no shared lock.
+
+**Pick a schedule interval safely greater than your typical sync
+duration.** A six-hour interval is a sensible starting point for most
+deployments; a one-hour interval is reasonable only if you have measured
+your full sync running in well under an hour. Do **not** invoke the
+single-exec compose from two crontabs / timers / runbooks at once.
+
+A real `/sync/active` endpoint and a join-or-fast-fail mode for
+`proxbox_sync` are tracked separately; until those land, this is a
+documentation-level constraint.
+
+## Smoke test
+
+CI exercises this compose file as part of
+[`.github/workflows/e2e-docker.yml`][e2e]: after the e2e stack is healthy
+and the plugin endpoints are configured, the workflow runs
+`docker compose -f docs/installation/docker-compose-single-exec.yml run --rm netbox`
+attached to the e2e network and asserts exit code `0`.
+
+[e2e]: ../../.github/workflows/e2e-docker.yml
+
+## Related
+
+- [`proxbox_sync` flag and exit-code reference](./headless-sync.md)
+- [Installing the plugin in a Docker NetBox deployment](../installation/3-installing-plugin-docker.md)
+- [`netbox_proxbox/jobs.py`](../../netbox_proxbox/jobs.py) for the RQ job model

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - Cluster and Node Tracking: 'user-guide/cluster-nodes.md'
   - Operations:
     - Headless Sync: 'operations/headless-sync.md'
+    - Single-Exec Compose: 'operations/single-exec.md'
   - API Reference:
     - Overview: 'api/index.md'
     - Endpoints: 'api/endpoints.md'


### PR DESCRIPTION
## Summary

- Adds `docs/installation/docker-compose-single-exec.yml` plus the sidecar `proxbox-single-exec.sh` boot script — a one-shot container that installs the plugin, registers it in `PLUGINS`, and runs `manage.py proxbox_sync --wait`. Intended to be invoked from a host crontab, systemd timer, or Kubernetes CronJob.
- Adds `docs/operations/single-exec.md` with worked crontab / systemd-timer examples, a configuration-variable table, and an explicit concurrent-invocation warning.
- Cross-links the new doc from `docs/installation/3-installing-plugin-docker.md` and wires it into the mkdocs Operations nav.
- Extends `.github/workflows/e2e-docker.yml` with a `Smoke test single-exec compose` step that validates the compose file (`config --quiet`) and runs it for real against the live e2e stack. Gated to `install_source == 'local'` so it doesn't break on published wheels that pre-date `proxbox_sync`.

Closes #371. Depends on #360 (already shipped on v0.0.15).

## Design choices

- **Location**: `docs/installation/docker-compose-single-exec.yml` matches the v0.0.19 roadmap.
- **Service name**: `netbox` (also from the roadmap; the issue body's `proxbox-sync` and EdgeUno's `proxbox-single-exec` were both rejected during plan review).
- **env_file precedence**: the compose `environment:` block only sets sync-wrapper-specific overrides (`NETBOX_PROXBOX_PIP_SPEC`, `PROXBOX_SYNC_TIMEOUT`, `PROXBOX_SYNC_USER`). Everything NetBox-side (`DB_*`, `REDIS_*`, `REDIS_TASK_*`, `SECRET_KEY`, `ALLOWED_HOSTS`, ...) is read from the operator's existing `env/netbox.env`, the same file netbox-docker ships.
- **Sidecar boot script**: extracted to `proxbox-single-exec.sh` (bind-mounted in) to keep Compose's `${VAR}` interpolation from fighting the shell variables. Cleaner YAML, independently version-controlled, and `chmod 755` on disk.
- **Concurrency**: documentation-only for this PR. A real `/sync/active` endpoint and join-or-fast-fail mode for `proxbox_sync` will be filed as a follow-up.

## Test plan

- [x] `docker compose -f docs/installation/docker-compose-single-exec.yml config --quiet` exits 0 locally
- [x] `python -m compileall netbox_proxbox tests` passes (no Python changes in this PR)
- [ ] CI `e2e-docker` job's new smoke step is green on the `4.5.8 / 4.5.9 / 4.6.0` matrix
- [ ] Manual: paste the documented crontab line on a fresh netbox-docker stack and verify `--rm` cleanup + redirected log capture