### PR TITLE
fix(migrations): create core.objecttype ContentType row defensively

### DIFF
--- a/netbox_proxbox/migrations/0041_run_proxmox_action_permission.py
+++ b/netbox_proxbox/migrations/0041_run_proxmox_action_permission.py
@@ -36,7 +36,7 @@ CT_MODEL = "objecttype"
 def _create_perm(apps, schema_editor):
     ContentType = apps.get_model("contenttypes", "ContentType")
     Permission = apps.get_model("auth", "Permission")
-    ct = ContentType.objects.get(app_label=CT_APP_LABEL, model=CT_MODEL)
+    ct, _ = ContentType.objects.get_or_create(app_label=CT_APP_LABEL, model=CT_MODEL)
     Permission.objects.get_or_create(
         content_type=ct,
         codename=PERM_CODENAME,


### PR DESCRIPTION
## Summary
- Migration 0041 (introduced by #404) calls `ContentType.objects.get("core.objecttype")` during a data migration.
- ContentType rows are populated by the `post_migrate` signal that fires **after** all migrations finish, so the row does not exist yet when 0041 runs.
- On a fresh database this raises `ContentType.DoesNotExist` and crashes NetBox during plugin migration, leaving the container unready.

Observed effect: every proxbox-api E2E Docker run since 2026-05-12 18:32 UTC times out at "NetBox did not become ready" with the traceback in plugin migration 0041.

## Fix
Use `get_or_create()` instead of `get()`. If the ContentType row is missing, materialize it; otherwise reuse it. The subsequent `post_migrate` signal treats a pre-existing row as a no-op.

## Test plan
- [x] Migration logic unchanged in shape — only the lookup is made defensive.
- [ ] Re-run proxbox-api PR #77 E2E Docker matrix after merge; NetBox should boot.
- [ ] Confirm `auth_permission` row with `core.run_proxmox_action` still appears post-migrate on a fresh DB.