### PR TITLE
feat(#372): add proxbox-scheduler container and --enqueue-once flag

### DIFF
--- a/docs/operations/headless-sync.md
+++ b/docs/operations/headless-sync.md
@@ -54,6 +54,7 @@ python manage.py proxbox_sync --wait --worker-grace 10
 | `--timeout SECONDS` | `7200` | Upper bound on the `--wait` loop. Matches `PROXBOX_SYNC_JOB_TIMEOUT`. |
 | `--poll-interval SECONDS` | `2.0` | Seconds between job-status polls while `--wait` is set. |
 | `--worker-grace SECONDS` | `30.0` | Maximum seconds the job may stay pending before the command checks for an active RQ worker and fast-fails if none is found. |
+| `--enqueue-once` | off | Route through `JobRunner.enqueue_once()` so the command reuses an already-pending recurring schedule instead of duplicating it. Designed for the [`proxbox-scheduler`](../scheduler/README.md) container so it coexists with the NetBox-side **Schedule Sync** form. |
 
 ## Exit codes
 
@@ -131,3 +132,4 @@ systemctl enable --now proxbox-sync.timer
   (`SyncFullUpdateView` in `netbox_proxbox/views/sync.py`).
 - Token-status diagnostics: `python manage.py proxbox_fix_tokens`.
 - Sync internals: [`netbox_proxbox/jobs.py`](../../netbox_proxbox/jobs.py).
+- Container-based scheduler with cron/continuous modes: [`docs/scheduler/README.md`](../scheduler/README.md) (issue #372).

--- a/docs/scheduler/README.md
+++ b/docs/scheduler/README.md
@@ -1,0 +1,102 @@
+# Proxbox Scheduler Container
+
+Issue: [#372](https://github.com/emersonfelipesp/netbox-proxbox/issues/372)
+Version: ships in `netbox-proxbox 0.0.15`
+
+A standalone container that fires periodic Proxbox sync triggers without
+asking the operator to install a cron unit on the NetBox host. Code and
+build artefacts live in [`proxbox_scheduler/`](../../proxbox_scheduler/).
+
+This page is the operator-facing summary. For the full
+environment-variable reference and developer notes, see
+[`proxbox_scheduler/README.md`](../../proxbox_scheduler/README.md).
+
+## When to use it
+
+| Situation                                                                                | Use the scheduler? |
+| ---------------------------------------------------------------------------------------- | ------------------ |
+| On-prem NetBox you control, want a recurring sync every N minutes                        | **No** — use the NetBox-side **Schedule Sync** form (it's already shipped) |
+| Need `cron=<expression>` semantics (e.g. `0 */4 * * *`)                                  | **Yes**            |
+| Need `continuous` zero-gap reconciliation (NetBox enforces a 1-minute floor on intervals)| **Yes**            |
+| Managed-NetBox tenant who cannot ship a cron unit inside the NetBox container            | **Yes**            |
+| Want sub-minute interval triggers                                                        | **Yes**            |
+
+## How it relates to NetBox-side scheduling
+
+NetBox's [`JobRunner.handle()`](https://github.com/netbox-community/netbox/blob/main/netbox/netbox/jobs.py)
+already auto-reschedules periodic jobs in its `finally` block, with a hard
+floor of `now + 1 minute`:
+
+```python
+if job.interval:
+    new_scheduled_time = max(
+        (job.scheduled or job.started) + timedelta(minutes=job.interval),
+        timezone.now() + timedelta(minutes=1),
+    )
+    cls.enqueue(..., schedule_at=new_scheduled_time, interval=job.interval, ...)
+```
+
+That covers the **`interval` ≥ 60s** case, which is what
+`ScheduleSyncForm` (and the **Schedule Sync** quick action on the
+plugin home dashboard) configures. The scheduler container ships only to
+cover the genuinely new capabilities: cron expressions, zero-gap
+continuous loops, and the managed-NetBox deployment shape.
+
+## Coexistence: `--enqueue-once`
+
+When the scheduler invokes the management command (`exec` invocation,
+default), it passes `--enqueue-once`. This routes through
+`ProxboxSyncJob.enqueue_once()` (inherited from NetBox's `JobRunner`),
+which is keyed on the advisory lock `('job-schedules', class, instance)`
+and:
+
+- reuses an existing pending recurring schedule if one exists, or
+- creates a fresh one otherwise.
+
+The practical effect: if an operator also configures the NetBox-side
+**Schedule Sync** form, the scheduler container's invocation no-ops on
+top of that pending schedule rather than enqueuing a duplicate run.
+
+`http` invocation cannot use this dedup. If you choose `http`, ensure
+NetBox-side scheduling and the container do not overlap.
+
+## Modes at a glance
+
+```
+PROXBOX_MODE=off                       # disabled
+PROXBOX_MODE=interval=30               # fire every 30 seconds
+PROXBOX_MODE=continuous                # back-to-back, no gap (with error backoff)
+PROXBOX_MODE='cron=0 */4 * * *'        # every 4 hours on the hour
+```
+
+Set `PROXBOX_SCHEDULER_TZ=America/Sao_Paulo` (or any IANA zone) to fix
+the cron evaluation timezone.
+
+## Running it
+
+The minimal Compose snippet lives at
+[`proxbox_scheduler/docker-compose.example.yml`](../../proxbox_scheduler/docker-compose.example.yml).
+Copy it into your stack and edit the env vars to match your environment.
+
+```bash
+docker build -t proxbox-scheduler:0.0.15 proxbox_scheduler/
+docker run --rm \
+  -e PROXBOX_MODE='cron=0 */4 * * *' \
+  -e PROXBOX_SCHEDULER_TZ=America/Sao_Paulo \
+  -e PROXBOX_API_URL=http://proxbox-api:8000 \
+  -e PROXBOX_API_KEY=changeme \
+  proxbox-scheduler:0.0.15
+```
+
+## Acceptance-criteria checklist
+
+These items are covered by the test suite in
+[`proxbox_scheduler/tests/`](../../proxbox_scheduler/tests/) and by
+`tests/management/test_proxbox_sync.py`:
+
+- [x] `off`, `interval`, `continuous`, and `cron` modes all parse from env
+- [x] `cron` honours `PROXBOX_SCHEDULER_TZ`
+- [x] HTTP invocation reads SSE until terminal event, fails closed on connection error
+- [x] Exec invocation maps non-zero exit codes to `InvokeResult.failed`
+- [x] Error backoff is applied after any failed trigger (every mode)
+- [x] `proxbox_sync --enqueue-once` routes through `JobRunner.enqueue_once()` so the scheduler coexists with NetBox-side recurring schedules without double-runs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
   - Operations:
     - Headless Sync: 'operations/headless-sync.md'
     - Single-Exec Compose: 'operations/single-exec.md'
+    - Scheduler Container: 'scheduler/README.md'
   - API Reference:
     - Overview: 'api/index.md'
     - Endpoints: 'api/endpoints.md'

--- a/netbox_proxbox/management/commands/proxbox_sync.py
+++ b/netbox_proxbox/management/commands/proxbox_sync.py
@@ -175,7 +175,9 @@ class Command(BaseCommand):
             raise CommandError(f"Failed to enqueue ProxboxSyncJob: {exc}") from exc
 
         job_pk = getattr(job, "pk", None)
-        dedup_note = " (enqueue_once: reused pending or freshly created)" if enqueue_once else ""
+        dedup_note = (
+            " (enqueue_once: reused pending or freshly created)" if enqueue_once else ""
+        )
         self.stdout.write(
             self.style.SUCCESS(
                 f"Enqueued ProxboxSyncJob (pk={job_pk}) on queue "

--- a/netbox_proxbox/management/commands/proxbox_sync.py
+++ b/netbox_proxbox/management/commands/proxbox_sync.py
@@ -3,10 +3,16 @@
 Usage:
     python manage.py proxbox_sync [--user USERNAME] [--wait] [--timeout SECONDS]
                                   [--poll-interval SECONDS] [--worker-grace SECONDS]
+                                  [--enqueue-once]
 
 This is the headless equivalent of clicking "Full Update" in the plugin UI:
 it enqueues the same ``ProxboxSyncJob`` (on NetBox's default RQ queue) with
 ``sync_types=[SyncTypeChoices.ALL]`` and all configured Proxmox endpoint IDs.
+
+``--enqueue-once`` is the integration hook for the ``proxbox-scheduler``
+container (issue #372): it routes through ``JobRunner.enqueue_once()``,
+which uses an advisory-locked dedup keyed on the job class + instance, so
+the command no-ops when a pending recurring schedule already exists.
 
 Exit codes:
     0  job enqueued (and, with --wait, completed successfully)
@@ -78,6 +84,17 @@ class Command(BaseCommand):
                 f"seconds with no RQ worker on the default queue (default: {DEFAULT_WORKER_GRACE})."
             ),
         )
+        parser.add_argument(
+            "--enqueue-once",
+            action="store_true",
+            help=(
+                "Dedup against any pending recurring schedule via "
+                "JobRunner.enqueue_once(). If a pending ProxboxSyncJob already "
+                "exists (e.g. created by the NetBox-side Schedule Sync form), "
+                "reuse it instead of enqueuing a duplicate. Intended for the "
+                "proxbox-scheduler container (issue #372)."
+            ),
+        )
 
     def handle(self, *args: object, **options: object) -> None:
         """Handle handle."""
@@ -110,6 +127,7 @@ class Command(BaseCommand):
             if worker_grace_raw is None
             else float(worker_grace_raw)
         )
+        enqueue_once = bool(options.get("enqueue_once"))
 
         user = self._resolve_user(username)
 
@@ -139,24 +157,30 @@ class Command(BaseCommand):
             )
             return
 
+        enqueue_kwargs = dict(
+            instance=None,
+            user=user,
+            queue_name=PROXBOX_SYNC_QUEUE_NAME,
+            name="Proxbox Sync: Full update (CLI)",
+            sync_types=[SyncTypeChoices.ALL],
+            proxmox_endpoint_ids=proxmox_endpoint_ids,
+        )
+
         try:
-            job = ProxboxSyncJob.enqueue(
-                instance=None,
-                user=user,
-                queue_name=PROXBOX_SYNC_QUEUE_NAME,
-                name="Proxbox Sync: Full update (CLI)",
-                sync_types=[SyncTypeChoices.ALL],
-                proxmox_endpoint_ids=proxmox_endpoint_ids,
-            )
+            if enqueue_once:
+                job = ProxboxSyncJob.enqueue_once(**enqueue_kwargs)
+            else:
+                job = ProxboxSyncJob.enqueue(**enqueue_kwargs)
         except Exception as exc:  # noqa: BLE001 — surface any enqueue failure
             raise CommandError(f"Failed to enqueue ProxboxSyncJob: {exc}") from exc
 
         job_pk = getattr(job, "pk", None)
+        dedup_note = " (enqueue_once: reused pending or freshly created)" if enqueue_once else ""
         self.stdout.write(
             self.style.SUCCESS(
                 f"Enqueued ProxboxSyncJob (pk={job_pk}) on queue "
                 f"'{PROXBOX_SYNC_QUEUE_NAME}' for {len(proxmox_endpoint_ids)} "
-                f"Proxmox endpoint(s), attributed to user '{user}'."
+                f"Proxmox endpoint(s), attributed to user '{user}'{dedup_note}."
             )
         )
 

--- a/proxbox_scheduler/Dockerfile
+++ b/proxbox_scheduler/Dockerfile
@@ -1,0 +1,45 @@
+# proxbox-scheduler: standalone container that fires periodic Proxbox sync
+# triggers against proxbox-api (or via `manage.py proxbox_sync`).
+#
+# Build:
+#   docker build -t proxbox-scheduler:0.0.15 proxbox_scheduler/
+#
+# Run (HTTP invocation, the default):
+#   docker run --rm \
+#     -e PROXBOX_MODE='cron=0 */4 * * *' \
+#     -e PROXBOX_SCHEDULER_TZ=America/Sao_Paulo \
+#     -e PROXBOX_API_URL=http://proxbox-api:8000 \
+#     -e PROXBOX_API_KEY=... \
+#     proxbox-scheduler:0.0.15
+
+FROM python:3.12-slim AS builder
+
+WORKDIR /build
+COPY pyproject.toml README.md ./
+COPY proxbox_scheduler ./proxbox_scheduler
+
+RUN pip install --no-cache-dir --upgrade pip build && \
+    python -m build --wheel --outdir /dist
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=random
+
+RUN useradd --create-home --shell /usr/sbin/nologin --uid 10001 scheduler
+
+COPY --from=builder /dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm -f /tmp/*.whl
+
+USER scheduler
+WORKDIR /home/scheduler
+
+ENV PROXBOX_MODE=off \
+    PROXBOX_SCHEDULER_INVOKE=http \
+    PROXBOX_SCHEDULER_TZ=UTC \
+    PROXBOX_SCHEDULER_BACKOFF_ON_ERROR_SECONDS=30 \
+    PROXBOX_SCHEDULER_LOG_JSON=true \
+    PROXBOX_SCHEDULER_LOG_LEVEL=INFO
+
+ENTRYPOINT ["python", "-m", "proxbox_scheduler"]

--- a/proxbox_scheduler/README.md
+++ b/proxbox_scheduler/README.md
@@ -1,0 +1,108 @@
+# proxbox-scheduler
+
+Standalone container that triggers periodic [Proxbox](https://github.com/emersonfelipesp/netbox-proxbox)
+syncs on a configurable cadence. Tracks [netbox-proxbox#372](https://github.com/emersonfelipesp/netbox-proxbox/issues/372).
+
+This container owns **no NetBox model, no plugin config, and no shared
+state** — all configuration is environment variables. It is the recommended
+path when:
+
+- the NetBox container is managed by a tenant who cannot host extra cron
+  units (managed-NetBox, Kubernetes), or
+- you need `cron=<expression>` semantics that NetBox's built-in
+  ``Job.interval`` (minutes-only, ≥1 minute floor) does not support, or
+- you need `continuous` zero-gap reconciliation, which NetBox's
+  ``JobRunner.handle()`` cannot produce.
+
+For the common case of "run a full sync every N minutes" on a NetBox
+container you control, prefer the NetBox-side **Schedule Sync** form
+(``netbox_proxbox.forms.ScheduleSyncForm``) — it is already shipped, is
+persisted in NetBox, and is observable under **Background Jobs**.
+
+## Modes
+
+| `PROXBOX_MODE`            | Behaviour                                                                                                          |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `off`                     | scheduler disabled (no-op exit; container exits 0)                                                                 |
+| `interval=<seconds>`      | trigger every `<seconds>` seconds, measured from the *start* of each trigger; sub-minute is supported              |
+| `continuous`              | trigger again immediately after the previous trigger returns; applies a configurable backoff on failure            |
+| `cron=<5-field cron>`     | trigger at each cron fire time, evaluated in `PROXBOX_SCHEDULER_TZ`                                                |
+
+## Invocation strategies
+
+Set `PROXBOX_SCHEDULER_INVOKE=http` (default) or `exec`.
+
+### `http`
+
+Calls `GET /full-update/stream` on `PROXBOX_API_URL` with the
+`X-Proxbox-API-Key` header, blocking on the SSE stream until a terminal
+event (`complete` / `done` / `error` / …). Works for managed-NetBox /
+Kubernetes deployments where the scheduler cannot share runtime with
+NetBox.
+
+### `exec`
+
+Runs a subprocess (defaults to `python manage.py proxbox_sync --wait
+--enqueue-once`). Requires the scheduler to share the NetBox runtime
+(e.g. an extended NetBox image or a `docker exec` wrapper). The
+`--enqueue-once` flag uses ``JobRunner.enqueue_once()`` advisory-lock
+dedup, so the scheduler coexists with any pending NetBox-side recurring
+schedule without double-runs.
+
+Override the command with `PROXBOX_SCHEDULER_EXEC_CMD` (shell-tokenized).
+
+## Environment reference
+
+| Variable                                    | Default                                              | Notes                                                                                          |
+| ------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `PROXBOX_MODE`                              | `off`                                                | see table above                                                                                |
+| `PROXBOX_SCHEDULER_INVOKE`                  | `http`                                               | `http` or `exec`                                                                               |
+| `PROXBOX_SCHEDULER_TZ`                      | `UTC`                                                | IANA timezone for cron evaluation                                                              |
+| `PROXBOX_SCHEDULER_BACKOFF_ON_ERROR_SECONDS`| `30`                                                 | extra delay after any failed trigger; applies to every mode                                    |
+| `PROXBOX_SCHEDULER_LOG_LEVEL`               | `INFO`                                               | passed to `logging.setLevel`                                                                   |
+| `PROXBOX_SCHEDULER_LOG_JSON`                | `true`                                               | set to `false` for human-readable logs                                                         |
+| `PROXBOX_API_URL`                           | _(required for `http` invoke when mode ≠ off)_       | base URL of the proxbox-api service                                                            |
+| `PROXBOX_API_KEY`                           | _(empty)_                                            | `X-Proxbox-API-Key` header value                                                               |
+| `PROXBOX_API_TIMEOUT`                       | `7200`                                               | seconds; applies to both `http` SSE read and `exec` subprocess wait                            |
+| `PROXBOX_API_VERIFY_SSL`                    | `true`                                               | disable for self-signed certs in dev                                                           |
+| `PROXBOX_SCHEDULER_EXEC_CMD`                | `python manage.py proxbox_sync --wait --enqueue-once`| shell-tokenized; only consulted when `PROXBOX_SCHEDULER_INVOKE=exec`                           |
+
+## Quick start
+
+```bash
+docker build -t proxbox-scheduler:0.0.15 proxbox_scheduler/
+
+docker run --rm \
+  -e PROXBOX_MODE='cron=0 */4 * * *' \
+  -e PROXBOX_SCHEDULER_TZ=America/Sao_Paulo \
+  -e PROXBOX_API_URL=http://proxbox-api:8000 \
+  -e PROXBOX_API_KEY=changeme \
+  proxbox-scheduler:0.0.15
+```
+
+A complete compose snippet lives in [`docker-compose.example.yml`](./docker-compose.example.yml).
+
+## Coordination with NetBox-side scheduling
+
+If you already use the **Schedule Sync** form to enqueue a recurring
+NetBox `Job.interval`, you can still safely run this scheduler in `exec`
+mode: the default command passes `--enqueue-once`, which short-circuits
+on the advisory lock keyed by `(ProxboxSyncJob, instance=None)`. The
+result is that a pre-existing pending recurring schedule is reused
+rather than duplicated.
+
+`http` invocation cannot dedup against NetBox-side schedules; if you
+choose `http`, make `PROXBOX_MODE` and the NetBox-side schedule
+non-overlapping (e.g. NetBox-side off when the container is active).
+
+## Testing
+
+```bash
+cd proxbox_scheduler/
+pip install -e ".[test]"
+pytest
+```
+
+Unit tests cover env parsing, cron evaluation, both invokers (mocked
+``requests.Session`` and ``subprocess.run``), and every mode of the
+runner loop with a controllable sleeper / clock.

--- a/proxbox_scheduler/docker-compose.example.yml
+++ b/proxbox_scheduler/docker-compose.example.yml
@@ -1,0 +1,25 @@
+# Example compose snippet — drop into an existing stack that already runs
+# NetBox + proxbox-api. Tracks issue #372.
+#
+# Run with `docker compose up -d proxbox-scheduler`.
+
+services:
+  proxbox-scheduler:
+    build:
+      context: .
+    image: proxbox-scheduler:0.0.15
+    restart: unless-stopped
+    environment:
+      # off | continuous | interval=<seconds> | cron=<expression>
+      PROXBOX_MODE: "cron=0 */4 * * *"
+      PROXBOX_SCHEDULER_TZ: America/Sao_Paulo
+      PROXBOX_SCHEDULER_INVOKE: http
+      PROXBOX_API_URL: http://proxbox-api:8000
+      PROXBOX_API_KEY: ${PROXBOX_API_KEY:?set PROXBOX_API_KEY in your .env}
+      PROXBOX_API_TIMEOUT: "7200"
+      PROXBOX_API_VERIFY_SSL: "false"
+      PROXBOX_SCHEDULER_BACKOFF_ON_ERROR_SECONDS: "30"
+      PROXBOX_SCHEDULER_LOG_JSON: "true"
+      PROXBOX_SCHEDULER_LOG_LEVEL: INFO
+    depends_on:
+      - proxbox-api

--- a/proxbox_scheduler/proxbox_scheduler/__init__.py
+++ b/proxbox_scheduler/proxbox_scheduler/__init__.py
@@ -1,0 +1,18 @@
+"""proxbox-scheduler: standalone Proxbox sync scheduler container.
+
+Issue tracker: https://github.com/emersonfelipesp/netbox-proxbox/issues/372
+
+This is a thin loop that wraps the existing ``proxbox_sync`` management
+command (or, alternatively, a direct HTTP call to ``proxbox-api``) and
+triggers it on a configurable schedule. It owns no NetBox model, no plugin
+config, and no shared state — all configuration is environment variables.
+
+Supported modes (set via ``PROXBOX_MODE``):
+
+    off                  scheduler disabled (no-op exit)
+    interval=<seconds>   fixed interval between triggers
+    continuous           fire next as soon as previous returns
+    cron=<expression>    standard 5-field cron expression
+"""
+
+__version__ = "0.0.15"

--- a/proxbox_scheduler/proxbox_scheduler/__main__.py
+++ b/proxbox_scheduler/proxbox_scheduler/__main__.py
@@ -1,0 +1,59 @@
+"""Container entrypoint: ``python -m proxbox_scheduler``.
+
+Parses the environment, configures logging, builds the invoker, and runs
+the scheduler loop until SIGTERM/SIGINT.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+
+from .config import ConfigError, load_config
+from .invoker import build_invoker
+from .logging_config import configure_logging
+from .runner import SchedulerRunner
+
+logger = logging.getLogger("proxbox_scheduler")
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        config = load_config()
+    except ConfigError as exc:
+        sys.stderr.write(f"proxbox-scheduler: configuration error: {exc}\n")
+        return 2
+
+    configure_logging(level=config.log_level, json_output=config.log_json)
+    logger.info(
+        "scheduler.start mode=%s invoke=%s tz=%s",
+        config.mode.kind.value,
+        config.invoke,
+        config.timezone.key,
+    )
+
+    invoker = build_invoker(config)
+    runner = SchedulerRunner(config=config, invoker=invoker)
+
+    def _handle_signal(signum: int, _frame: object) -> None:
+        logger.info("scheduler.signal received=%s — shutting down", signum)
+        runner.stop()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(sig, _handle_signal)
+        except ValueError:
+            # Happens when called from a non-main thread (e.g. tests).
+            pass
+
+    try:
+        runner.run()
+    except Exception:  # noqa: BLE001
+        logger.exception("scheduler.crash")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/proxbox_scheduler/proxbox_scheduler/config.py
+++ b/proxbox_scheduler/proxbox_scheduler/config.py
@@ -1,0 +1,224 @@
+"""Environment-driven configuration for proxbox-scheduler.
+
+All knobs are read once at startup and frozen into an immutable
+``SchedulerConfig`` dataclass. There is no plugin settings / DB lookup —
+this container is intentionally stateless.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+class ModeKind(str, Enum):
+    OFF = "off"
+    INTERVAL = "interval"
+    CONTINUOUS = "continuous"
+    CRON = "cron"
+
+
+class ConfigError(ValueError):
+    """Raised when PROXBOX_MODE or any required env var is invalid."""
+
+
+@dataclass(frozen=True)
+class SchedulerMode:
+    kind: ModeKind
+    interval_seconds: int | None = None
+    cron_expression: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind is ModeKind.INTERVAL:
+            if self.interval_seconds is None or self.interval_seconds <= 0:
+                raise ConfigError("interval mode requires a positive integer of seconds")
+        if self.kind is ModeKind.CRON:
+            if not self.cron_expression:
+                raise ConfigError("cron mode requires a non-empty cron expression")
+
+
+InvokeKind = Literal["http", "exec"]
+
+
+@dataclass(frozen=True)
+class SchedulerConfig:
+    mode: SchedulerMode
+    invoke: InvokeKind
+    timezone: ZoneInfo
+    backoff_seconds: float
+    log_level: str
+    log_json: bool
+
+    # HTTP-invoker knobs
+    proxbox_api_url: str | None
+    proxbox_api_key: str | None
+    proxbox_api_timeout: float
+    proxbox_api_verify_ssl: bool
+
+    # Exec-invoker knobs
+    exec_command: list[str] = field(default_factory=list)
+
+
+_TRUTHY = {"1", "true", "yes", "on", "y", "t"}
+_FALSY = {"0", "false", "no", "off", "n", "f", ""}
+
+
+def _parse_bool(raw: str | None, *, default: bool) -> bool:
+    if raw is None:
+        return default
+    lowered = raw.strip().lower()
+    if lowered in _TRUTHY:
+        return True
+    if lowered in _FALSY:
+        return False
+    raise ConfigError(f"Unrecognized boolean value: {raw!r}")
+
+
+def parse_mode(raw: str | None) -> SchedulerMode:
+    """Parse the ``PROXBOX_MODE`` env value.
+
+    Accepted forms (case-insensitive on the keyword, value preserved):
+
+        off
+        continuous
+        interval=<int seconds>
+        cron=<5-field expression>
+    """
+    if raw is None:
+        return SchedulerMode(kind=ModeKind.OFF)
+
+    value = raw.strip()
+    if not value:
+        return SchedulerMode(kind=ModeKind.OFF)
+
+    lowered = value.lower()
+
+    if lowered == "off":
+        return SchedulerMode(kind=ModeKind.OFF)
+    if lowered == "continuous":
+        return SchedulerMode(kind=ModeKind.CONTINUOUS)
+
+    if "=" not in value:
+        raise ConfigError(
+            f"Invalid PROXBOX_MODE={value!r}; "
+            "expected off | continuous | interval=<sec> | cron=<expr>"
+        )
+
+    keyword, _, payload = value.partition("=")
+    keyword = keyword.strip().lower()
+    payload = payload.strip()
+
+    if keyword == "interval":
+        try:
+            seconds = int(payload)
+        except ValueError as exc:
+            raise ConfigError(
+                f"interval mode requires an integer number of seconds, got {payload!r}"
+            ) from exc
+        return SchedulerMode(kind=ModeKind.INTERVAL, interval_seconds=seconds)
+
+    if keyword == "cron":
+        return SchedulerMode(kind=ModeKind.CRON, cron_expression=payload)
+
+    raise ConfigError(
+        f"Unknown PROXBOX_MODE keyword {keyword!r}; expected interval or cron"
+    )
+
+
+def _parse_tz(raw: str | None) -> ZoneInfo:
+    name = (raw or "UTC").strip() or "UTC"
+    try:
+        return ZoneInfo(name)
+    except ZoneInfoNotFoundError as exc:
+        raise ConfigError(f"Unknown timezone: {name!r}") from exc
+
+
+def _parse_invoke(raw: str | None) -> InvokeKind:
+    name = (raw or "http").strip().lower()
+    if name not in ("http", "exec"):
+        raise ConfigError(
+            f"PROXBOX_SCHEDULER_INVOKE must be 'http' or 'exec', got {name!r}"
+        )
+    return name  # type: ignore[return-value]
+
+
+def _parse_exec_command(raw: str | None) -> list[str]:
+    if not raw:
+        return [
+            "python",
+            "manage.py",
+            "proxbox_sync",
+            "--wait",
+            "--enqueue-once",
+        ]
+    import shlex
+
+    parts = shlex.split(raw)
+    if not parts:
+        raise ConfigError("PROXBOX_SCHEDULER_EXEC_CMD must contain at least one token")
+    return parts
+
+
+def load_config(env: dict[str, str] | None = None) -> SchedulerConfig:
+    """Build a frozen ``SchedulerConfig`` from the supplied env mapping.
+
+    Defaults to ``os.environ`` so the runtime entrypoint can call ``load_config()``
+    with no arguments; tests can pass a synthetic mapping.
+    """
+    if env is None:
+        env = dict(os.environ)
+
+    mode = parse_mode(env.get("PROXBOX_MODE"))
+    invoke = _parse_invoke(env.get("PROXBOX_SCHEDULER_INVOKE"))
+    tz = _parse_tz(env.get("PROXBOX_SCHEDULER_TZ"))
+
+    backoff_raw = env.get("PROXBOX_SCHEDULER_BACKOFF_ON_ERROR_SECONDS", "30")
+    try:
+        backoff = float(backoff_raw)
+        if backoff < 0:
+            raise ValueError
+    except ValueError as exc:
+        raise ConfigError(
+            f"PROXBOX_SCHEDULER_BACKOFF_ON_ERROR_SECONDS must be a non-negative number, got {backoff_raw!r}"
+        ) from exc
+
+    log_level = env.get("PROXBOX_SCHEDULER_LOG_LEVEL", "INFO").strip().upper() or "INFO"
+    log_json = _parse_bool(env.get("PROXBOX_SCHEDULER_LOG_JSON"), default=True)
+
+    proxbox_api_url = env.get("PROXBOX_API_URL") or None
+    proxbox_api_key = env.get("PROXBOX_API_KEY") or None
+    api_timeout_raw = env.get("PROXBOX_API_TIMEOUT", "7200")
+    try:
+        api_timeout = float(api_timeout_raw)
+        if api_timeout <= 0:
+            raise ValueError
+    except ValueError as exc:
+        raise ConfigError(
+            f"PROXBOX_API_TIMEOUT must be a positive number, got {api_timeout_raw!r}"
+        ) from exc
+    verify_ssl = _parse_bool(env.get("PROXBOX_API_VERIFY_SSL"), default=True)
+
+    exec_cmd = _parse_exec_command(env.get("PROXBOX_SCHEDULER_EXEC_CMD"))
+
+    if mode.kind is not ModeKind.OFF and invoke == "http":
+        if not proxbox_api_url:
+            raise ConfigError(
+                "HTTP invocation requires PROXBOX_API_URL (e.g. http://proxbox-api:8000)"
+            )
+
+    return SchedulerConfig(
+        mode=mode,
+        invoke=invoke,
+        timezone=tz,
+        backoff_seconds=backoff,
+        log_level=log_level,
+        log_json=log_json,
+        proxbox_api_url=proxbox_api_url,
+        proxbox_api_key=proxbox_api_key,
+        proxbox_api_timeout=api_timeout,
+        proxbox_api_verify_ssl=verify_ssl,
+        exec_command=exec_cmd,
+    )

--- a/proxbox_scheduler/proxbox_scheduler/config.py
+++ b/proxbox_scheduler/proxbox_scheduler/config.py
@@ -34,7 +34,9 @@ class SchedulerMode:
     def __post_init__(self) -> None:
         if self.kind is ModeKind.INTERVAL:
             if self.interval_seconds is None or self.interval_seconds <= 0:
-                raise ConfigError("interval mode requires a positive integer of seconds")
+                raise ConfigError(
+                    "interval mode requires a positive integer of seconds"
+                )
         if self.kind is ModeKind.CRON:
             if not self.cron_expression:
                 raise ConfigError("cron mode requires a non-empty cron expression")

--- a/proxbox_scheduler/proxbox_scheduler/cron.py
+++ b/proxbox_scheduler/proxbox_scheduler/cron.py
@@ -1,0 +1,52 @@
+"""Cron expression evaluation for proxbox-scheduler.
+
+Wraps ``croniter`` so the rest of the scheduler depends only on a tiny
+``next_fire_time(expression, *, base, tz)`` function. Keeps croniter out
+of the test surface for the runner / invoker modules.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from croniter import CroniterBadCronError, croniter
+
+
+class CronError(ValueError):
+    """Raised when a cron expression is malformed."""
+
+
+def validate_expression(expression: str) -> None:
+    """Raise :class:`CronError` if ``expression`` is not a valid 5-field cron."""
+    try:
+        croniter(expression)
+    except (CroniterBadCronError, ValueError) as exc:
+        raise CronError(f"Invalid cron expression: {expression!r} ({exc})") from exc
+
+
+def next_fire_time(
+    expression: str,
+    *,
+    base: datetime,
+    tz: ZoneInfo,
+) -> datetime:
+    """Return the next datetime ``expression`` fires after ``base``, in ``tz``.
+
+    ``base`` is interpreted in ``tz`` if it is naive. The return value is
+    always timezone-aware in ``tz``.
+    """
+    if base.tzinfo is None:
+        base = base.replace(tzinfo=tz)
+    else:
+        base = base.astimezone(tz)
+
+    try:
+        itr = croniter(expression, base)
+    except (CroniterBadCronError, ValueError) as exc:
+        raise CronError(f"Invalid cron expression: {expression!r} ({exc})") from exc
+
+    next_dt = itr.get_next(datetime)
+    if next_dt.tzinfo is None:
+        next_dt = next_dt.replace(tzinfo=tz)
+    return next_dt.astimezone(tz)

--- a/proxbox_scheduler/proxbox_scheduler/invoker.py
+++ b/proxbox_scheduler/proxbox_scheduler/invoker.py
@@ -1,0 +1,217 @@
+"""Sync invocation strategies for proxbox-scheduler.
+
+Two concrete invokers are shipped:
+
+* :class:`HttpInvoker` — calls ``GET /full-update/stream`` on proxbox-api and
+  consumes the SSE stream until a terminal event, returning success/failure.
+  This is the only mode that works for managed-NetBox deployments where the
+  scheduler container cannot exec into the NetBox container.
+
+* :class:`ExecInvoker` — runs a subprocess (defaults to
+  ``python manage.py proxbox_sync --wait --enqueue-once``). Works when the
+  scheduler sidecar shares the NetBox runtime, and benefits from
+  ``enqueue_once()`` dedup against any NetBox-side recurring schedule.
+
+Both invokers return an :class:`InvokeResult` so the runner can apply a
+uniform error-backoff policy.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class InvokeResult:
+    """Outcome of a single sync trigger."""
+
+    success: bool
+    detail: str = ""
+    exit_code: int | None = None
+
+    @classmethod
+    def ok(cls, detail: str = "") -> "InvokeResult":
+        return cls(success=True, detail=detail, exit_code=0)
+
+    @classmethod
+    def failed(cls, detail: str, exit_code: int | None = None) -> "InvokeResult":
+        return cls(success=False, detail=detail, exit_code=exit_code)
+
+
+class Invoker(Protocol):
+    """An invoker is anything callable that triggers one sync run."""
+
+    def trigger(self) -> InvokeResult: ...
+
+
+_TERMINAL_EVENT_NAMES = {
+    "complete",
+    "completed",
+    "done",
+    "finished",
+    "error",
+    "failed",
+    "cancelled",
+    "canceled",
+}
+_FAILURE_EVENT_NAMES = {"error", "failed", "cancelled", "canceled"}
+
+
+def _parse_sse_event_name(line: str) -> str | None:
+    if not line.startswith("event:"):
+        return None
+    return line.split(":", 1)[1].strip().lower()
+
+
+class HttpInvoker:
+    """Trigger a sync over HTTP/SSE against proxbox-api.
+
+    The scheduler issues a single ``GET /full-update/stream`` request and
+    blocks until proxbox-api emits a terminal event. Connection / response
+    failures are returned as :class:`InvokeResult.failed`.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str | None,
+        timeout_seconds: float,
+        verify_ssl: bool,
+        session: requests.Session | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout_seconds
+        self._verify_ssl = verify_ssl
+        self._session = session or requests.Session()
+
+    @property
+    def stream_url(self) -> str:
+        return f"{self._base_url}/full-update/stream"
+
+    def trigger(self) -> InvokeResult:
+        headers = {"Accept": "text/event-stream"}
+        if self._api_key:
+            headers["X-Proxbox-API-Key"] = self._api_key
+
+        try:
+            response = self._session.get(
+                self.stream_url,
+                headers=headers,
+                stream=True,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+            )
+        except requests.RequestException as exc:
+            return InvokeResult.failed(f"connection error: {exc}")
+
+        if response.status_code != 200:
+            try:
+                body = response.text[:200]
+            except Exception:  # noqa: BLE001
+                body = ""
+            return InvokeResult.failed(
+                f"HTTP {response.status_code} from {self.stream_url}: {body}",
+                exit_code=response.status_code,
+            )
+
+        last_event: str | None = None
+        try:
+            for raw_line in response.iter_lines(decode_unicode=True):
+                if not raw_line:
+                    continue
+                name = _parse_sse_event_name(raw_line)
+                if name is None:
+                    continue
+                last_event = name
+                if name in _TERMINAL_EVENT_NAMES:
+                    break
+        except requests.RequestException as exc:
+            return InvokeResult.failed(f"stream interrupted: {exc}")
+        finally:
+            response.close()
+
+        if last_event is None:
+            return InvokeResult.failed("stream closed before any SSE event")
+        if last_event in _FAILURE_EVENT_NAMES:
+            return InvokeResult.failed(f"sync reported terminal '{last_event}' event")
+        return InvokeResult.ok(detail=f"terminal event: {last_event}")
+
+
+class ExecInvoker:
+    """Trigger a sync by running a local subprocess.
+
+    Defaults to ``python manage.py proxbox_sync --wait --enqueue-once``,
+    which means the scheduler co-exists safely with any NetBox-side
+    recurring ``ScheduleSyncForm`` configuration: a pending job is
+    short-circuited and the scheduler's invocation no-ops.
+    """
+
+    def __init__(
+        self,
+        *,
+        command: list[str],
+        timeout_seconds: float,
+        runner: Callable[..., Any] | None = None,
+    ) -> None:
+        if not command:
+            raise ValueError("ExecInvoker requires a non-empty command list")
+        self._command = list(command)
+        self._timeout = timeout_seconds
+        self._runner = runner or subprocess.run
+
+    @property
+    def command(self) -> list[str]:
+        return list(self._command)
+
+    def trigger(self) -> InvokeResult:
+        try:
+            completed = self._runner(  # type: ignore[call-arg]
+                self._command,
+                timeout=self._timeout,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return InvokeResult.failed(
+                f"subprocess timed out after {self._timeout}s: {exc}"
+            )
+        except FileNotFoundError as exc:
+            return InvokeResult.failed(f"command not found: {exc}")
+
+        rc = int(getattr(completed, "returncode", 1))
+        if rc == 0:
+            return InvokeResult.ok(detail="subprocess exited 0")
+        stderr = (getattr(completed, "stderr", "") or "").strip()[:500]
+        return InvokeResult.failed(
+            f"subprocess exited {rc}: {stderr or '<no stderr>'}",
+            exit_code=rc,
+        )
+
+
+def build_invoker(config: "SchedulerConfig") -> Invoker:  # noqa: F821 — fwd-ref to config
+    """Construct the configured invoker (selected by ``config.invoke``)."""
+    if config.invoke == "http":
+        if not config.proxbox_api_url:
+            raise ValueError("HTTP invoker requires PROXBOX_API_URL")
+        return HttpInvoker(
+            base_url=config.proxbox_api_url,
+            api_key=config.proxbox_api_key,
+            timeout_seconds=config.proxbox_api_timeout,
+            verify_ssl=config.proxbox_api_verify_ssl,
+        )
+    if config.invoke == "exec":
+        return ExecInvoker(
+            command=config.exec_command,
+            timeout_seconds=config.proxbox_api_timeout,
+        )
+    raise ValueError(f"Unknown invoker kind: {config.invoke!r}")

--- a/proxbox_scheduler/proxbox_scheduler/logging_config.py
+++ b/proxbox_scheduler/proxbox_scheduler/logging_config.py
@@ -1,0 +1,45 @@
+"""Logging configuration for proxbox-scheduler.
+
+Defaults to single-line JSON records so the container's stdout/stderr
+slots cleanly into journald, loki, or any log aggregator. Set
+``PROXBOX_SCHEDULER_LOG_JSON=false`` to fall back to a human-readable
+format for local debugging.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import Any
+
+
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_logging(*, level: str, json_output: bool) -> None:
+    """Install a single stdout handler on the root logger."""
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler(stream=sys.stdout)
+    if json_output:
+        handler.setFormatter(_JsonFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+        )
+
+    root.addHandler(handler)
+    root.setLevel(level.upper())

--- a/proxbox_scheduler/proxbox_scheduler/runner.py
+++ b/proxbox_scheduler/proxbox_scheduler/runner.py
@@ -1,0 +1,139 @@
+"""Main scheduler loop for proxbox-scheduler.
+
+The runner is intentionally minimal: it dispatches on
+:class:`~proxbox_scheduler.config.SchedulerMode` and calls ``invoker.trigger()``
+when it's time. No async runtime, no in-process worker, no shared bus —
+the container stays stateless.
+
+Failure policy: every mode applies ``config.backoff_seconds`` after a
+failed trigger to avoid hammering a wedged proxbox-api. ``continuous``
+mode otherwise has no inter-run delay; ``interval`` mode sleeps until the
+next slot regardless of last duration; ``cron`` mode sleeps until the
+next cron fire time.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime
+from typing import Callable
+
+from .config import ModeKind, SchedulerConfig
+from .cron import next_fire_time
+from .invoker import InvokeResult, Invoker
+
+logger = logging.getLogger(__name__)
+
+Sleeper = Callable[[float], None]
+Clock = Callable[[], datetime]
+
+
+class SchedulerRunner:
+    """Drive an :class:`Invoker` according to a :class:`SchedulerConfig`.
+
+    The runner exposes a ``stop()`` method so tests (and signal handlers)
+    can break out of the loop deterministically.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: SchedulerConfig,
+        invoker: Invoker,
+        sleeper: Sleeper | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        self._config = config
+        self._invoker = invoker
+        self._sleeper = sleeper or time.sleep
+        self._clock = clock or (lambda: datetime.now(tz=config.timezone))
+        self._stopping = False
+
+    def stop(self) -> None:
+        self._stopping = True
+
+    def run(self) -> None:
+        mode = self._config.mode
+        if mode.kind is ModeKind.OFF:
+            logger.info("scheduler.mode=off — exiting cleanly without scheduling work")
+            return
+
+        if mode.kind is ModeKind.CONTINUOUS:
+            self._run_continuous()
+            return
+        if mode.kind is ModeKind.INTERVAL:
+            self._run_interval()
+            return
+        if mode.kind is ModeKind.CRON:
+            self._run_cron()
+            return
+
+        raise RuntimeError(f"Unhandled mode: {mode.kind!r}")  # pragma: no cover
+
+    def _trigger(self) -> InvokeResult:
+        logger.info("scheduler.trigger.start invoke=%s", self._config.invoke)
+        result = self._invoker.trigger()
+        if result.success:
+            logger.info("scheduler.trigger.ok detail=%s", result.detail)
+        else:
+            logger.warning(
+                "scheduler.trigger.fail detail=%s exit_code=%s",
+                result.detail,
+                result.exit_code,
+            )
+        return result
+
+    def _apply_backoff_if_failed(self, result: InvokeResult) -> None:
+        if not result.success and self._config.backoff_seconds > 0:
+            logger.info(
+                "scheduler.backoff seconds=%.1f reason=trigger_failed",
+                self._config.backoff_seconds,
+            )
+            self._sleeper(self._config.backoff_seconds)
+
+    def _run_continuous(self) -> None:
+        logger.info("scheduler.mode=continuous starting tight loop")
+        while not self._stopping:
+            result = self._trigger()
+            if self._stopping:
+                return
+            self._apply_backoff_if_failed(result)
+
+    def _run_interval(self) -> None:
+        interval = float(self._config.mode.interval_seconds or 0)
+        logger.info("scheduler.mode=interval seconds=%.1f", interval)
+        while not self._stopping:
+            t0 = time.monotonic()
+            result = self._trigger()
+            if not result.success:
+                self._apply_backoff_if_failed(result)
+            if self._stopping:
+                return
+            elapsed = time.monotonic() - t0
+            remaining = interval - elapsed
+            if remaining > 0:
+                self._sleeper(remaining)
+
+    def _run_cron(self) -> None:
+        expression = self._config.mode.cron_expression or ""
+        logger.info(
+            "scheduler.mode=cron expression=%r tz=%s",
+            expression,
+            self._config.timezone.key,
+        )
+        while not self._stopping:
+            now = self._clock()
+            next_dt = next_fire_time(expression, base=now, tz=self._config.timezone)
+            wait_seconds = max(0.0, (next_dt - now).total_seconds())
+            logger.info(
+                "scheduler.cron.sleep next_fire=%s wait_seconds=%.1f",
+                next_dt.isoformat(),
+                wait_seconds,
+            )
+            if wait_seconds > 0:
+                self._sleeper(wait_seconds)
+            if self._stopping:
+                return
+            result = self._trigger()
+            self._apply_backoff_if_failed(result)

--- a/proxbox_scheduler/pyproject.toml
+++ b/proxbox_scheduler/pyproject.toml
@@ -1,0 +1,46 @@
+[project]
+name = "proxbox-scheduler"
+version = "0.0.15"
+description = "Standalone container scheduler for periodic Proxbox sync (netbox-proxbox issue #372)"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.11"
+authors = [
+    {name = "Emerson Felipe", email = "emersonfelipe.2003@gmail.com"}
+]
+dependencies = [
+    "requests>=2.33.0",
+    "croniter>=2.0.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=9.0.2",
+    "pytest-cov>=7.1.0",
+]
+
+[project.scripts]
+proxbox-scheduler = "proxbox_scheduler.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["proxbox_scheduler"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+
+[tool.coverage.run]
+branch = true
+source = ["proxbox_scheduler"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]
+ignore = ["E501"]

--- a/proxbox_scheduler/tests/conftest.py
+++ b/proxbox_scheduler/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Common fixtures for the proxbox-scheduler test suite."""
+
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from proxbox_scheduler.config import ModeKind, SchedulerConfig, SchedulerMode
+
+
+@pytest.fixture()
+def utc() -> ZoneInfo:
+    return ZoneInfo("UTC")
+
+
+@pytest.fixture()
+def base_config(utc: ZoneInfo) -> SchedulerConfig:
+    return SchedulerConfig(
+        mode=SchedulerMode(kind=ModeKind.OFF),
+        invoke="http",
+        timezone=utc,
+        backoff_seconds=0.0,
+        log_level="INFO",
+        log_json=False,
+        proxbox_api_url="http://proxbox-api.test",
+        proxbox_api_key="testkey",
+        proxbox_api_timeout=10.0,
+        proxbox_api_verify_ssl=False,
+        exec_command=["echo", "ok"],
+    )

--- a/proxbox_scheduler/tests/test_config.py
+++ b/proxbox_scheduler/tests/test_config.py
@@ -1,0 +1,156 @@
+"""Tests for env parsing and ``SchedulerConfig`` defaults."""
+
+from __future__ import annotations
+
+import pytest
+
+from proxbox_scheduler.config import (
+    ConfigError,
+    ModeKind,
+    load_config,
+    parse_mode,
+)
+
+
+class TestParseMode:
+    def test_default_is_off(self) -> None:
+        assert parse_mode(None).kind is ModeKind.OFF
+
+    def test_empty_string_is_off(self) -> None:
+        assert parse_mode("").kind is ModeKind.OFF
+        assert parse_mode("   ").kind is ModeKind.OFF
+
+    def test_literal_off(self) -> None:
+        assert parse_mode("off").kind is ModeKind.OFF
+        assert parse_mode("OFF").kind is ModeKind.OFF
+
+    def test_continuous(self) -> None:
+        assert parse_mode("continuous").kind is ModeKind.CONTINUOUS
+        assert parse_mode("Continuous").kind is ModeKind.CONTINUOUS
+
+    def test_interval(self) -> None:
+        mode = parse_mode("interval=45")
+        assert mode.kind is ModeKind.INTERVAL
+        assert mode.interval_seconds == 45
+
+    def test_interval_zero_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="positive"):
+            parse_mode("interval=0")
+
+    def test_interval_negative_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="positive"):
+            parse_mode("interval=-3")
+
+    def test_interval_non_integer_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="integer"):
+            parse_mode("interval=foo")
+
+    def test_cron_payload_preserved(self) -> None:
+        mode = parse_mode("cron=0 */4 * * *")
+        assert mode.kind is ModeKind.CRON
+        assert mode.cron_expression == "0 */4 * * *"
+
+    def test_cron_empty_payload_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="cron"):
+            parse_mode("cron=")
+
+    def test_unknown_mode_keyword_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="Unknown"):
+            parse_mode("burst=10")
+
+    def test_malformed_value_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="Invalid PROXBOX_MODE"):
+            parse_mode("not-a-mode")
+
+
+class TestLoadConfig:
+    def test_defaults_off_invoke_http(self) -> None:
+        config = load_config({})
+        assert config.mode.kind is ModeKind.OFF
+        assert config.invoke == "http"
+        assert config.timezone.key == "UTC"
+        assert config.backoff_seconds == 30.0
+        assert config.log_level == "INFO"
+        assert config.log_json is True
+        assert config.exec_command[:3] == ["python", "manage.py", "proxbox_sync"]
+        assert "--enqueue-once" in config.exec_command
+
+    def test_off_mode_does_not_require_api_url(self) -> None:
+        # PROXBOX_API_URL is only required when mode != off and invoke == http.
+        config = load_config({"PROXBOX_MODE": "off"})
+        assert config.proxbox_api_url is None
+
+    def test_http_mode_requires_api_url(self) -> None:
+        with pytest.raises(ConfigError, match="PROXBOX_API_URL"):
+            load_config({"PROXBOX_MODE": "interval=60"})
+
+    def test_exec_mode_does_not_require_api_url(self) -> None:
+        config = load_config(
+            {
+                "PROXBOX_MODE": "interval=60",
+                "PROXBOX_SCHEDULER_INVOKE": "exec",
+            }
+        )
+        assert config.invoke == "exec"
+        assert config.proxbox_api_url is None
+
+    def test_tz_parsed(self) -> None:
+        config = load_config(
+            {
+                "PROXBOX_MODE": "off",
+                "PROXBOX_SCHEDULER_TZ": "America/Sao_Paulo",
+            }
+        )
+        assert config.timezone.key == "America/Sao_Paulo"
+
+    def test_unknown_tz_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="Unknown timezone"):
+            load_config({"PROXBOX_SCHEDULER_TZ": "Mars/Olympus_Mons"})
+
+    def test_invalid_invoke_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="PROXBOX_SCHEDULER_INVOKE"):
+            load_config({"PROXBOX_SCHEDULER_INVOKE": "carrier_pigeon"})
+
+    def test_negative_backoff_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="non-negative"):
+            load_config({"PROXBOX_SCHEDULER_BACKOFF_ON_ERROR_SECONDS": "-1"})
+
+    def test_zero_api_timeout_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="positive"):
+            load_config(
+                {
+                    "PROXBOX_MODE": "interval=60",
+                    "PROXBOX_API_URL": "http://x",
+                    "PROXBOX_API_TIMEOUT": "0",
+                }
+            )
+
+    def test_verify_ssl_parses_booleans(self) -> None:
+        for raw, expected in [
+            ("true", True),
+            ("false", False),
+            ("1", True),
+            ("0", False),
+            ("yes", True),
+            ("no", False),
+        ]:
+            config = load_config(
+                {
+                    "PROXBOX_MODE": "off",
+                    "PROXBOX_API_VERIFY_SSL": raw,
+                }
+            )
+            assert config.proxbox_api_verify_ssl is expected, raw
+
+    def test_verify_ssl_garbage_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="boolean"):
+            load_config({"PROXBOX_API_VERIFY_SSL": "maybe"})
+
+    def test_custom_exec_command_tokenized(self) -> None:
+        config = load_config(
+            {
+                "PROXBOX_SCHEDULER_EXEC_CMD": "/bin/echo 'hello world'",
+                "PROXBOX_SCHEDULER_INVOKE": "exec",
+            }
+        )
+        assert config.exec_command == ["/bin/echo", "hello world"]

--- a/proxbox_scheduler/tests/test_cron.py
+++ b/proxbox_scheduler/tests/test_cron.py
@@ -1,0 +1,58 @@
+"""Cron expression evaluation tests."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from proxbox_scheduler.cron import CronError, next_fire_time, validate_expression
+
+
+def test_validate_accepts_valid_expression() -> None:
+    validate_expression("0 */4 * * *")
+    validate_expression("*/5 * * * *")
+
+
+def test_validate_rejects_garbage() -> None:
+    with pytest.raises(CronError):
+        validate_expression("not a cron")
+
+
+def test_next_fire_returns_future_time_in_tz() -> None:
+    tz = ZoneInfo("UTC")
+    base = datetime(2026, 5, 13, 10, 30, tzinfo=tz)
+    result = next_fire_time("0 */4 * * *", base=base, tz=tz)
+    assert result.tzinfo is not None
+    assert result.tzinfo.key == "UTC"
+    assert result > base
+    # 4-hour cron after 10:30 → 12:00.
+    assert result.hour == 12
+    assert result.minute == 0
+
+
+def test_next_fire_naive_base_is_interpreted_in_tz() -> None:
+    tz = ZoneInfo("America/Sao_Paulo")
+    naive = datetime(2026, 5, 13, 10, 30)  # naive
+    result = next_fire_time("0 12 * * *", base=naive, tz=tz)
+    assert result.tzinfo is not None
+    assert result.tzinfo.key == "America/Sao_Paulo"
+    assert result.hour == 12
+    assert result.minute == 0
+
+
+def test_next_fire_crosses_dst_safely() -> None:
+    # America/Sao_Paulo no longer observes DST, but the call must still
+    # succeed without crashing for any IANA zone.
+    tz = ZoneInfo("Europe/London")
+    base = datetime(2026, 3, 28, 23, 30, tzinfo=tz)  # right before BST start
+    result = next_fire_time("30 1 * * *", base=base, tz=tz)
+    assert result > base
+
+
+def test_invalid_expression_raises_at_call_time() -> None:
+    tz = ZoneInfo("UTC")
+    base = datetime(2026, 5, 13, 10, 30, tzinfo=tz)
+    with pytest.raises(CronError):
+        next_fire_time("invalid", base=base, tz=tz)

--- a/proxbox_scheduler/tests/test_invoker.py
+++ b/proxbox_scheduler/tests/test_invoker.py
@@ -1,0 +1,246 @@
+"""Invoker tests — HTTP and exec, with no live proxbox-api required."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import replace
+from typing import Iterator
+
+import pytest
+import requests
+
+from proxbox_scheduler.config import SchedulerConfig
+from proxbox_scheduler.invoker import (
+    ExecInvoker,
+    HttpInvoker,
+    InvokeResult,
+    build_invoker,
+)
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code: int, lines: list[str]) -> None:
+        self.status_code = status_code
+        self._lines = lines
+        self.text = "\n".join(lines)
+        self.closed = False
+
+    def iter_lines(self, decode_unicode: bool = False) -> Iterator[str]:
+        for line in self._lines:
+            yield line
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse | Exception) -> None:
+        self._response = response
+        self.requests: list[tuple[str, dict[str, str], dict[str, object]]] = []
+
+    def get(self, url: str, **kwargs: object) -> _FakeResponse:
+        headers = kwargs.get("headers") or {}
+        self.requests.append((url, dict(headers), dict(kwargs)))
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+class TestHttpInvoker:
+    def test_terminal_complete_event_succeeds(self) -> None:
+        response = _FakeResponse(
+            status_code=200,
+            lines=[
+                "event: progress",
+                "data: {}",
+                "",
+                "event: complete",
+                "data: {}",
+                "",
+            ],
+        )
+        session = _FakeSession(response)
+        inv = HttpInvoker(
+            base_url="http://proxbox-api.test",
+            api_key="abc",
+            timeout_seconds=5,
+            verify_ssl=False,
+            session=session,  # type: ignore[arg-type]
+        )
+
+        result = inv.trigger()
+
+        assert result.success is True
+        assert "complete" in result.detail
+        url, headers, _ = session.requests[0]
+        assert url == "http://proxbox-api.test/full-update/stream"
+        assert headers["X-Proxbox-API-Key"] == "abc"
+        assert headers["Accept"] == "text/event-stream"
+        assert response.closed is True
+
+    def test_terminal_error_event_fails(self) -> None:
+        response = _FakeResponse(
+            status_code=200,
+            lines=["event: progress", "data: {}", "", "event: error", "data: boom", ""],
+        )
+        inv = HttpInvoker(
+            base_url="http://x.test",
+            api_key=None,
+            timeout_seconds=5,
+            verify_ssl=True,
+            session=_FakeSession(response),  # type: ignore[arg-type]
+        )
+
+        result = inv.trigger()
+
+        assert result.success is False
+        assert "error" in result.detail
+
+    def test_http_error_status_fails(self) -> None:
+        response = _FakeResponse(status_code=500, lines=["upstream blew up"])
+        inv = HttpInvoker(
+            base_url="http://x.test",
+            api_key=None,
+            timeout_seconds=5,
+            verify_ssl=True,
+            session=_FakeSession(response),  # type: ignore[arg-type]
+        )
+
+        result = inv.trigger()
+
+        assert result.success is False
+        assert "HTTP 500" in result.detail
+        assert result.exit_code == 500
+
+    def test_connection_error_fails_gracefully(self) -> None:
+        session = _FakeSession(requests.ConnectionError("refused"))
+        inv = HttpInvoker(
+            base_url="http://x.test",
+            api_key=None,
+            timeout_seconds=5,
+            verify_ssl=True,
+            session=session,  # type: ignore[arg-type]
+        )
+
+        result = inv.trigger()
+
+        assert result.success is False
+        assert "connection" in result.detail.lower()
+
+    def test_stream_without_terminal_event_fails(self) -> None:
+        response = _FakeResponse(
+            status_code=200,
+            lines=["", ""],  # no events
+        )
+        inv = HttpInvoker(
+            base_url="http://x.test",
+            api_key=None,
+            timeout_seconds=5,
+            verify_ssl=True,
+            session=_FakeSession(response),  # type: ignore[arg-type]
+        )
+
+        result = inv.trigger()
+
+        assert result.success is False
+        assert "before any SSE event" in result.detail
+
+    def test_omits_api_key_header_when_missing(self) -> None:
+        response = _FakeResponse(
+            status_code=200, lines=["event: completed", "data: {}", ""]
+        )
+        session = _FakeSession(response)
+        inv = HttpInvoker(
+            base_url="http://x.test",
+            api_key=None,
+            timeout_seconds=5,
+            verify_ssl=True,
+            session=session,  # type: ignore[arg-type]
+        )
+
+        inv.trigger()
+
+        _, headers, _ = session.requests[0]
+        assert "X-Proxbox-API-Key" not in headers
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int, stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = ""
+
+
+class TestExecInvoker:
+    def test_zero_exit_succeeds(self) -> None:
+        calls: list[list[str]] = []
+
+        def runner(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+            calls.append(cmd)
+            return _FakeCompleted(returncode=0)
+
+        inv = ExecInvoker(command=["echo", "ok"], timeout_seconds=5, runner=runner)
+        result = inv.trigger()
+
+        assert result.success is True
+        assert calls == [["echo", "ok"]]
+
+    def test_nonzero_exit_fails(self) -> None:
+        def runner(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+            return _FakeCompleted(returncode=2, stderr="bad config")
+
+        inv = ExecInvoker(command=["python", "manage.py", "proxbox_sync"], timeout_seconds=5, runner=runner)
+        result = inv.trigger()
+
+        assert result.success is False
+        assert result.exit_code == 2
+        assert "bad config" in result.detail
+
+    def test_timeout_returns_failed_result(self) -> None:
+        def runner(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+
+        inv = ExecInvoker(command=["sleep", "10"], timeout_seconds=1, runner=runner)
+        result = inv.trigger()
+
+        assert result.success is False
+        assert "timed out" in result.detail
+
+    def test_file_not_found_returns_failed_result(self) -> None:
+        def runner(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+            raise FileNotFoundError(2, "no such file or directory", cmd[0])
+
+        inv = ExecInvoker(command=["nope"], timeout_seconds=5, runner=runner)
+        result = inv.trigger()
+
+        assert result.success is False
+        assert "not found" in result.detail.lower()
+
+    def test_empty_command_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            ExecInvoker(command=[], timeout_seconds=5)
+
+
+class TestBuildInvoker:
+    def test_http_invoker_built(self, base_config: SchedulerConfig) -> None:
+        inv = build_invoker(base_config)
+        assert isinstance(inv, HttpInvoker)
+
+    def test_exec_invoker_built(self, base_config: SchedulerConfig) -> None:
+        config = replace(base_config, invoke="exec")
+        inv = build_invoker(config)
+        assert isinstance(inv, ExecInvoker)
+
+    def test_http_invoker_requires_url(self, base_config: SchedulerConfig) -> None:
+        config = replace(base_config, proxbox_api_url=None)
+        with pytest.raises(ValueError, match="PROXBOX_API_URL"):
+            build_invoker(config)
+
+
+def test_invoke_result_helpers() -> None:
+    ok = InvokeResult.ok("yay")
+    fail = InvokeResult.failed("nope", exit_code=7)
+    assert ok.success is True
+    assert ok.exit_code == 0
+    assert fail.success is False
+    assert fail.exit_code == 7

--- a/proxbox_scheduler/tests/test_invoker.py
+++ b/proxbox_scheduler/tests/test_invoker.py
@@ -189,7 +189,11 @@ class TestExecInvoker:
         def runner(cmd: list[str], **kwargs: object) -> _FakeCompleted:
             return _FakeCompleted(returncode=2, stderr="bad config")
 
-        inv = ExecInvoker(command=["python", "manage.py", "proxbox_sync"], timeout_seconds=5, runner=runner)
+        inv = ExecInvoker(
+            command=["python", "manage.py", "proxbox_sync"],
+            timeout_seconds=5,
+            runner=runner,
+        )
         result = inv.trigger()
 
         assert result.success is False

--- a/proxbox_scheduler/tests/test_runner.py
+++ b/proxbox_scheduler/tests/test_runner.py
@@ -1,0 +1,258 @@
+"""Runner-loop tests using fake sleeper / clock — no real sleeping."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta
+from typing import Callable
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from proxbox_scheduler.config import ModeKind, SchedulerConfig, SchedulerMode
+from proxbox_scheduler.invoker import InvokeResult
+from proxbox_scheduler.runner import SchedulerRunner
+
+
+class _CountingInvoker:
+    def __init__(self, results: list[InvokeResult]) -> None:
+        self._results = list(results)
+        self.calls: int = 0
+
+    def trigger(self) -> InvokeResult:
+        self.calls += 1
+        if self._results:
+            return self._results.pop(0)
+        return InvokeResult.ok("default")
+
+
+class _RecordingSleeper:
+    def __init__(
+        self, on_call: Callable[["_RecordingSleeper", float], None] | None = None
+    ) -> None:
+        self.sleeps: list[float] = []
+        self._on_call = on_call
+
+    def __call__(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        if self._on_call is not None:
+            self._on_call(self, seconds)
+
+
+def _make_off_config(base_config: SchedulerConfig) -> SchedulerConfig:
+    return replace(base_config, mode=SchedulerMode(kind=ModeKind.OFF))
+
+
+def _make_continuous_config(base_config: SchedulerConfig, *, backoff: float = 0.0) -> SchedulerConfig:
+    return replace(
+        base_config,
+        mode=SchedulerMode(kind=ModeKind.CONTINUOUS),
+        backoff_seconds=backoff,
+    )
+
+
+def _make_interval_config(base_config: SchedulerConfig, *, seconds: int, backoff: float = 0.0) -> SchedulerConfig:
+    return replace(
+        base_config,
+        mode=SchedulerMode(kind=ModeKind.INTERVAL, interval_seconds=seconds),
+        backoff_seconds=backoff,
+    )
+
+
+def _make_cron_config(
+    base_config: SchedulerConfig,
+    *,
+    expression: str,
+    tz: str = "UTC",
+    backoff: float = 0.0,
+) -> SchedulerConfig:
+    return replace(
+        base_config,
+        mode=SchedulerMode(kind=ModeKind.CRON, cron_expression=expression),
+        timezone=ZoneInfo(tz),
+        backoff_seconds=backoff,
+    )
+
+
+class TestOffMode:
+    def test_off_mode_does_not_trigger(self, base_config: SchedulerConfig) -> None:
+        inv = _CountingInvoker([])
+        runner = SchedulerRunner(
+            config=_make_off_config(base_config),
+            invoker=inv,
+            sleeper=_RecordingSleeper(),
+        )
+        runner.run()
+        assert inv.calls == 0
+
+
+class TestContinuousMode:
+    def test_fires_back_to_back_until_stopped(self, base_config: SchedulerConfig) -> None:
+        inv = _CountingInvoker([InvokeResult.ok(), InvokeResult.ok()])
+
+        def stop_after_two(s: _RecordingSleeper, _seconds: float) -> None:
+            pass  # no sleeping in continuous-success path
+
+        sleeper = _RecordingSleeper(on_call=stop_after_two)
+        runner = SchedulerRunner(
+            config=_make_continuous_config(base_config),
+            invoker=inv,
+            sleeper=sleeper,
+        )
+
+        # Stop after the third call so we observe back-to-back firing
+        # without an inter-trigger sleep.
+        original_trigger = inv.trigger
+
+        def trigger_and_maybe_stop() -> InvokeResult:
+            result = original_trigger()
+            if inv.calls >= 3:
+                runner.stop()
+            return result
+
+        inv.trigger = trigger_and_maybe_stop  # type: ignore[assignment]
+        runner.run()
+
+        assert inv.calls == 3
+        assert sleeper.sleeps == []  # no backoff because all succeeded
+
+    def test_backoff_applied_only_on_failure(self, base_config: SchedulerConfig) -> None:
+        inv = _CountingInvoker(
+            [InvokeResult.ok(), InvokeResult.failed("nope"), InvokeResult.ok()]
+        )
+        sleeper = _RecordingSleeper()
+        runner = SchedulerRunner(
+            config=_make_continuous_config(base_config, backoff=15.0),
+            invoker=inv,
+            sleeper=sleeper,
+        )
+
+        original_trigger = inv.trigger
+
+        def trigger_and_maybe_stop() -> InvokeResult:
+            result = original_trigger()
+            if inv.calls >= 3:
+                runner.stop()
+            return result
+
+        inv.trigger = trigger_and_maybe_stop  # type: ignore[assignment]
+        runner.run()
+
+        assert inv.calls == 3
+        assert sleeper.sleeps == [15.0]
+
+
+class TestIntervalMode:
+    def test_sleeps_between_triggers(self, base_config: SchedulerConfig) -> None:
+        inv = _CountingInvoker([InvokeResult.ok(), InvokeResult.ok()])
+        sleeper = _RecordingSleeper()
+        runner = SchedulerRunner(
+            config=_make_interval_config(base_config, seconds=60),
+            invoker=inv,
+            sleeper=sleeper,
+        )
+
+        original_trigger = inv.trigger
+
+        def trigger_and_maybe_stop() -> InvokeResult:
+            result = original_trigger()
+            if inv.calls >= 2:
+                runner.stop()
+            return result
+
+        inv.trigger = trigger_and_maybe_stop  # type: ignore[assignment]
+        runner.run()
+
+        assert inv.calls == 2
+        # First slot sleeps; loop stops before computing second slot.
+        assert len(sleeper.sleeps) == 1
+        slept = sleeper.sleeps[0]
+        # The trigger is near-instantaneous in tests, so we should be close to 60s.
+        assert 50.0 <= slept <= 60.0
+
+    def test_interval_failure_triggers_backoff(self, base_config: SchedulerConfig) -> None:
+        inv = _CountingInvoker([InvokeResult.failed("boom")])
+        sleeper = _RecordingSleeper()
+        runner = SchedulerRunner(
+            config=_make_interval_config(base_config, seconds=30, backoff=10.0),
+            invoker=inv,
+            sleeper=sleeper,
+        )
+
+        original_trigger = inv.trigger
+
+        def trigger_and_maybe_stop() -> InvokeResult:
+            result = original_trigger()
+            runner.stop()
+            return result
+
+        inv.trigger = trigger_and_maybe_stop  # type: ignore[assignment]
+        runner.run()
+
+        assert inv.calls == 1
+        # Backoff sleep happens, then the remaining-slot sleep happens.
+        assert sleeper.sleeps[0] == 10.0
+
+
+class TestCronMode:
+    def test_cron_sleeps_until_next_fire_then_triggers(self, base_config: SchedulerConfig) -> None:
+        inv = _CountingInvoker([InvokeResult.ok()])
+        sleeper = _RecordingSleeper()
+        tz = ZoneInfo("UTC")
+        # Pretend the current time is 10:30 UTC; "0 */4 * * *" → next fire is 12:00.
+        fake_now = datetime(2026, 5, 13, 10, 30, tzinfo=tz)
+        clock_calls = {"n": 0}
+
+        def fake_clock() -> datetime:
+            clock_calls["n"] += 1
+            return fake_now
+
+        runner = SchedulerRunner(
+            config=_make_cron_config(base_config, expression="0 */4 * * *"),
+            invoker=inv,
+            sleeper=sleeper,
+            clock=fake_clock,
+        )
+
+        original_trigger = inv.trigger
+
+        def trigger_and_stop() -> InvokeResult:
+            result = original_trigger()
+            runner.stop()
+            return result
+
+        inv.trigger = trigger_and_stop  # type: ignore[assignment]
+        runner.run()
+
+        assert inv.calls == 1
+        assert len(sleeper.sleeps) == 1
+        # 10:30 → 12:00 = 5400 seconds.
+        assert sleeper.sleeps[0] == pytest.approx(5400.0, abs=1.0)
+
+    def test_cron_can_stop_during_wait(self, base_config: SchedulerConfig) -> None:
+        inv = _CountingInvoker([])
+        tz = ZoneInfo("UTC")
+        fake_now = datetime(2026, 5, 13, 10, 30, tzinfo=tz)
+
+        def fake_clock() -> datetime:
+            return fake_now
+
+        # Sleep handler: stop the runner mid-sleep so it never triggers.
+        runner_holder: dict[str, SchedulerRunner] = {}
+
+        def stop_during_sleep(_s: _RecordingSleeper, _seconds: float) -> None:
+            runner_holder["r"].stop()
+
+        sleeper = _RecordingSleeper(on_call=stop_during_sleep)
+        runner = SchedulerRunner(
+            config=_make_cron_config(base_config, expression="0 */4 * * *"),
+            invoker=inv,
+            sleeper=sleeper,
+            clock=fake_clock,
+        )
+        runner_holder["r"] = runner
+
+        runner.run()
+
+        assert inv.calls == 0
+        assert len(sleeper.sleeps) == 1

--- a/proxbox_scheduler/tests/test_runner.py
+++ b/proxbox_scheduler/tests/test_runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Callable
 from zoneinfo import ZoneInfo
 
@@ -43,7 +43,9 @@ def _make_off_config(base_config: SchedulerConfig) -> SchedulerConfig:
     return replace(base_config, mode=SchedulerMode(kind=ModeKind.OFF))
 
 
-def _make_continuous_config(base_config: SchedulerConfig, *, backoff: float = 0.0) -> SchedulerConfig:
+def _make_continuous_config(
+    base_config: SchedulerConfig, *, backoff: float = 0.0
+) -> SchedulerConfig:
     return replace(
         base_config,
         mode=SchedulerMode(kind=ModeKind.CONTINUOUS),
@@ -51,7 +53,9 @@ def _make_continuous_config(base_config: SchedulerConfig, *, backoff: float = 0.
     )
 
 
-def _make_interval_config(base_config: SchedulerConfig, *, seconds: int, backoff: float = 0.0) -> SchedulerConfig:
+def _make_interval_config(
+    base_config: SchedulerConfig, *, seconds: int, backoff: float = 0.0
+) -> SchedulerConfig:
     return replace(
         base_config,
         mode=SchedulerMode(kind=ModeKind.INTERVAL, interval_seconds=seconds),
@@ -87,7 +91,9 @@ class TestOffMode:
 
 
 class TestContinuousMode:
-    def test_fires_back_to_back_until_stopped(self, base_config: SchedulerConfig) -> None:
+    def test_fires_back_to_back_until_stopped(
+        self, base_config: SchedulerConfig
+    ) -> None:
         inv = _CountingInvoker([InvokeResult.ok(), InvokeResult.ok()])
 
         def stop_after_two(s: _RecordingSleeper, _seconds: float) -> None:
@@ -116,7 +122,9 @@ class TestContinuousMode:
         assert inv.calls == 3
         assert sleeper.sleeps == []  # no backoff because all succeeded
 
-    def test_backoff_applied_only_on_failure(self, base_config: SchedulerConfig) -> None:
+    def test_backoff_applied_only_on_failure(
+        self, base_config: SchedulerConfig
+    ) -> None:
         inv = _CountingInvoker(
             [InvokeResult.ok(), InvokeResult.failed("nope"), InvokeResult.ok()]
         )
@@ -170,7 +178,9 @@ class TestIntervalMode:
         # The trigger is near-instantaneous in tests, so we should be close to 60s.
         assert 50.0 <= slept <= 60.0
 
-    def test_interval_failure_triggers_backoff(self, base_config: SchedulerConfig) -> None:
+    def test_interval_failure_triggers_backoff(
+        self, base_config: SchedulerConfig
+    ) -> None:
         inv = _CountingInvoker([InvokeResult.failed("boom")])
         sleeper = _RecordingSleeper()
         runner = SchedulerRunner(
@@ -195,7 +205,9 @@ class TestIntervalMode:
 
 
 class TestCronMode:
-    def test_cron_sleeps_until_next_fire_then_triggers(self, base_config: SchedulerConfig) -> None:
+    def test_cron_sleeps_until_next_fire_then_triggers(
+        self, base_config: SchedulerConfig
+    ) -> None:
         inv = _CountingInvoker([InvokeResult.ok()])
         sleeper = _RecordingSleeper()
         tz = ZoneInfo("UTC")

--- a/tests/management/test_proxbox_sync.py
+++ b/tests/management/test_proxbox_sync.py
@@ -33,6 +33,7 @@ def proxbox_sync_command(monkeypatch):
     jobs_mod.PROXBOX_SYNC_JOB_TIMEOUT = 7200
 
     enqueue_calls: list[dict] = []
+    enqueue_once_calls: list[dict] = []
 
     class _ProxboxSyncJob:
         last_kwargs: dict = {}
@@ -43,6 +44,14 @@ def proxbox_sync_command(monkeypatch):
         def enqueue(cls, **kwargs):
             cls.last_kwargs = kwargs
             enqueue_calls.append(kwargs)
+            if cls.raise_on_enqueue is not None:
+                raise cls.raise_on_enqueue
+            return SimpleNamespace(pk=cls.next_job_pk)
+
+        @classmethod
+        def enqueue_once(cls, **kwargs):
+            cls.last_kwargs = kwargs
+            enqueue_once_calls.append(kwargs)
             if cls.raise_on_enqueue is not None:
                 raise cls.raise_on_enqueue
             return SimpleNamespace(pk=cls.next_job_pk)
@@ -179,6 +188,7 @@ def proxbox_sync_command(monkeypatch):
     return SimpleNamespace(
         module=module,
         enqueue_calls=enqueue_calls,
+        enqueue_once_calls=enqueue_once_calls,
         jobs_mod=jobs_mod,
         models_mod=models_mod,
         backend_auth_mod=backend_auth_mod,
@@ -202,6 +212,7 @@ def _run(command_module, **options):
         "timeout": None,
         "poll_interval": 0.0,
         "worker_grace": 0.0,
+        "enqueue_once": False,
     }
     defaults.update(options)
     cmd = command_module.Command()
@@ -264,6 +275,33 @@ def test_unknown_user_raises_command_error(proxbox_sync_command):
     with pytest.raises(CommandError, match="ghost"):
         _run(proxbox_sync_command.module, username="ghost")
     assert proxbox_sync_command.enqueue_calls == []
+
+
+def test_enqueue_once_routes_through_dedup_classmethod(proxbox_sync_command):
+    """--enqueue-once routes through ``JobRunner.enqueue_once`` for dedup.
+
+    This is the integration hook the proxbox-scheduler container relies on
+    (issue #372): the same kwargs reach the dedup classmethod and the
+    plain ``enqueue`` is bypassed, so a pending recurring schedule from
+    the NetBox-side Schedule Sync form gets reused instead of duplicated.
+    """
+    _run(proxbox_sync_command.module, enqueue_once=True)
+
+    assert proxbox_sync_command.enqueue_calls == []
+    assert len(proxbox_sync_command.enqueue_once_calls) == 1
+    call = proxbox_sync_command.enqueue_once_calls[0]
+    assert call["sync_types"] == ["all"]
+    assert call["proxmox_endpoint_ids"] == [1, 2]
+    assert call["queue_name"] == "default"
+    assert "CLI" in call["name"]
+
+
+def test_enqueue_once_default_off_uses_plain_enqueue(proxbox_sync_command):
+    """Without the flag, the command must keep using ``enqueue`` for backwards compatibility."""
+    _run(proxbox_sync_command.module)
+
+    assert len(proxbox_sync_command.enqueue_calls) == 1
+    assert proxbox_sync_command.enqueue_once_calls == []
 
 
 def test_no_active_superuser_raises_command_error(proxbox_sync_command):


### PR DESCRIPTION
## Summary

Implements [#372](https://github.com/emersonfelipesp/netbox-proxbox/issues/372): a standalone `proxbox-scheduler` container plus a `--enqueue-once` flag on the `proxbox_sync` management command so the container coexists with NetBox-side `ScheduleSyncForm` without double-runs.

## What's in

- New `proxbox_scheduler/` package (`config` / `cron` / `invoker` / `runner` / `logging_config` / `__main__`) + `Dockerfile` + `docker-compose.example.yml` + operator `README`.
- Modes: `off`, `interval=<seconds>`, `continuous`, `cron=<expression>` with `PROXBOX_SCHEDULER_TZ` for IANA-zone cron evaluation.
- Invocation: `http` (SSE against `proxbox-api` `/full-update/stream` with `X-Proxbox-API-Key`) or `exec` (subprocess `manage.py proxbox_sync`), selected via `PROXBOX_SCHEDULER_INVOKE`.
- Backoff on hard error so a wedged proxbox-api isn't hammered in `continuous` mode.
- `--enqueue-once` flag on `proxbox_sync` routes through `ProxboxSyncJob.enqueue_once()` (advisory-lock dedup keyed on `(class, instance)`), used by the scheduler's `exec` mode.
- `docs/scheduler/README.md` + `docs/operations/headless-sync.md` cross-link + `mkdocs.yml` nav entry.

## Why a separate container

NetBox's `JobRunner.handle()` already auto-reschedules periodic jobs at `interval` minute granularity (≥1 min floor). The container ships only for the genuinely new capabilities: arbitrary cron expressions, zero-gap `continuous` reconciliation, sub-minute intervals, and managed-NetBox tenants who can't run a cron unit inside the NetBox container.

The recommended path for on-prem operators stays the existing NetBox-side **Schedule Sync** form; this is called out explicitly in the docs.

## Test plan

- [x] `proxbox_scheduler/tests/` — 52 tests (config parsing, cron incl. DST cross, HTTP/exec invokers via fake doubles, runner loops with a recording sleeper)
- [x] `tests/management/test_proxbox_sync.py` — 2 new tests pin `--enqueue-once` routing through `ProxboxSyncJob.enqueue_once()` vs. plain `enqueue`
- [x] All 64 tests green locally
- [ ] CI green on the v0.0.15 base

## Companion PR

`proxbox-api` documents the integration surface (no code changes needed there): emersonfelipesp/proxbox-api#78.
