### PR TITLE
feat(#373): add `pxb sync run` to wrap the proxbox_sync management command

### DIFF
--- a/docs/cli/sync.md
+++ b/docs/cli/sync.md
@@ -1,0 +1,121 @@
+# `pxb sync run`
+
+`pxb sync run` is the operator-friendly trigger for a full Proxmox→NetBox sync.
+It wraps the [`proxbox_sync` Django management command](../operations/headless-sync.md)
+as a subprocess, auto-locates NetBox's `manage.py` and the venv interpreter
+that should run it, and forwards stdout, stderr, and the exit code back to
+the terminal.
+
+This is the same primitive as the plugin UI's **Full Update** button, the
+`netbox-rq`-scheduled job, and the bare `python manage.py proxbox_sync`
+invocation — just with a single, predictable CLI surface that does not require
+knowing where NetBox lives on disk.
+
+## When to use which trigger
+
+| Trigger | Best for |
+|---|---|
+| Plugin UI → **Full Update** | Interactive operator runs from the browser. |
+| `python manage.py proxbox_sync` | Cron jobs and systemd timers that already know the NetBox path. |
+| `pxb sync run` | Operators on the shell who want one command regardless of host layout. |
+
+## Examples
+
+### Enqueue and exit
+
+```bash
+pxb sync run
+```
+
+Resolves `manage.py`, enqueues a `ProxboxSyncJob` on the default RQ queue,
+prints `Enqueued ProxboxSyncJob (pk=N)`, and exits 0. The RQ worker picks
+the job up; check its progress in the NetBox UI under **Background Tasks**.
+
+### Wait for completion with live progress
+
+```bash
+pxb sync run --wait --timeout 600
+```
+
+Blocks until the job reaches a terminal state. The management command's
+poll loop writes a progress line every `--poll-interval` seconds (default
+2.0s); the CLI relays each line as it arrives, with `completed` in green
+and `errored` / `failed` in red. Exit code mirrors the job:
+`0` for `completed`, non-zero for `errored` / `failed` / timeout.
+
+`--worker-grace` (default 30s) fast-fails when the job stays pending and
+no RQ worker is consuming the default queue.
+
+### Machine-readable output
+
+```bash
+pxb sync run --json | jq '.job_pk'
+```
+
+Emits a single JSON document at exit. `--json` captures the merged
+stdout/stderr stream as a single `output` field rather than streaming it,
+which is the right shape for log aggregators and CI step parsers.
+
+Schema:
+
+```json
+{
+  "exit_code": 0,
+  "success": true,
+  "job_pk": 42,
+  "manage_py": "/opt/netbox/manage.py",
+  "command": ["/opt/netbox/venv/bin/python", "-u", "/opt/netbox/manage.py", "proxbox_sync", "--poll-interval", "2.0", "--worker-grace", "30.0"],
+  "output": "Enqueued ProxboxSyncJob (pk=42) on queue 'default' for 1 Proxmox endpoint(s), attributed to user 'admin'.\n"
+}
+```
+
+`job_pk` is `null` when the management command exits before enqueuing
+(for example when no `ProxmoxEndpoint` records are configured).
+
+## `manage.py` resolution
+
+The CLI checks each source in order and uses the first match:
+
+1. `--netbox-path FILE_OR_DIR` (explicit override).
+2. Walk up from the current working directory, looking at each ancestor's
+   `manage.py`. The match must look like a NetBox install — its sibling
+   `netbox/settings.py` contains `from netbox.plugins`, or
+   `netbox/configuration_example.py` exists. Non-NetBox matches are skipped
+   so the walk continues past unrelated Django projects.
+3. `$NETBOX_PATH` environment variable — accepts either a file path or a
+   directory containing `manage.py`.
+4. `/opt/netbox/manage.py` (the canonical install path used by
+   [`docs/operations/headless-sync.md`](../operations/headless-sync.md)).
+5. `netbox_manage_py` from `~/.config/proxbox-cli/config.json`.
+
+If every source is exhausted, `pxb sync run` exits non-zero with:
+
+```text
+Error: could not find manage.py — set $NETBOX_PATH or run from inside the project tree
+```
+
+## Interpreter resolution
+
+The locate helper resolves `manage.py` first (so symlinks like `/opt/netbox`
+point at the real install dir), then prefers
+`<resolved_parent>/venv/bin/python` when it exists, and falls back to
+`Path(sys.executable)`. This matters because `sys.executable` is the *CLI's*
+interpreter (often a pipx-managed venv) — NetBox has its own venv with the
+plugin installed, and the management command must run inside that one.
+
+## Flags
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--wait` | off | Block until the job is in a terminal state. |
+| `--timeout SECONDS` | `PROXBOX_SYNC_JOB_TIMEOUT` (7200) | Max wait when `--wait` is set. |
+| `--poll-interval SECONDS` | `2.0` | Seconds between status polls. |
+| `--worker-grace SECONDS` | `30.0` | Fast-fail when no worker takes the job. |
+| `--user USERNAME` | oldest active superuser | Owner attribution for the enqueued job. |
+| `--json` | off | Emit JSON at exit instead of streaming. |
+| `--netbox-path PATH` | — | Override the `manage.py` resolution chain. |
+
+## See also
+
+- [`docs/operations/headless-sync.md`](../operations/headless-sync.md) — the
+  management command this wraps, plus cron/systemd guidance.

--- a/proxbox_cli/__init__.py
+++ b/proxbox_cli/__init__.py
@@ -23,6 +23,7 @@ from proxbox_cli.commands.extras import extras_app
 from proxbox_cli.commands.netbox import netbox_app
 from proxbox_cli.commands.proxmox import proxmox_app
 from proxbox_cli.commands.proxbox import proxbox_app
+from proxbox_cli.commands.sync import sync_app
 from proxbox_cli.commands.virtualization import virtualization_app
 from proxbox_cli.config import Config, load_config, normalize_base_url, save_config
 from proxbox_cli.runtime import _cache_config, _ensure_config, _get_client
@@ -46,6 +47,7 @@ app.add_typer(proxbox_app, name="proxbox")
 app.add_typer(dcim_app, name="dcim")
 app.add_typer(virtualization_app, name="virtualization")
 app.add_typer(extras_app, name="extras")
+app.add_typer(sync_app, name="sync")
 
 docs_app = typer.Typer(no_args_is_help=True, help="Documentation generation commands.")
 app.add_typer(docs_app, name="docs")

--- a/proxbox_cli/_locate_manage.py
+++ b/proxbox_cli/_locate_manage.py
@@ -1,0 +1,142 @@
+"""Resolve the NetBox ``manage.py`` and the interpreter that should run it.
+
+Used by ``pxb sync run`` to invoke ``manage.py proxbox_sync`` as a subprocess
+without the operator having to know where NetBox is installed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+NETBOX_PATH_ENV_VAR = "NETBOX_PATH"
+DEFAULT_NETBOX_PATH = Path("/opt/netbox/manage.py")
+
+NOT_FOUND_MESSAGE = (
+    "could not find manage.py — set $NETBOX_PATH or run from inside the "
+    "project tree"
+)
+
+
+class ManageLocation(NamedTuple):
+    """Resolved ``manage.py`` and the interpreter to invoke it with."""
+
+    manage_py: Path
+    python: Path
+
+
+class ManagePyNotFoundError(RuntimeError):
+    """Raised when no ``manage.py`` could be located via any source."""
+
+
+def _is_netbox_install(manage_py: Path) -> bool:
+    """Return True when ``manage.py``'s siblings look like a NetBox install.
+
+    The check resolves ``manage.py`` first so symlinks (e.g. ``/opt/netbox``
+    pointing at a versioned dir) point at the real install. The heuristic
+    accepts either ``netbox/settings.py`` containing the literal
+    ``from netbox.plugins`` import or the presence of
+    ``netbox/configuration_example.py`` — the latter ships with every
+    NetBox release.
+    """
+    try:
+        resolved = manage_py.resolve()
+    except OSError:
+        return False
+
+    netbox_dir = resolved.parent / "netbox"
+    if (netbox_dir / "configuration_example.py").exists():
+        return True
+
+    settings = netbox_dir / "settings.py"
+    if not settings.exists():
+        return False
+    try:
+        return "from netbox.plugins" in settings.read_text(
+            encoding="utf-8", errors="replace"
+        )
+    except OSError:
+        return False
+
+
+def _resolve_interpreter(manage_py: Path) -> Path:
+    """Prefer the venv shipped next to ``manage.py``; fall back to ``sys.executable``."""
+    try:
+        resolved_parent = manage_py.resolve().parent
+    except OSError:
+        resolved_parent = manage_py.parent
+
+    venv_python = resolved_parent / "venv" / "bin" / "python"
+    if venv_python.exists():
+        return venv_python
+    return Path(sys.executable)
+
+
+def _candidate_from_path_like(value: str | Path) -> Path | None:
+    """Accept either a directory containing ``manage.py`` or a direct file path."""
+    p = Path(value).expanduser()
+    if p.is_dir():
+        candidate = p / "manage.py"
+        return candidate if candidate.is_file() else None
+    if p.is_file():
+        return p
+    return None
+
+
+def locate_manage_py(
+    *,
+    override: Path | None = None,
+    config_manage_py: str | None = None,
+) -> ManageLocation:
+    """Resolve ``manage.py`` via the documented chain.
+
+    Resolution order:
+
+    1. ``override`` (typically ``--netbox-path``)
+    2. Walk up from ``Path.cwd()``, applying the NetBox heuristic at each
+       ancestor; non-NetBox ``manage.py`` files are skipped so the walk
+       continues past unrelated Django projects.
+    3. ``$NETBOX_PATH`` environment variable (file or directory).
+    4. :data:`DEFAULT_NETBOX_PATH` (``/opt/netbox/manage.py``).
+    5. ``config_manage_py`` (from ``~/.config/proxbox-cli/config.json``).
+    6. Otherwise raise :class:`ManagePyNotFoundError`.
+
+    Sources other than the walk-up are accepted as-is (the operator made an
+    explicit choice). Only the walk-up applies the NetBox heuristic, which
+    protects against an unrelated Django project on a parent directory.
+    """
+    if override is not None:
+        candidate = _candidate_from_path_like(override)
+        if candidate is not None:
+            return ManageLocation(candidate, _resolve_interpreter(candidate))
+
+    try:
+        start = Path.cwd().resolve()
+    except OSError:
+        start = None
+
+    if start is not None:
+        for ancestor in (start, *start.parents):
+            candidate = ancestor / "manage.py"
+            if candidate.is_file() and _is_netbox_install(candidate):
+                return ManageLocation(candidate, _resolve_interpreter(candidate))
+
+    env_value = os.environ.get(NETBOX_PATH_ENV_VAR, "").strip()
+    if env_value:
+        candidate = _candidate_from_path_like(env_value)
+        if candidate is not None:
+            return ManageLocation(candidate, _resolve_interpreter(candidate))
+
+    if DEFAULT_NETBOX_PATH.is_file():
+        return ManageLocation(
+            DEFAULT_NETBOX_PATH, _resolve_interpreter(DEFAULT_NETBOX_PATH)
+        )
+
+    if config_manage_py:
+        candidate = _candidate_from_path_like(config_manage_py)
+        if candidate is not None:
+            return ManageLocation(candidate, _resolve_interpreter(candidate))
+
+    raise ManagePyNotFoundError(NOT_FOUND_MESSAGE)

--- a/proxbox_cli/_locate_manage.py
+++ b/proxbox_cli/_locate_manage.py
@@ -15,8 +15,7 @@ NETBOX_PATH_ENV_VAR = "NETBOX_PATH"
 DEFAULT_NETBOX_PATH = Path("/opt/netbox/manage.py")
 
 NOT_FOUND_MESSAGE = (
-    "could not find manage.py — set $NETBOX_PATH or run from inside the "
-    "project tree"
+    "could not find manage.py — set $NETBOX_PATH or run from inside the project tree"
 )
 
 

--- a/proxbox_cli/commands/sync.py
+++ b/proxbox_cli/commands/sync.py
@@ -19,9 +19,7 @@ from proxbox_cli._locate_manage import (
 from proxbox_cli.config import load_config
 from proxbox_cli.support import console, emit_cli_error, stderr
 
-sync_app = typer.Typer(
-    no_args_is_help=True, help="Run Proxbox sync jobs from the CLI."
-)
+sync_app = typer.Typer(no_args_is_help=True, help="Run Proxbox sync jobs from the CLI.")
 
 JOB_PK_RE = re.compile(r"\(pk=(\d+)\)")
 COMPLETE_RE = re.compile(r"\bcompleted\b", re.IGNORECASE)

--- a/proxbox_cli/commands/sync.py
+++ b/proxbox_cli/commands/sync.py
@@ -1,0 +1,241 @@
+"""CLI commands for triggering Proxbox sync jobs."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+from proxbox_cli._locate_manage import (
+    ManagePyNotFoundError,
+    locate_manage_py,
+)
+from proxbox_cli.config import load_config
+from proxbox_cli.support import console, emit_cli_error, stderr
+
+sync_app = typer.Typer(
+    no_args_is_help=True, help="Run Proxbox sync jobs from the CLI."
+)
+
+JOB_PK_RE = re.compile(r"\(pk=(\d+)\)")
+COMPLETE_RE = re.compile(r"\bcompleted\b", re.IGNORECASE)
+FAIL_RE = re.compile(r"\b(errored|failed)\b", re.IGNORECASE)
+TERMINATE_GRACE_SECONDS = 5.0
+
+
+def _extract_job_pk(output: str) -> int | None:
+    match = JOB_PK_RE.search(output)
+    return int(match.group(1)) if match else None
+
+
+def _style_line(line: str) -> str:
+    """Apply prefix coloring for terminal lines without adding new content."""
+    stripped = line.rstrip("\n")
+    if FAIL_RE.search(stripped):
+        return f"[red]{stripped}[/red]"
+    if COMPLETE_RE.search(stripped):
+        return f"[green]{stripped}[/green]"
+    return stripped
+
+
+def _build_argv(
+    *,
+    python: Path,
+    manage_py: Path,
+    wait: bool,
+    timeout: int | None,
+    poll_interval: float,
+    worker_grace: float,
+    user: str | None,
+) -> list[str]:
+    argv: list[str] = [
+        str(python),
+        "-u",
+        str(manage_py),
+        "proxbox_sync",
+    ]
+    if user:
+        argv.extend(["--user", user])
+    if wait:
+        argv.append("--wait")
+    if timeout is not None:
+        argv.extend(["--timeout", str(timeout)])
+    argv.extend(["--poll-interval", str(poll_interval)])
+    argv.extend(["--worker-grace", str(worker_grace)])
+    return argv
+
+
+@sync_app.command("run")
+def run_sync(
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            help="Block until the job reaches a terminal state; mirror its exit code.",
+        ),
+    ] = False,
+    timeout: Annotated[
+        Optional[int],
+        typer.Option(
+            "--timeout",
+            help=(
+                "Max seconds to wait when --wait is set. "
+                "Defaults to the management command's PROXBOX_SYNC_JOB_TIMEOUT (7200)."
+            ),
+        ),
+    ] = None,
+    poll_interval: Annotated[
+        float,
+        typer.Option(
+            "--poll-interval",
+            help="Seconds between job-status polls when --wait is set.",
+        ),
+    ] = 2.0,
+    worker_grace: Annotated[
+        float,
+        typer.Option(
+            "--worker-grace",
+            help=(
+                "Seconds to wait for an RQ worker on the default queue before "
+                "failing fast when --wait is set."
+            ),
+        ),
+    ] = 30.0,
+    user: Annotated[
+        Optional[str],
+        typer.Option(
+            "--user",
+            help=(
+                "Username to attribute the enqueued job to. "
+                "Defaults to the oldest active superuser."
+            ),
+        ),
+    ] = None,
+    json_out: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Emit a single JSON document at exit instead of streaming output.",
+        ),
+    ] = False,
+    netbox_path: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--netbox-path",
+            help=(
+                "Path to NetBox's manage.py (or a directory containing it). "
+                "Overrides the walk-up, $NETBOX_PATH, and default-path resolution."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Enqueue a full Proxmox→NetBox sync via the proxbox_sync management command."""
+    cfg = load_config()
+
+    try:
+        location = locate_manage_py(
+            override=netbox_path,
+            config_manage_py=cfg.netbox_manage_py,
+        )
+    except ManagePyNotFoundError as exc:
+        emit_cli_error(str(exc))
+
+    argv = _build_argv(
+        python=location.python,
+        manage_py=location.manage_py,
+        wait=wait,
+        timeout=timeout,
+        poll_interval=poll_interval,
+        worker_grace=worker_grace,
+        user=user,
+    )
+
+    env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+    # stderr=STDOUT is deliberate: merging into one stream avoids the
+    # deadlock that splitting them risks (a child blocked on its stderr
+    # write would hang us while we're blocked on a stdout read). The
+    # management command writes errors through Django's styled
+    # `CommandError` / `self.stderr.write`, which keeps the merged output
+    # readable.
+    proc = subprocess.Popen(  # noqa: S603 — argv is composed from validated inputs
+        argv,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        bufsize=1,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
+
+    try:
+        if json_out:
+            output, exit_code = _drain_for_json(proc, wait=wait, timeout=timeout)
+            payload = {
+                "exit_code": exit_code,
+                "success": exit_code == 0,
+                "job_pk": _extract_job_pk(output),
+                "manage_py": str(location.manage_py),
+                "command": argv,
+                "output": output,
+            }
+            # Bypass Rich so the JSON document is unstyled and pipe-safe.
+            sys.stdout.write(json.dumps(payload, indent=2))
+            sys.stdout.write("\n")
+            sys.stdout.flush()
+        else:
+            exit_code = _stream_lines(proc)
+    except KeyboardInterrupt:
+        _terminate(proc)
+        raise
+
+    raise typer.Exit(code=exit_code)
+
+
+def _stream_lines(proc: subprocess.Popen[str]) -> int:
+    """Relay the child's merged stdout/stderr line-by-line to the Rich console."""
+    assert proc.stdout is not None  # noqa: S101 — Popen above always sets stdout
+    try:
+        for line in proc.stdout:
+            console.print(_style_line(line), markup=True, highlight=False)
+    except KeyboardInterrupt:
+        _terminate(proc)
+        raise
+    return proc.wait()
+
+
+def _drain_for_json(
+    proc: subprocess.Popen[str],
+    *,
+    wait: bool,
+    timeout: int | None,
+) -> tuple[str, int]:
+    """Wait for the subprocess and capture its merged output as a single string."""
+    communicate_timeout = (timeout + 60) if (wait and timeout) else None
+    try:
+        stdout_data, _ = proc.communicate(timeout=communicate_timeout)
+    except subprocess.TimeoutExpired:
+        _terminate(proc)
+        stdout_data, _ = proc.communicate()
+        return stdout_data or "", proc.returncode if proc.returncode is not None else 1
+    return stdout_data or "", proc.returncode
+
+
+def _terminate(proc: subprocess.Popen[str]) -> None:
+    """Send SIGTERM, wait briefly, then SIGKILL if the child is still alive."""
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=TERMINATE_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    except Exception as exc:  # noqa: BLE001 — best-effort cleanup, never re-raise
+        stderr.print(f"[yellow]Could not terminate subprocess cleanly: {exc}[/yellow]")

--- a/proxbox_cli/config.py
+++ b/proxbox_cli/config.py
@@ -12,6 +12,7 @@ DEFAULT_CONFIG_DIR = "proxbox-cli"
 DEFAULT_CONFIG_FILENAME = "config.json"
 DEFAULT_BASE_URL = "http://localhost:8000"
 BASE_URL_ENV_VAR = "PROXBOX_URL"
+NETBOX_PATH_ENV_VAR = "NETBOX_PATH"
 
 
 class Config(BaseModel):
@@ -19,6 +20,7 @@ class Config(BaseModel):
 
     base_url: str = DEFAULT_BASE_URL
     timeout: float = 30.0
+    netbox_manage_py: str | None = None
 
 
 def config_dir() -> Path:

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -242,7 +242,9 @@ def test_netbox_path_override(
 
     def capturing_locate(**kwargs: Any) -> ManageLocation:
         captured.update(kwargs)
-        return ManageLocation(manage_py=Path("/some/manage.py"), python=Path(sys.executable))
+        return ManageLocation(
+            manage_py=Path("/some/manage.py"), python=Path(sys.executable)
+        )
 
     monkeypatch.setattr(sync_module, "locate_manage_py", capturing_locate)
     monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -1,0 +1,268 @@
+"""Tests for the ``pxb sync run`` Typer command."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+for module_name in ("click", "typer", "rich"):
+    pytest.importorskip(module_name)
+
+from typer.testing import CliRunner  # noqa: E402 — guarded by importorskip above
+
+import proxbox_cli  # noqa: E402
+from proxbox_cli import _locate_manage  # noqa: E402
+from proxbox_cli._locate_manage import (  # noqa: E402
+    ManageLocation,
+    ManagePyNotFoundError,
+)
+from proxbox_cli.commands import sync as sync_module  # noqa: E402
+
+
+class FakePopen:
+    """Minimal ``subprocess.Popen`` stand-in for argv capture and output replay.
+
+    Captures the argv/kwargs the CLI passes through, replays a canned
+    `stdout` stream (with merged stderr per the production design), and
+    exposes the lifecycle hooks the production code calls.
+    """
+
+    instances: list[FakePopen] = []
+
+    def __init__(
+        self,
+        argv: list[str],
+        *,
+        output: str = "",
+        returncode: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        self.argv = argv
+        self.kwargs = kwargs
+        self._output = output
+        self.returncode = returncode
+        self.stdout = io.StringIO(output)
+        self._terminated = False
+        FakePopen.instances.append(self)
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.instances = []
+
+    def wait(self, timeout: float | None = None) -> int:  # noqa: ARG002
+        return self.returncode
+
+    def communicate(self, timeout: float | None = None) -> tuple[str, str]:  # noqa: ARG002
+        return self._output, ""
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self._terminated = True
+
+    def kill(self) -> None:
+        self._terminated = True
+
+
+def _popen_factory(output: str = "", returncode: int = 0):
+    def factory(argv: list[str], **kwargs: Any) -> FakePopen:
+        return FakePopen(argv, output=output, returncode=returncode, **kwargs)
+
+    return factory
+
+
+@pytest.fixture(autouse=True)
+def _stub_locate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every test resolves manage.py to a deterministic stub location."""
+    FakePopen.reset()
+    fake_manage = Path("/opt/netbox/manage.py")
+    fake_python = Path("/opt/netbox/venv/bin/python")
+    location = ManageLocation(manage_py=fake_manage, python=fake_python)
+    monkeypatch.setattr(sync_module, "locate_manage_py", lambda **_: location)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _invoke(runner: CliRunner, args: list[str]):
+    return runner.invoke(proxbox_cli.app, ["sync", "run", *args])
+
+
+def test_run_no_flags_argv(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())
+    result = _invoke(runner, [])
+    assert result.exit_code == 0
+    assert len(FakePopen.instances) == 1
+    argv = FakePopen.instances[0].argv
+    assert argv[:4] == [
+        "/opt/netbox/venv/bin/python",
+        "-u",
+        "/opt/netbox/manage.py",
+        "proxbox_sync",
+    ]
+    assert "--wait" not in argv
+    assert "--user" not in argv
+    assert "--timeout" not in argv
+    assert "--poll-interval" in argv
+    assert "--worker-grace" in argv
+
+
+def test_run_wait_flag(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())
+    result = _invoke(runner, ["--wait"])
+    assert result.exit_code == 0
+    assert "--wait" in FakePopen.instances[0].argv
+
+
+def test_run_user_flag(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())
+    result = _invoke(runner, ["--user", "admin"])
+    assert result.exit_code == 0
+    argv = FakePopen.instances[0].argv
+    assert argv[argv.index("--user") + 1] == "admin"
+
+
+def test_run_timeout_flag(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())
+    result = _invoke(runner, ["--timeout", "120"])
+    assert result.exit_code == 0
+    argv = FakePopen.instances[0].argv
+    assert argv[argv.index("--timeout") + 1] == "120"
+
+
+def test_run_poll_interval_flag(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())
+    result = _invoke(runner, ["--poll-interval", "0.5"])
+    assert result.exit_code == 0
+    argv = FakePopen.instances[0].argv
+    assert argv[argv.index("--poll-interval") + 1] == "0.5"
+
+
+def test_run_worker_grace_flag(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())
+    result = _invoke(runner, ["--worker-grace", "10"])
+    assert result.exit_code == 0
+    argv = FakePopen.instances[0].argv
+    assert argv[argv.index("--worker-grace") + 1] == "10.0"
+
+
+def test_run_exit_code_forwarded_zero(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        sync_module.subprocess,
+        "Popen",
+        _popen_factory(output="Enqueued ProxboxSyncJob (pk=7)\n", returncode=0),
+    )
+    result = _invoke(runner, [])
+    assert result.exit_code == 0
+
+
+def test_run_exit_code_forwarded_nonzero(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        sync_module.subprocess,
+        "Popen",
+        _popen_factory(output="CommandError: backend unreachable\n", returncode=1),
+    )
+    result = _invoke(runner, [])
+    assert result.exit_code == 1
+
+
+def test_json_mode_shape(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    output = "Enqueued ProxboxSyncJob (pk=42) on queue 'default'\n"
+    monkeypatch.setattr(
+        sync_module.subprocess,
+        "Popen",
+        _popen_factory(output=output, returncode=0),
+    )
+    result = _invoke(runner, ["--json"])
+    assert result.exit_code == 0
+    # Locate the JSON document — the CliRunner captures stdout via Rich.
+    # The CLI bypasses Rich for the JSON write, so `result.stdout` carries it.
+    payload = json.loads(result.stdout)
+    assert payload["exit_code"] == 0
+    assert payload["success"] is True
+    assert payload["job_pk"] == 42
+    assert payload["manage_py"] == "/opt/netbox/manage.py"
+    assert payload["command"][0] == "/opt/netbox/venv/bin/python"
+    assert "Enqueued" in payload["output"]
+
+
+def test_json_mode_job_pk_none_when_absent(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        sync_module.subprocess,
+        "Popen",
+        _popen_factory(output="No ProxmoxEndpoint records configured\n", returncode=0),
+    )
+    result = _invoke(runner, ["--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["job_pk"] is None
+
+
+def test_locate_failure_exits_nonzero(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def raising_locate(**_: Any) -> ManageLocation:
+        raise ManagePyNotFoundError(
+            "could not find manage.py — set $NETBOX_PATH or run from "
+            "inside the project tree"
+        )
+
+    monkeypatch.setattr(sync_module, "locate_manage_py", raising_locate)
+    monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())
+    result = _invoke(runner, [])
+    assert result.exit_code != 0
+    # The subprocess must not have been launched.
+    assert FakePopen.instances == []
+
+
+def test_netbox_path_override(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def capturing_locate(**kwargs: Any) -> ManageLocation:
+        captured.update(kwargs)
+        return ManageLocation(manage_py=Path("/some/manage.py"), python=Path(sys.executable))
+
+    monkeypatch.setattr(sync_module, "locate_manage_py", capturing_locate)
+    monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())
+    custom = tmp_path / "custom" / "manage.py"
+    custom.parent.mkdir()
+    custom.write_text("")
+    result = _invoke(runner, ["--netbox-path", str(custom)])
+    assert result.exit_code == 0
+    assert captured["override"] == custom
+
+
+def test_popen_uses_merged_stream(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: stderr must be merged into stdout to avoid pipe deadlock."""
+    monkeypatch.setattr(sync_module.subprocess, "Popen", _popen_factory())
+    _invoke(runner, [])
+    kwargs = FakePopen.instances[0].kwargs
+    assert kwargs["stderr"] == sync_module.subprocess.STDOUT
+    assert kwargs["stdout"] == sync_module.subprocess.PIPE
+    assert kwargs["bufsize"] == 1
+    assert kwargs["text"] is True
+    assert kwargs["env"]["PYTHONUNBUFFERED"] == "1"

--- a/tests/test_locate_manage.py
+++ b/tests/test_locate_manage.py
@@ -38,7 +38,9 @@ def _make_django_only_install(root: Path) -> Path:
 def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make every test start with no NETBOX_PATH and a guaranteed-missing default."""
     monkeypatch.delenv(NETBOX_PATH_ENV_VAR, raising=False)
-    monkeypatch.setattr(_locate_manage, "DEFAULT_NETBOX_PATH", Path("/nonexistent-default"))
+    monkeypatch.setattr(
+        _locate_manage, "DEFAULT_NETBOX_PATH", Path("/nonexistent-default")
+    )
 
 
 def test_override_file(tmp_path: Path) -> None:
@@ -89,9 +91,7 @@ def test_walk_up_hits_filesystem_root(
     assert NETBOX_PATH_ENV_VAR in str(exc.value)
 
 
-def test_env_var_as_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_env_var_as_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     manage_py = _make_netbox_install(tmp_path)
     empty = tmp_path.parent / f"empty-{tmp_path.name}"
     empty.mkdir(exist_ok=True)
@@ -101,9 +101,7 @@ def test_env_var_as_directory(
     assert location.manage_py == manage_py
 
 
-def test_env_var_as_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_env_var_as_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     manage_py = _make_netbox_install(tmp_path)
     empty = tmp_path.parent / f"empty-file-{tmp_path.name}"
     empty.mkdir(exist_ok=True)
@@ -113,9 +111,7 @@ def test_env_var_as_file(
     assert location.manage_py == manage_py
 
 
-def test_env_var_nonexistent(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_env_var_nonexistent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     empty = tmp_path / "empty"
     empty.mkdir()
     monkeypatch.chdir(empty)
@@ -124,9 +120,7 @@ def test_env_var_nonexistent(
         locate_manage_py()
 
 
-def test_default_path_fallback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_default_path_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     manage_py = _make_netbox_install(tmp_path)
     monkeypatch.setattr(_locate_manage, "DEFAULT_NETBOX_PATH", manage_py)
     empty = tmp_path.parent / f"empty-default-{tmp_path.name}"
@@ -136,9 +130,7 @@ def test_default_path_fallback(
     assert location.manage_py == manage_py
 
 
-def test_config_fallback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_config_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     manage_py = _make_netbox_install(tmp_path)
     empty = tmp_path.parent / f"empty-cfg-{tmp_path.name}"
     empty.mkdir(exist_ok=True)
@@ -186,8 +178,7 @@ def test_netbox_heuristic_via_settings_import(
     netbox_dir = root / "netbox"
     netbox_dir.mkdir()
     (netbox_dir / "settings.py").write_text(
-        "from netbox.plugins import PluginConfig\n"
-        "INSTALLED_APPS = ['core', 'dcim']\n"
+        "from netbox.plugins import PluginConfig\nINSTALLED_APPS = ['core', 'dcim']\n"
     )
     # No configuration_example.py here — the import-substring branch must
     # carry this on its own.

--- a/tests/test_locate_manage.py
+++ b/tests/test_locate_manage.py
@@ -1,0 +1,230 @@
+"""Tests for proxbox_cli._locate_manage."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from proxbox_cli import _locate_manage
+from proxbox_cli._locate_manage import (
+    ManageLocation,
+    ManagePyNotFoundError,
+    NETBOX_PATH_ENV_VAR,
+    locate_manage_py,
+)
+
+
+def _make_netbox_install(root: Path) -> Path:
+    """Create a fake NetBox install at ``root``; return the manage.py path."""
+    manage_py = root / "manage.py"
+    manage_py.write_text("#!/usr/bin/env python\n")
+    netbox_dir = root / "netbox"
+    netbox_dir.mkdir()
+    (netbox_dir / "configuration_example.py").write_text("# example config\n")
+    return manage_py
+
+
+def _make_django_only_install(root: Path) -> Path:
+    """Create a non-NetBox Django project at ``root``; return the manage.py path."""
+    manage_py = root / "manage.py"
+    manage_py.write_text("#!/usr/bin/env python\n")
+    (root / "settings.py").write_text("INSTALLED_APPS = []\n")
+    return manage_py
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every test start with no NETBOX_PATH and a guaranteed-missing default."""
+    monkeypatch.delenv(NETBOX_PATH_ENV_VAR, raising=False)
+    monkeypatch.setattr(_locate_manage, "DEFAULT_NETBOX_PATH", Path("/nonexistent-default"))
+
+
+def test_override_file(tmp_path: Path) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    location = locate_manage_py(override=manage_py)
+    assert location.manage_py == manage_py
+
+
+def test_override_directory(tmp_path: Path) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    location = locate_manage_py(override=tmp_path)
+    assert location.manage_py == manage_py
+
+
+def test_walk_up_finds_valid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    deep = tmp_path / "netbox" / "deep" / "nested"
+    deep.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(deep)
+    location = locate_manage_py()
+    assert location.manage_py == manage_py
+
+
+def test_walk_up_skips_invalid_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    mid = root / "mid"
+    leaf = mid / "leaf"
+    leaf.mkdir(parents=True)
+
+    _make_netbox_install(root)
+    _make_django_only_install(mid)
+
+    monkeypatch.chdir(leaf)
+    location = locate_manage_py()
+    assert location.manage_py == root / "manage.py"
+
+
+def test_walk_up_hits_filesystem_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.chdir(empty)
+    with pytest.raises(ManagePyNotFoundError) as exc:
+        locate_manage_py()
+    assert NETBOX_PATH_ENV_VAR in str(exc.value)
+
+
+def test_env_var_as_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    empty = tmp_path.parent / f"empty-{tmp_path.name}"
+    empty.mkdir(exist_ok=True)
+    monkeypatch.chdir(empty)
+    monkeypatch.setenv(NETBOX_PATH_ENV_VAR, str(tmp_path))
+    location = locate_manage_py()
+    assert location.manage_py == manage_py
+
+
+def test_env_var_as_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    empty = tmp_path.parent / f"empty-file-{tmp_path.name}"
+    empty.mkdir(exist_ok=True)
+    monkeypatch.chdir(empty)
+    monkeypatch.setenv(NETBOX_PATH_ENV_VAR, str(manage_py))
+    location = locate_manage_py()
+    assert location.manage_py == manage_py
+
+
+def test_env_var_nonexistent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.chdir(empty)
+    monkeypatch.setenv(NETBOX_PATH_ENV_VAR, str(tmp_path / "does-not-exist"))
+    with pytest.raises(ManagePyNotFoundError):
+        locate_manage_py()
+
+
+def test_default_path_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    monkeypatch.setattr(_locate_manage, "DEFAULT_NETBOX_PATH", manage_py)
+    empty = tmp_path.parent / f"empty-default-{tmp_path.name}"
+    empty.mkdir(exist_ok=True)
+    monkeypatch.chdir(empty)
+    location = locate_manage_py()
+    assert location.manage_py == manage_py
+
+
+def test_config_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    empty = tmp_path.parent / f"empty-cfg-{tmp_path.name}"
+    empty.mkdir(exist_ok=True)
+    monkeypatch.chdir(empty)
+    location = locate_manage_py(config_manage_py=str(manage_py))
+    assert location.manage_py == manage_py
+
+
+def test_all_exhausted_raises_actionable_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.chdir(empty)
+    with pytest.raises(ManagePyNotFoundError) as exc:
+        locate_manage_py()
+    msg = str(exc.value)
+    assert NETBOX_PATH_ENV_VAR in msg
+    assert "manage.py" in msg
+
+
+def test_interpreter_prefers_venv(tmp_path: Path) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_python = venv_bin / "python"
+    venv_python.write_text("#!/bin/sh\n")
+    location = locate_manage_py(override=manage_py)
+    assert location.python == venv_python
+
+
+def test_interpreter_falls_back_to_sys_executable(tmp_path: Path) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    location = locate_manage_py(override=manage_py)
+    assert location.python == Path(sys.executable)
+
+
+def test_netbox_heuristic_via_settings_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    manage_py = root / "manage.py"
+    manage_py.write_text("#!/usr/bin/env python\n")
+    netbox_dir = root / "netbox"
+    netbox_dir.mkdir()
+    (netbox_dir / "settings.py").write_text(
+        "from netbox.plugins import PluginConfig\n"
+        "INSTALLED_APPS = ['core', 'dcim']\n"
+    )
+    # No configuration_example.py here — the import-substring branch must
+    # carry this on its own.
+    monkeypatch.chdir(root)
+    location = locate_manage_py()
+    assert location.manage_py == manage_py
+
+
+def test_netbox_heuristic_via_configuration_example(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    manage_py = root / "manage.py"
+    manage_py.write_text("#!/usr/bin/env python\n")
+    netbox_dir = root / "netbox"
+    netbox_dir.mkdir()
+    (netbox_dir / "configuration_example.py").write_text("# placeholder\n")
+    # Deliberately no settings.py — the configuration_example.py branch
+    # must carry this on its own.
+    monkeypatch.chdir(root)
+    location = locate_manage_py()
+    assert location.manage_py == manage_py
+
+
+def test_non_netbox_manage_py_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _make_django_only_install(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ManagePyNotFoundError):
+        locate_manage_py()
+
+
+def test_namedtuple_shape(tmp_path: Path) -> None:
+    manage_py = _make_netbox_install(tmp_path)
+    location = locate_manage_py(override=manage_py)
+    assert isinstance(location, ManageLocation)
+    assert location.manage_py == manage_py
+    assert isinstance(location.python, Path)

--- a/tests/test_locate_manage.py
+++ b/tests/test_locate_manage.py
@@ -7,8 +7,15 @@ from pathlib import Path
 
 import pytest
 
-from proxbox_cli import _locate_manage
-from proxbox_cli._locate_manage import (
+# proxbox_cli/__init__.py imports click and typer at module import time, so the
+# test environment must have the CLI extras installed before any submodule of
+# proxbox_cli can be imported — even one (like _locate_manage) that itself
+# depends only on stdlib.
+for module_name in ("click", "typer", "rich"):
+    pytest.importorskip(module_name)
+
+from proxbox_cli import _locate_manage  # noqa: E402 — guarded by importorskip above
+from proxbox_cli._locate_manage import (  # noqa: E402 — guarded by importorskip above
     ManageLocation,
     ManagePyNotFoundError,
     NETBOX_PATH_ENV_VAR,


### PR DESCRIPTION
Closes #373.

## Summary

- Adds `pxb sync run` — a Typer subcommand that wraps the existing `proxbox_sync` Django management command (#360, already landed) as a subprocess so operators on the shell can trigger a full Proxmox→NetBox sync without knowing where NetBox lives on disk.
- Auto-locates `manage.py` via a documented chain (override → walk-up with NetBox heuristic → `$NETBOX_PATH` → `/opt/netbox/manage.py` → config). Picks the right interpreter by preferring `<install>/venv/bin/python` over `sys.executable` (the CLI's own pipx venv) after resolving symlinks like `/opt/netbox`.
- Forwards `--wait`, `--timeout`, `--poll-interval`, `--worker-grace`, and `--user` to the management command; implements `--json` entirely in the CLI layer with a `{exit_code, success, job_pk, manage_py, command, output}` payload that bypasses Rich for pipe-safety.
- Uses `stderr=STDOUT` deliberately to avoid the pipe-deadlock where a child blocked on its stderr write would hang us while we're blocked on a stdout read.

## Notable design refinements (vs the issue body)

These four were captured in the [pre-implementation analysis comment](https://github.com/emersonfelipesp/netbox-proxbox/issues/373#issuecomment-4433393280):

1. **Subprocess wrapper instead of SSE consumer** — proxbox-api's `/full-update/stream` triggers its own sync (no `job_id` parameter, generates its own `operation_id`), so calling it after enqueue would have caused two concurrent syncs. Going via `manage.py proxbox_sync --wait` is the safe path.
2. **NetBox-detection heuristic** — real NetBox `INSTALLED_APPS` lists `core`, `dcim`, `ipam`, etc., never a literal `'netbox'`. Using `from netbox.plugins` substring in `netbox/settings.py` OR `netbox/configuration_example.py` presence instead.
3. **Canonical install path** is `/opt/netbox/manage.py`, not `/opt/netbox/netbox/manage.py` (matches `docs/operations/headless-sync.md`).
4. **Interpreter resolution** — `sys.executable` is the CLI's interpreter (pipx venv), not NetBox's. Prefer `<resolved_parent>/venv/bin/python` after `.resolve()`.

## Files

- New: `proxbox_cli/_locate_manage.py`, `proxbox_cli/commands/sync.py`, `tests/test_locate_manage.py`, `tests/test_cli_sync.py`, `docs/cli/sync.md`.
- Modified: `proxbox_cli/__init__.py` (wire `sync_app`), `proxbox_cli/config.py` (`netbox_manage_py` field, `NETBOX_PATH_ENV_VAR` constant).

## Test plan

- [x] `python3 -m compileall proxbox_cli tests` — clean
- [x] `uv run ruff check proxbox_cli tests` — clean
- [x] `uv run ty check proxbox_cli` — clean
- [x] `uv run pytest tests/test_locate_manage.py tests/test_cli_sync.py` — 30/30 pass
- [x] Full `pytest tests/` — 545 pass, 3 skipped, 9 pre-existing failures unrelated to this PR (all from `overwrite_vm_cloudinit` field added in #402, verified by checking out `origin/v0.0.15` and observing the same failures)
- [ ] Manual smoke after install: `pxb sync run --help`, `pxb sync run` from outside a NetBox tree (exits non-zero with the actionable message), `pxb sync run --json | jq .` from inside one