### PR TITLE
fix(migrations): MPTT defaults on 0045 + defensive ContentType on 0046

### DIFF
--- a/netbox_proxbox/migrations/0045_seed_default_vm_roles.py
+++ b/netbox_proxbox/migrations/0045_seed_default_vm_roles.py
@@ -3,9 +3,16 @@
 Idempotent: existing DeviceRoles with the well-known slugs are reused; the
 ProxboxPluginSettings singleton's default_role_qemu / default_role_lxc fields
 are only populated when they are currently NULL.
+
+DeviceRole is MPTT-tracked (level/lft/rght/tree_id are NOT NULL). Historical
+models returned by ``apps.get_model`` do not carry the custom TreeManager that
+fills these on save, so the values are set explicitly here. The seeded rows
+are roots with no children: level=0, lft=1, rght=2, and a tree_id picked
+above the current MAX(tree_id) so each row owns its own tree.
 """
 
 from django.db import migrations
+from django.db.models import Max
 
 
 VM_ROLE_SEEDS = (
@@ -26,16 +33,24 @@ def seed_default_vm_roles(apps, schema_editor):
     DeviceRole = apps.get_model("dcim", "DeviceRole")
     ProxboxPluginSettings = apps.get_model("netbox_proxbox", "ProxboxPluginSettings")
 
+    next_tree_id = (DeviceRole.objects.aggregate(Max("tree_id"))["tree_id__max"] or 0) + 1
+
     roles_by_slug = {}
     for seed in VM_ROLE_SEEDS:
-        role, _created = DeviceRole.objects.get_or_create(
+        role, created = DeviceRole.objects.get_or_create(
             slug=seed["slug"],
             defaults={
                 "name": seed["name"],
                 "color": seed["color"],
                 "vm_role": True,
+                "level": 0,
+                "lft": 1,
+                "rght": 2,
+                "tree_id": next_tree_id,
             },
         )
+        if created:
+            next_tree_id += 1
         roles_by_slug[seed["slug"]] = role
 
     settings = ProxboxPluginSettings.objects.filter(singleton_key="default").first()

--- a/netbox_proxbox/migrations/0046_register_last_synced_role_cf.py
+++ b/netbox_proxbox/migrations/0046_register_last_synced_role_cf.py
@@ -7,6 +7,12 @@ across sync runs. The field is hidden in the NetBox UI.
 
 Idempotent: uses get_or_create on the name and adds the VirtualMachine
 content type to object_types if missing.
+
+ContentType rows are created by Django's ``post_migrate`` signal after the
+full migration plan runs, so during a fresh-database migration this RunPython
+may execute before the row exists. ``get_or_create`` lets the data migration
+materialise the row defensively rather than aborting — same pattern as #408
+applied to migration 0041.
 """
 
 from django.db import migrations
@@ -19,10 +25,10 @@ def register_last_synced_role_cf(apps, schema_editor):
     CustomField = apps.get_model("extras", "CustomField")
     ContentType = apps.get_model("contenttypes", "ContentType")
 
-    try:
-        vm_ct = ContentType.objects.get(app_label="virtualization", model="virtualmachine")
-    except ContentType.DoesNotExist:
-        return
+    vm_ct, _ = ContentType.objects.get_or_create(
+        app_label="virtualization",
+        model="virtualmachine",
+    )
 
     cf, _created = CustomField.objects.get_or_create(
         name=CUSTOM_FIELD_NAME,


### PR DESCRIPTION
## Summary

Unblocks E2E Docker on PRs targeting `v0.0.15` by repairing two data
migrations introduced after #404.

- **0045 (`seed_default_vm_roles`)**: `DeviceRole` is MPTT-tracked
  (`level`, `lft`, `rght`, `tree_id` are `NOT NULL`), and the historical
  model returned by `apps.get_model("dcim", "DeviceRole")` does not carry
  the custom `TreeManager` that would auto-fill those columns on save.
  On a fresh DB the migration hits `IntegrityError: NOT NULL constraint
  failed: dcim_devicerole.level`. Fix: seed each row explicitly as a
  root tree — `level=0`, `lft=1`, `rght=2`, and a `tree_id` chosen above
  the current `MAX(tree_id)` per row. Idempotency is preserved (the
  defaults only apply when `get_or_create` actually creates a row), and
  no second-run side effects.

- **0046 (`register_last_synced_role_cf`)**: looks up the
  `virtualization.virtualmachine` ContentType via `ContentType.objects.get()`,
  which raises `DoesNotExist` on a fresh DB because ContentType rows are
  materialised by Django's `post_migrate` signal **after** the entire
  migration plan finishes. Swap to `get_or_create()` so the data
  migration materialises the row defensively — exact same pattern that
  #408 applied to migration 0041.

## Test plan

- [x] `python3 -m py_compile` both migration files
- [ ] CI: `migrate` smoke job (covers fresh-DB run)
- [ ] CI: full E2E Docker matrix on `develop` (NetBox 4.5.8 / 4.5.9 / 4.6.0)
- [ ] Verify PR #77 E2E unblocks once this lands and CDN propagates

## Links

- Blocks the E2E matrix on #77 (proxbox-api `feat/issue-406-port-branching-v0.0.11`).
- Mirrors the migration-0041 fix in #408 (which is already merged).