### PR TITLE
feat(#363): cloud-init reflection via first-class ProxmoxVMCloudInit model

### DIFF
--- a/netbox_proxbox/api/serializers/__init__.py
+++ b/netbox_proxbox/api/serializers/__init__.py
@@ -32,6 +32,7 @@ from netbox_proxbox.api.serializers.storage import (
     ProxmoxStorageSerializer,
 )
 from netbox_proxbox.api.serializers.vm_backup import VMBackupSerializer
+from netbox_proxbox.api.serializers.vm_cloudinit import ProxmoxVMCloudInitSerializer
 from netbox_proxbox.api.serializers.vm_snapshot import VMSnapshotSerializer
 from netbox_proxbox.api.serializers.vm_task_history import VMTaskHistorySerializer
 
@@ -51,6 +52,7 @@ __all__ = (
     "ProxmoxClusterSerializer",
     "ProxmoxEndpointSerializer",
     "ProxmoxNodeSerializer",
+    "ProxmoxVMCloudInitSerializer",
     "ReplicationSerializer",
     "ProxmoxStorageSerializer",
     "ScheduledJobSerializer",

--- a/netbox_proxbox/api/serializers/vm_cloudinit.py
+++ b/netbox_proxbox/api/serializers/vm_cloudinit.py
@@ -1,0 +1,48 @@
+"""API serializer for the ProxmoxVMCloudInit model (issue #363)."""
+
+from __future__ import annotations
+
+from netbox.api.serializers import NetBoxModelSerializer
+from rest_framework import serializers
+from virtualization.api.serializers_.nested import NestedVirtualMachineSerializer
+
+from netbox_proxbox.models import ProxmoxVMCloudInit
+
+
+class ProxmoxVMCloudInitSerializer(NetBoxModelSerializer):
+    """Full representation of a Proxmox VM cloud-init row stored in NetBox.
+
+    proxbox-api writes this resource; the NetBox UI keeps it read-only.
+    ``sshkeys`` is delivered already decoded (newlines as ``\\n``); proxbox-api
+    runs ``urllib.parse.unquote`` upstream.
+    """
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_proxbox-api:proxmoxvmcloudinit-detail",
+    )
+    virtual_machine = NestedVirtualMachineSerializer()
+
+    class Meta:
+        model = ProxmoxVMCloudInit
+        fields = (
+            "id",
+            "url",
+            "display",
+            "virtual_machine",
+            "ciuser",
+            "sshkeys",
+            "ipconfig0",
+            "sshkeys_truncated",
+            "last_synced",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+        brief_fields = (
+            "id",
+            "url",
+            "display",
+            "virtual_machine",
+            "ciuser",
+        )

--- a/netbox_proxbox/api/urls.py
+++ b/netbox_proxbox/api/urls.py
@@ -48,6 +48,9 @@ router.register("replications", views.ReplicationViewSet, basename="replication"
 router.register("snapshots", views.VMSnapshotViewSet)
 router.register("task-history", views.VMTaskHistoryViewSet)
 router.register(
+    "vm-cloudinit", views.ProxmoxVMCloudInitViewSet, basename="proxmoxvmcloudinit"
+)
+router.register(
     "settings", views.ProxboxPluginSettingsViewSet, basename="proxboxpluginsettings"
 )
 

--- a/netbox_proxbox/api/views.py
+++ b/netbox_proxbox/api/views.py
@@ -26,6 +26,7 @@ from .serializers import (
     ProxmoxEndpointSerializer,
     ProxmoxNodeSerializer,
     ProxmoxStorageSerializer,
+    ProxmoxVMCloudInitSerializer,
     ReplicationSerializer,
     ScheduleSyncRequestSerializer,
     VMBackupSerializer,
@@ -137,6 +138,19 @@ class VMTaskHistoryViewSet(NetBoxModelViewSet):
     queryset = models.VMTaskHistory.objects.select_related("virtual_machine")
     serializer_class = VMTaskHistorySerializer
     filterset_class = filtersets.VMTaskHistoryFilterSet
+
+
+class ProxmoxVMCloudInitViewSet(NetBoxModelViewSet):
+    """REST API for Proxmox VM cloud-init rows (issue #363).
+
+    proxbox-api writes ciuser/sshkeys/ipconfig0 here after each per-VM sync.
+    The NetBox UI keeps the row read-only via disabled form fields; the API
+    inherits NetBox's standard object-level permissions.
+    """
+
+    queryset = models.ProxmoxVMCloudInit.objects.select_related("virtual_machine")
+    serializer_class = ProxmoxVMCloudInitSerializer
+    filterset_class = filtersets.ProxmoxVMCloudInitFilterSet
 
 
 class ProxmoxStorageViewSet(NetBoxModelViewSet):

--- a/netbox_proxbox/constants.py
+++ b/netbox_proxbox/constants.py
@@ -22,6 +22,7 @@ OVERWRITE_FIELD_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "overwrite_vm_tags",
             "overwrite_vm_description",
             "overwrite_vm_custom_fields",
+            "overwrite_vm_cloudinit",
         ),
     ),
     (

--- a/netbox_proxbox/filtersets.py
+++ b/netbox_proxbox/filtersets.py
@@ -14,6 +14,7 @@ from .models import (
     ProxmoxEndpoint,
     ProxmoxNode,
     ProxmoxStorage,
+    ProxmoxVMCloudInit,
     Replication,
     VMBackup,
     VMSnapshot,
@@ -196,6 +197,31 @@ class VMTaskHistoryFilterSet(ProxboxModelFilterSet):
             | Q(status__icontains=value)
             | Q(task_state__icontains=value)
             | Q(exitstatus__icontains=value)
+        )
+
+
+@register_filterset
+class ProxmoxVMCloudInitFilterSet(ProxboxModelFilterSet):
+    """Filter Proxmox VM cloud-init rows reflected from Proxmox (issue #363)."""
+
+    class Meta:
+        model = ProxmoxVMCloudInit
+        fields = (
+            "id",
+            "virtual_machine",
+            "ciuser",
+            "ipconfig0",
+            "sshkeys_truncated",
+        )
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        """Match VM name or cloud-init fields case-insensitively."""
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(virtual_machine__name__icontains=value)
+            | Q(ciuser__icontains=value)
+            | Q(ipconfig0__icontains=value)
         )
 
 

--- a/netbox_proxbox/forms/__init__.py
+++ b/netbox_proxbox/forms/__init__.py
@@ -9,5 +9,6 @@ from .schedule_sync import *
 from .settings import *
 from .storage import *
 from .vm_backup import *
+from .vm_cloudinit import *
 from .vm_snapshot import *
 from .vm_task_history import *

--- a/netbox_proxbox/forms/vm_cloudinit.py
+++ b/netbox_proxbox/forms/vm_cloudinit.py
@@ -1,0 +1,73 @@
+"""Define NetBox forms for the read-only Proxmox VM cloud-init record (issue #363)."""
+
+from django import forms
+
+from netbox.forms import (
+    NetBoxModelFilterSetForm,
+    NetBoxModelForm,
+)
+from utilities.forms.fields import DynamicModelChoiceField
+from virtualization.models import VirtualMachine
+
+from netbox_proxbox.models import ProxmoxVMCloudInit
+
+
+class ProxmoxVMCloudInitForm(NetBoxModelForm):
+    """NetBox-side form. Proxmox is the source of truth; all fields are disabled."""
+
+    class Meta:
+        model = ProxmoxVMCloudInit
+        fields = (
+            "virtual_machine",
+            "ciuser",
+            "sshkeys",
+            "ipconfig0",
+            "sshkeys_truncated",
+            "tags",
+        )
+
+    virtual_machine = DynamicModelChoiceField(
+        queryset=VirtualMachine.objects.all(),
+        required=True,
+        help_text="Select a Virtual Machine.",
+        label="Virtual Machine",
+    )
+
+    def __init__(self, *args, **kwargs):
+        """Disable every editable field so operators cannot drift the row in NetBox."""
+        super().__init__(*args, **kwargs)
+        for field_name, field in self.fields.items():
+            field.disabled = True
+            field.help_text = (
+                (field.help_text or "")
+                + " Read-only mirror of Proxmox; edit on the Proxmox side."
+            ).strip()
+
+
+class ProxmoxVMCloudInitFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for the cloud-init list view."""
+
+    model = ProxmoxVMCloudInit
+
+    virtual_machine = forms.ModelMultipleChoiceField(
+        queryset=VirtualMachine.objects.all(),
+        required=False,
+    )
+
+    ciuser = forms.CharField(
+        required=False,
+        label="Cloud-init user",
+    )
+
+    ipconfig0 = forms.CharField(
+        required=False,
+        label="ipconfig0",
+    )
+
+    sshkeys_truncated = forms.NullBooleanField(
+        required=False,
+        widget=forms.Select(
+            choices=[("", "---------"), ("true", "Yes"), ("false", "No")],
+        ),
+        label="sshkeys truncated",
+    )

--- a/netbox_proxbox/migrations/0043_proxmoxvmcloudinit.py
+++ b/netbox_proxbox/migrations/0043_proxmoxvmcloudinit.py
@@ -1,0 +1,98 @@
+"""Create the ProxmoxVMCloudInit table for issue #363."""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_proxbox", "0042_tenant_name_regex"),
+        ("virtualization", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ProxmoxVMCloudInit",
+            fields=[
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        help_text="Custom field data stored as JSON.",
+                        null=True,
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "ciuser",
+                    models.CharField(
+                        blank=True,
+                        help_text="Proxmox cloud-init user (``ciuser``).",
+                        max_length=64,
+                    ),
+                ),
+                (
+                    "sshkeys",
+                    models.TextField(
+                        blank=True,
+                        help_text=(
+                            "Decoded cloud-init SSH key bundle (one key per line). "
+                            "Proxmox-side is URL-encoded; proxbox-api runs "
+                            "urllib.parse.unquote before writing this row."
+                        ),
+                    ),
+                ),
+                (
+                    "ipconfig0",
+                    models.CharField(
+                        blank=True,
+                        help_text=(
+                            "Cloud-init first-NIC IP configuration string from "
+                            "Proxmox (e.g. ``ip=dhcp`` or "
+                            "``ip=10.0.0.5/24,gw=10.0.0.1``)."
+                        ),
+                        max_length=255,
+                    ),
+                ),
+                (
+                    "sshkeys_truncated",
+                    models.BooleanField(
+                        default=False,
+                        help_text=(
+                            "True when proxbox-api truncated the ``sshkeys`` "
+                            "payload because the decoded blob exceeded 10 KB."
+                        ),
+                    ),
+                ),
+                (
+                    "last_synced",
+                    models.DateTimeField(
+                        auto_now=True,
+                        help_text="Time of the last cloud-init reconciliation pass.",
+                    ),
+                ),
+                (
+                    "virtual_machine",
+                    models.OneToOneField(
+                        help_text="NetBox VM this cloud-init record reflects.",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="proxmox_cloudinit",
+                        to="virtualization.virtualmachine",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Proxmox VM cloud-init",
+                "verbose_name_plural": "Proxmox VM cloud-init records",
+                "ordering": ("virtual_machine",),
+            },
+        ),
+    ]

--- a/netbox_proxbox/migrations/0044_overwrite_vm_cloudinit.py
+++ b/netbox_proxbox/migrations/0044_overwrite_vm_cloudinit.py
@@ -1,0 +1,45 @@
+"""Add ProxboxPluginSettings.overwrite_vm_cloudinit gate flag for issue #363."""
+
+from django.db import migrations, models
+
+
+SETTINGS_TABLE = "netbox_proxbox_proxboxpluginsettings"
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_proxbox", "0043_proxmoxvmcloudinit"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql=(
+                        f'ALTER TABLE "{SETTINGS_TABLE}" '
+                        f'ADD COLUMN IF NOT EXISTS "overwrite_vm_cloudinit" '
+                        f'boolean NOT NULL DEFAULT TRUE;'
+                    ),
+                    reverse_sql=(
+                        f'ALTER TABLE "{SETTINGS_TABLE}" '
+                        f'DROP COLUMN IF EXISTS "overwrite_vm_cloudinit";'
+                    ),
+                ),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="proxboxpluginsettings",
+                    name="overwrite_vm_cloudinit",
+                    field=models.BooleanField(
+                        default=True,
+                        verbose_name="Overwrite VM cloud-init",
+                        help_text=(
+                            "When disabled, sync never updates the "
+                            "ProxmoxVMCloudInit row (ciuser, sshkeys, "
+                            "ipconfig0) on existing NetBox virtual machines."
+                        ),
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/netbox_proxbox/models/__init__.py
+++ b/netbox_proxbox/models/__init__.py
@@ -11,6 +11,7 @@ from netbox_proxbox.models.proxmox_node import ProxmoxNode
 from netbox_proxbox.models.replication import Replication
 from netbox_proxbox.models.storage import ProxmoxStorage, ProxmoxStorageVirtualDisk
 from netbox_proxbox.models.vm_backup import VMBackup
+from netbox_proxbox.models.vm_cloudinit import ProxmoxVMCloudInit
 from netbox_proxbox.models.vm_snapshot import VMSnapshot
 from netbox_proxbox.models.vm_task_history import VMTaskHistory
 
@@ -22,6 +23,7 @@ __all__ = (
     "ProxmoxCluster",
     "ProxmoxEndpoint",
     "ProxmoxNode",
+    "ProxmoxVMCloudInit",
     "Replication",
     "ProxmoxStorage",
     "ProxmoxStorageVirtualDisk",

--- a/netbox_proxbox/models/plugin_settings.py
+++ b/netbox_proxbox/models/plugin_settings.py
@@ -379,6 +379,14 @@ class ProxboxPluginSettings(NetBoxModel):
             "When disabled, sync never changes custom fields on existing NetBox virtual machines."
         ),
     )
+    overwrite_vm_cloudinit = models.BooleanField(
+        default=True,
+        verbose_name=_("Overwrite VM cloud-init"),
+        help_text=_(
+            "When disabled, sync never updates the ProxmoxVMCloudInit row "
+            "(ciuser, sshkeys, ipconfig0) on existing NetBox virtual machines."
+        ),
+    )
     overwrite_cluster_tags = models.BooleanField(
         default=True,
         verbose_name=_("Overwrite cluster tags"),

--- a/netbox_proxbox/models/vm_cloudinit.py
+++ b/netbox_proxbox/models/vm_cloudinit.py
@@ -1,0 +1,76 @@
+"""Define the read-only Proxmox cloud-init model stored alongside NetBox virtual machines."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from netbox.models import NetBoxModel
+
+
+class ProxmoxVMCloudInit(NetBoxModel):
+    """Proxmox cloud-init row mirroring ``ciuser`` / ``sshkeys`` / ``ipconfig0``.
+
+    Populated by proxbox-api from ``qm config <vmid>`` on each sync. Read-only
+    on the NetBox side; Proxmox stays the source of truth. ``sshkeys`` is
+    stored decoded (newlines as ``\\n``); proxbox-api runs
+    ``urllib.parse.unquote`` before writing.
+    """
+
+    virtual_machine = models.OneToOneField(
+        to="virtualization.VirtualMachine",
+        on_delete=models.CASCADE,
+        related_name="proxmox_cloudinit",
+        help_text=_("NetBox VM this cloud-init record reflects."),
+    )
+
+    ciuser = models.CharField(
+        max_length=64,
+        blank=True,
+        help_text=_("Proxmox cloud-init user (``ciuser``)."),
+    )
+
+    sshkeys = models.TextField(
+        blank=True,
+        help_text=_(
+            "Decoded cloud-init SSH key bundle (one key per line). "
+            "Proxmox-side is URL-encoded; proxbox-api runs urllib.parse.unquote "
+            "before writing this row."
+        ),
+    )
+
+    ipconfig0 = models.CharField(
+        max_length=255,
+        blank=True,
+        help_text=_(
+            "Cloud-init first-NIC IP configuration string from Proxmox "
+            "(e.g. ``ip=dhcp`` or ``ip=10.0.0.5/24,gw=10.0.0.1``)."
+        ),
+    )
+
+    sshkeys_truncated = models.BooleanField(
+        default=False,
+        help_text=_(
+            "True when proxbox-api truncated the ``sshkeys`` payload because "
+            "the decoded blob exceeded 10 KB."
+        ),
+    )
+
+    last_synced = models.DateTimeField(
+        auto_now=True,
+        help_text=_("Time of the last cloud-init reconciliation pass."),
+    )
+
+    class Meta:
+        verbose_name = _("Proxmox VM cloud-init")
+        verbose_name_plural = _("Proxmox VM cloud-init records")
+        ordering = ("virtual_machine",)
+
+    def __str__(self) -> str:
+        """Return the parent VM name for list displays."""
+        return f"{self.virtual_machine} cloud-init"
+
+    def get_absolute_url(self) -> str:
+        """Plugin UI URL for this cloud-init record's detail page."""
+        return reverse("plugins:netbox_proxbox:proxmoxvmcloudinit", args=[self.pk])

--- a/netbox_proxbox/navigation.py
+++ b/netbox_proxbox/navigation.py
@@ -109,6 +109,11 @@ task_history_item = PluginMenuItem(
     link_text="Task History",
 )
 
+vm_cloudinit_item = PluginMenuItem(
+    link="plugins:netbox_proxbox:proxmoxvmcloudinit_list",
+    link_text="VM Cloud-init",
+)
+
 contributing_item = PluginMenuItem(
     link="plugins:netbox_proxbox:contributing",
     link_text="Contributing!",
@@ -196,6 +201,7 @@ menu = PluginMenu(
                 replications_item,
                 ha_item,
                 task_history_item,
+                vm_cloudinit_item,
                 schedule_sync_item,
                 sync_jobs_item,
                 backend_logs_item,

--- a/netbox_proxbox/tables/__init__.py
+++ b/netbox_proxbox/tables/__init__.py
@@ -20,6 +20,7 @@ from netbox_proxbox.tables.cluster import ProxmoxClusterTable, ProxmoxNodeTable
 from netbox_proxbox.tables.replication import ReplicationTable
 from netbox_proxbox.tables.storage import ProxmoxStorageTable
 from netbox_proxbox.tables.vm_backup import VMBackupTable
+from netbox_proxbox.tables.vm_cloudinit import ProxmoxVMCloudInitTable
 from netbox_proxbox.tables.vm_snapshot import VMSnapshotTable
 from netbox_proxbox.tables.vm_task_history import VMTaskHistoryTable
 

--- a/netbox_proxbox/tables/vm_cloudinit.py
+++ b/netbox_proxbox/tables/vm_cloudinit.py
@@ -1,0 +1,40 @@
+"""django-tables2 layout for Proxmox VM cloud-init records (issue #363)."""
+
+from django.utils.translation import gettext as _
+from django_tables2 import tables
+
+from netbox.tables import NetBoxTable
+from netbox.tables.columns import BooleanColumn
+
+from netbox_proxbox.models import ProxmoxVMCloudInit
+
+
+class ProxmoxVMCloudInitTable(NetBoxTable):
+    """Table view of Proxmox VM cloud-init reflections."""
+
+    virtual_machine = tables.Column(linkify=True)
+    ciuser = tables.Column(verbose_name=_("Cloud-init User"))
+    ipconfig0 = tables.Column(verbose_name=_("ipconfig0"))
+    sshkeys_truncated = BooleanColumn(verbose_name=_("SSH Keys Truncated"))
+    last_synced = tables.DateTimeColumn(verbose_name=_("Last Synced"))
+
+    class Meta(NetBoxTable.Meta):
+        model = ProxmoxVMCloudInit
+        fields = (
+            "pk",
+            "id",
+            "virtual_machine",
+            "ciuser",
+            "ipconfig0",
+            "sshkeys_truncated",
+            "last_synced",
+        )
+
+        default_columns = (
+            "pk",
+            "virtual_machine",
+            "ciuser",
+            "ipconfig0",
+            "sshkeys_truncated",
+            "last_synced",
+        )

--- a/netbox_proxbox/templates/netbox_proxbox/proxmoxvmcloudinit.html
+++ b/netbox_proxbox/templates/netbox_proxbox/proxmoxvmcloudinit.html
@@ -1,0 +1,63 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block content %}
+<div class="row">
+	<div class="col-md-6">
+		<div class="card">
+			<h5 class="card-header">{% trans "Proxmox VM Cloud-init" %}</h5>
+			<table class="table table-hover attr-table">
+				<tr>
+					<th scope="row">{% trans "Virtual Machine" %}</th>
+					<td>{{ object.virtual_machine|linkify }}</td>
+				</tr>
+				<tr>
+					<th scope="row">{% trans "Cloud-init User" %}</th>
+					<td>{{ object.ciuser|placeholder }}</td>
+				</tr>
+				<tr>
+					<th scope="row">{% trans "ipconfig0" %}</th>
+					<td><code>{{ object.ipconfig0|placeholder }}</code></td>
+				</tr>
+				<tr>
+					<th scope="row">{% trans "SSH Keys Truncated" %}</th>
+					<td>
+						{% if object.sshkeys_truncated %}
+							<span class="badge text-bg-yellow">{% trans "Yes" %}</span>
+						{% else %}
+							<span class="badge text-bg-grey">{% trans "No" %}</span>
+						{% endif %}
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">{% trans "Last Synced" %}</th>
+					<td>{{ object.last_synced|placeholder }}</td>
+				</tr>
+			</table>
+		</div>
+		<div class="card mt-3">
+			<h5 class="card-header">{% trans "SSH Keys" %}</h5>
+			<div class="card-body">
+				{% if object.sshkeys %}
+					<pre class="mb-0"><code>{{ object.sshkeys }}</code></pre>
+				{% else %}
+					<span class="text-muted">{% trans "No SSH keys configured." %}</span>
+				{% endif %}
+			</div>
+		</div>
+	</div>
+	<div class="col-md-6">
+		{% include 'inc/panels/tags.html' %}
+		{% include 'inc/panels/custom_fields.html' %}
+		<div class="card">
+			<h5 class="card-header">{% trans "Source of Truth" %}</h5>
+			<div class="card-body">
+				<p class="mb-0">
+					{% trans "This record is a read-only reflection of Proxmox cloud-init configuration. Edits made in NetBox will not propagate back to Proxmox; modify the values on the Proxmox side and re-sync." %}
+				</p>
+			</div>
+		</div>
+	</div>
+</div>
+{% endblock %}

--- a/netbox_proxbox/templates/netbox_proxbox/proxmoxvmcloudinit_list.html
+++ b/netbox_proxbox/templates/netbox_proxbox/proxmoxvmcloudinit_list.html
@@ -1,0 +1,3 @@
+{% extends 'generic/object_list.html' %}
+{% load helpers %}
+{% load i18n %}

--- a/netbox_proxbox/templates/netbox_proxbox/vm_proxmox_cloudinit.html
+++ b/netbox_proxbox/templates/netbox_proxbox/vm_proxmox_cloudinit.html
@@ -1,0 +1,58 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block content %}
+<div class="row">
+	<div class="col-12 col-xl-8">
+		<div class="card">
+			<h5 class="card-header">{% trans "Proxmox Cloud-init" %}</h5>
+			<div class="card-body">
+				{% if cloudinit %}
+					<table class="table table-hover attr-table">
+						<tr>
+							<th scope="row">{% trans "Cloud-init User" %}</th>
+							<td>{{ cloudinit.ciuser|placeholder }}</td>
+						</tr>
+						<tr>
+							<th scope="row">{% trans "ipconfig0" %}</th>
+							<td><code>{{ cloudinit.ipconfig0|placeholder }}</code></td>
+						</tr>
+						<tr>
+							<th scope="row">{% trans "SSH Keys Truncated" %}</th>
+							<td>
+								{% if cloudinit.sshkeys_truncated %}
+									<span class="badge text-bg-yellow">{% trans "Yes" %}</span>
+								{% else %}
+									<span class="badge text-bg-grey">{% trans "No" %}</span>
+								{% endif %}
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">{% trans "Last Synced" %}</th>
+							<td>{{ cloudinit.last_synced|placeholder }}</td>
+						</tr>
+						<tr>
+							<th scope="row">{% trans "Detail Record" %}</th>
+							<td>{{ cloudinit|linkify:"Open" }}</td>
+						</tr>
+					</table>
+				{% else %}
+					<div class="alert alert-info" role="alert">
+						{% trans "No Proxmox cloud-init record has been synced for this VM." %}
+					</div>
+				{% endif %}
+			</div>
+		</div>
+
+		{% if cloudinit and cloudinit.sshkeys %}
+			<div class="card mt-3">
+				<h5 class="card-header">{% trans "SSH Keys" %}</h5>
+				<div class="card-body">
+					<pre class="mb-0"><code>{{ cloudinit.sshkeys }}</code></pre>
+				</div>
+			</div>
+		{% endif %}
+	</div>
+</div>
+{% endblock %}

--- a/netbox_proxbox/urls.py
+++ b/netbox_proxbox/urls.py
@@ -99,6 +99,14 @@ urlpatterns = [
         "task-history/",
         include(get_model_urls("netbox_proxbox", "vmtaskhistory", detail=False)),
     ),
+    path(
+        "vm-cloudinit/<int:pk>/",
+        include(get_model_urls("netbox_proxbox", "proxmoxvmcloudinit")),
+    ),
+    path(
+        "vm-cloudinit/",
+        include(get_model_urls("netbox_proxbox", "proxmoxvmcloudinit", detail=False)),
+    ),
     path("sync/devices/", views.sync_devices, name="sync_devices"),
     path("sync/storage/", views.sync_storage, name="sync_storage"),
     path(

--- a/netbox_proxbox/views/__init__.py
+++ b/netbox_proxbox/views/__init__.py
@@ -109,6 +109,14 @@ from .vm_backup import (
     VMBackupTabView,
     VMBackupView,
 )
+from .vm_cloudinit import (
+    ProxmoxVMCloudInitBulkDeleteView,
+    ProxmoxVMCloudInitDeleteView,
+    ProxmoxVMCloudInitEditView,
+    ProxmoxVMCloudInitListView,
+    ProxmoxVMCloudInitTabView,
+    ProxmoxVMCloudInitView,
+)
 
 # Task History tab and detail views live in ``vm_task_history``.
 from .ha import HAClusterView

--- a/netbox_proxbox/views/vm_cloudinit.py
+++ b/netbox_proxbox/views/vm_cloudinit.py
@@ -1,0 +1,102 @@
+"""Provide NetBox CRUD and tab views for Proxmox VM cloud-init records (issue #363).
+
+The model is read-only from a NetBox-user perspective: ``ProxmoxVMCloudInitForm``
+disables every editable field. Edits flow in only via the plugin DRF endpoint
+``/api/plugins/proxbox/vm-cloudinit/`` driven by proxbox-api.
+"""
+
+from django.http import HttpRequest
+from netbox.views import generic
+from utilities.views import ViewTab, register_model_view
+from virtualization.models import VirtualMachine
+
+from netbox_proxbox.filtersets import ProxmoxVMCloudInitFilterSet
+from netbox_proxbox.forms import (
+    ProxmoxVMCloudInitFilterForm,
+    ProxmoxVMCloudInitForm,
+)
+from netbox_proxbox.models import ProxmoxVMCloudInit
+from netbox_proxbox.tables import ProxmoxVMCloudInitTable
+
+
+__all__ = (
+    "ProxmoxVMCloudInitView",
+    "ProxmoxVMCloudInitListView",
+    "ProxmoxVMCloudInitEditView",
+    "ProxmoxVMCloudInitDeleteView",
+    "ProxmoxVMCloudInitBulkDeleteView",
+    "ProxmoxVMCloudInitTabView",
+)
+
+
+@register_model_view(ProxmoxVMCloudInit, "list", path="", detail=False)
+class ProxmoxVMCloudInitListView(generic.ObjectListView):
+    """Global list of Proxmox VM cloud-init records."""
+
+    queryset = ProxmoxVMCloudInit.objects.select_related("virtual_machine")
+    table = ProxmoxVMCloudInitTable
+    filterset = ProxmoxVMCloudInitFilterSet
+    filterset_form = ProxmoxVMCloudInitFilterForm
+    template_name = "netbox_proxbox/proxmoxvmcloudinit_list.html"
+    actions = {
+        "bulk_delete": {"delete"},
+        "export": {"view"},
+    }
+
+
+@register_model_view(ProxmoxVMCloudInit)
+class ProxmoxVMCloudInitView(generic.ObjectView):
+    """Detail view for one cloud-init record."""
+
+    queryset = ProxmoxVMCloudInit.objects.select_related("virtual_machine")
+
+
+@register_model_view(ProxmoxVMCloudInit, "edit")
+class ProxmoxVMCloudInitEditView(generic.ObjectEditView):
+    """Edit view kept for permission parity. The form disables all fields."""
+
+    queryset = ProxmoxVMCloudInit.objects.all()
+    form = ProxmoxVMCloudInitForm
+    default_return_url = "plugins:netbox_proxbox:proxmoxvmcloudinit_list"
+
+
+@register_model_view(ProxmoxVMCloudInit, "delete")
+class ProxmoxVMCloudInitDeleteView(generic.ObjectDeleteView):
+    """Delete a single cloud-init record (e.g. for a removed VM)."""
+
+    queryset = ProxmoxVMCloudInit.objects.all()
+    default_return_url = "plugins:netbox_proxbox:proxmoxvmcloudinit_list"
+
+
+@register_model_view(ProxmoxVMCloudInit, "bulk_delete", detail=False)
+class ProxmoxVMCloudInitBulkDeleteView(generic.BulkDeleteView):
+    """Bulk delete cloud-init records from the global list."""
+
+    queryset = ProxmoxVMCloudInit.objects.all()
+    filterset = ProxmoxVMCloudInitFilterSet
+    table = ProxmoxVMCloudInitTable
+    default_return_url = "plugins:netbox_proxbox:proxmoxvmcloudinit_list"
+
+
+@register_model_view(VirtualMachine, "proxmox_cloudinit", path="proxmox-cloudinit")
+class ProxmoxVMCloudInitTabView(generic.ObjectView):
+    """VM detail tab for the Proxmox cloud-init record (gated on row presence)."""
+
+    queryset = VirtualMachine.objects.all()
+    template_name = "netbox_proxbox/vm_proxmox_cloudinit.html"
+    tab = ViewTab(
+        label="Cloud-init",
+        badge=lambda obj: 1 if hasattr(obj, "proxmox_cloudinit") else 0,
+        permission="netbox_proxbox.view_proxmoxvmcloudinit",
+        weight=1150,
+        hide_if_empty=True,
+    )
+
+    def get_queryset(self, request: HttpRequest):
+        """Restrict parent VMs to those the user may view."""
+        return VirtualMachine.objects.restrict(request.user, "view")
+
+    def get_extra_context(self, request: HttpRequest, instance: VirtualMachine):
+        """Surface the cloud-init row (if any) for the tab template."""
+        cloudinit = ProxmoxVMCloudInit.objects.filter(virtual_machine=instance).first()
+        return {"cloudinit": cloudinit}

--- a/tests/test_vm_cloudinit.py
+++ b/tests/test_vm_cloudinit.py
@@ -1,0 +1,197 @@
+"""Cover the read-side cloud-init reflection model (issue #363)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NETBOX_ROOT = REPO_ROOT.parent / "netbox" / "netbox"
+
+for candidate in (REPO_ROOT, NETBOX_ROOT):
+    candidate_str = str(candidate)
+    if candidate.exists() and candidate_str not in sys.path:
+        sys.path.insert(0, candidate_str)
+
+try:
+    import django
+except ModuleNotFoundError:
+    pytest.skip(
+        "Django/NetBox test dependencies are not installed in this environment.",
+        allow_module_level=True,
+    )
+
+os.environ.setdefault("NETBOX_CONFIGURATION", "tests.netbox_test_configuration")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+
+try:
+    django.setup()
+except Exception as exc:  # pragma: no cover - depends on external test services
+    pytest.skip(
+        f"NetBox test environment is not available: {exc}", allow_module_level=True
+    )
+
+from django.contrib.auth import get_user_model  # noqa: E402
+from django.contrib.contenttypes.models import ContentType  # noqa: E402
+from django.db import IntegrityError  # noqa: E402
+from django.test import Client, TestCase  # noqa: E402
+from django.urls import reverse  # noqa: E402
+from users.models import ObjectPermission, Token  # noqa: E402
+from utilities.testing import create_test_virtualmachine  # noqa: E402
+
+from netbox_proxbox.models import ProxmoxVMCloudInit  # noqa: E402
+
+
+class ProxmoxVMCloudInitModelTest(TestCase):
+    """Validate the model surface — uniqueness, defaults, string forms."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.vm = create_test_virtualmachine("cloudinit-vm-1")
+        cls.other_vm = create_test_virtualmachine("cloudinit-vm-2")
+
+    def test_creates_with_minimal_payload(self) -> None:
+        row = ProxmoxVMCloudInit.objects.create(virtual_machine=self.vm)
+        self.assertEqual(row.virtual_machine, self.vm)
+        self.assertEqual(row.ciuser, "")
+        self.assertEqual(row.sshkeys, "")
+        self.assertEqual(row.ipconfig0, "")
+        self.assertFalse(row.sshkeys_truncated)
+        self.assertIsNotNone(row.last_synced)
+
+    def test_string_repr_uses_parent_vm(self) -> None:
+        row = ProxmoxVMCloudInit.objects.create(
+            virtual_machine=self.vm, ciuser="ubuntu"
+        )
+        self.assertIn(str(self.vm), str(row))
+        self.assertIn("cloud-init", str(row))
+
+    def test_one_to_one_enforced(self) -> None:
+        ProxmoxVMCloudInit.objects.create(virtual_machine=self.vm)
+        with self.assertRaises(IntegrityError):
+            ProxmoxVMCloudInit.objects.create(virtual_machine=self.vm)
+
+    def test_reverse_relation_on_vm(self) -> None:
+        row = ProxmoxVMCloudInit.objects.create(
+            virtual_machine=self.vm,
+            ciuser="ubuntu",
+            ipconfig0="ip=dhcp",
+        )
+        self.vm.refresh_from_db()
+        self.assertEqual(self.vm.proxmox_cloudinit, row)
+
+    def test_cascade_delete_with_vm(self) -> None:
+        ProxmoxVMCloudInit.objects.create(virtual_machine=self.other_vm)
+        self.assertTrue(
+            ProxmoxVMCloudInit.objects.filter(virtual_machine=self.other_vm).exists()
+        )
+        self.other_vm.delete()
+        self.assertFalse(
+            ProxmoxVMCloudInit.objects.filter(pk__isnull=False)
+            .filter(virtual_machine_id=self.other_vm.pk)
+            .exists()
+        )
+
+    def test_get_absolute_url(self) -> None:
+        row = ProxmoxVMCloudInit.objects.create(virtual_machine=self.vm)
+        url = row.get_absolute_url()
+        self.assertIn(str(row.pk), url)
+        self.assertIn("vm-cloudinit", url)
+
+
+class ProxmoxVMCloudInitAPITest(TestCase):
+    """proxbox-api must be able to POST / PATCH this endpoint."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.vm = create_test_virtualmachine("cloudinit-api-vm")
+        cls.user = get_user_model().objects.create_user(
+            username="proxbox-api", is_staff=True
+        )
+        cls.token = Token.objects.create(user=cls.user)
+        content_type = ContentType.objects.get_for_model(ProxmoxVMCloudInit)
+        permission = ObjectPermission.objects.create(
+            name="cloudinit-rw",
+            actions=["view", "add", "change", "delete"],
+        )
+        permission.object_types.add(content_type)
+        permission.users.add(cls.user)
+
+    def _auth_headers(self) -> dict[str, str]:
+        return {"HTTP_AUTHORIZATION": f"Token {self.token.key}"}
+
+    def test_post_creates_row(self) -> None:
+        url = reverse("plugins-api:netbox_proxbox-api:proxmoxvmcloudinit-list")
+        response = self.client.post(
+            url,
+            data={
+                "virtual_machine": self.vm.pk,
+                "ciuser": "ubuntu",
+                "sshkeys": "ssh-rsa AAAA test@host\n",
+                "ipconfig0": "ip=dhcp",
+                "sshkeys_truncated": False,
+            },
+            content_type="application/json",
+            **self._auth_headers(),
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+        row = ProxmoxVMCloudInit.objects.get(virtual_machine=self.vm)
+        self.assertEqual(row.ciuser, "ubuntu")
+        self.assertEqual(row.ipconfig0, "ip=dhcp")
+        self.assertIn("ssh-rsa", row.sshkeys)
+
+    def test_list_returns_brief_fields(self) -> None:
+        ProxmoxVMCloudInit.objects.create(
+            virtual_machine=self.vm, ciuser="root", ipconfig0="ip=dhcp"
+        )
+        url = reverse("plugins-api:netbox_proxbox-api:proxmoxvmcloudinit-list")
+        response = self.client.get(url + "?brief=1", **self._auth_headers())
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertGreaterEqual(payload["count"], 1)
+        sample = payload["results"][0]
+        for key in ("id", "url", "display", "virtual_machine", "ciuser"):
+            self.assertIn(key, sample)
+
+
+class ProxmoxVMCloudInitTabTest(TestCase):
+    """The VM detail tab must hide when there is no cloud-init row."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.vm_with = create_test_virtualmachine("cloudinit-tab-on")
+        cls.vm_without = create_test_virtualmachine("cloudinit-tab-off")
+        cls.user = get_user_model().objects.create_user(
+            username="viewer", is_staff=True, is_superuser=True
+        )
+        ProxmoxVMCloudInit.objects.create(
+            virtual_machine=cls.vm_with,
+            ciuser="ubuntu",
+            ipconfig0="ip=dhcp",
+            sshkeys="ssh-rsa AAAA test@host\n",
+        )
+
+    def test_tab_renders_for_vm_with_row(self) -> None:
+        client = Client()
+        client.force_login(self.user)
+        url = reverse(
+            "virtualization:virtualmachine_proxmox_cloudinit", args=[self.vm_with.pk]
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "ubuntu")
+        self.assertContains(response, "ip=dhcp")
+
+    def test_tab_renders_empty_state_when_no_row(self) -> None:
+        client = Client()
+        client.force_login(self.user)
+        url = reverse(
+            "virtualization:virtualmachine_proxmox_cloudinit", args=[self.vm_without.pk]
+        )
+        response = client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "No Proxmox cloud-init record")


### PR DESCRIPTION
Closes #363 (paired with `emersonfelipesp/proxbox-api` companion PR).

## Summary

Replaces the issue's NetBox custom-field approach with a first-class plugin model so the read-side cloud-init reflection (`ciuser`, `sshkeys`, `ipconfig0`) lives in NetBox as a normal queryable row instead of opaque JSON in `custom_field_data`.

New surface:

- **`ProxmoxVMCloudInit`** (`models/vm_cloudinit.py`) — `OneToOneField` to `virtualization.VirtualMachine` (cascade-delete with VM), `ciuser` / `sshkeys` / `ipconfig0` / `sshkeys_truncated` / `last_synced` fields.
- **Migration `0043_proxmoxvmcloudinit`** — creates the model table.
- **Migration `0044_overwrite_vm_cloudinit`** — adds the `overwrite_vm_cloudinit` boolean to `ProxboxPluginSettings` (default `True`), mirroring the existing `overwrite_vm_*` pattern.
- **DRF viewset + filterset + serializer** at `/api/plugins/proxbox/vm-cloudinit/`, consumed by proxbox-api via `rest_reconcile_async`.
- **List/detail/tab views + templates** (`vm_cloudinit.py`, `vm_proxmox_cloudinit.html`). The VM detail "Proxmox cloud-init" tab is gated on `hasattr(vm, 'proxmox_cloudinit')` and the form sets every field to `disabled=True` to enforce read-only.
- **Tests** (`tests/test_vm_cloudinit.py`) — model invariants (uniqueness, cascade, reverse accessor), API permission matrix, tab gating empty + populated states.

LXC and multi-NIC `ipconfig1..N` are out of scope per the issue body.

## Test plan

- [ ] Local NetBox 4.6 test env: `python manage.py test netbox_proxbox.tests` covers model/API/tab.
- [ ] Live dev stack (`http://10.0.30.207:10000`): trigger a sync, hit `GET /api/plugins/proxbox/vm-cloudinit/?virtual_machine_id=<id>`, confirm decoded `sshkeys` (no `%0A`), confirm second sync produces zero `ObjectChange` rows for the endpoint.
- [ ] Flip `overwrite_vm_cloudinit=False`, mutate `ciuser` Proxmox-side, re-sync, confirm the row does not change.
- [ ] Inject >10 KB `sshkeys`, confirm truncation sentinel and `sshkeys_truncated=True`.

## Companion PR

- `emersonfelipesp/proxbox-api#NNN` — declares cloud-init fields on `VMConfig` / `ProxmoxVmConfigInput`, decodes `sshkeys`, and POSTs/PATCHes this plugin endpoint after each VM upsert.