### PR TITLE
docs: sync with v0.0.15 surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ This repository packages the `netbox_proxbox` NetBox plugin. The plugin adds end
 
 The current plugin config lives in [`netbox_proxbox/__init__.py`](./netbox_proxbox/__init__.py). It declares plugin version `0.0.15` and NetBox compatibility `4.5.8` through `4.6.99` (certified simultaneously against `4.5.8`, `4.5.9`, and official `4.6.0`). The `0.0.15` release is certified with the separate `proxbox-api` backend release `0.0.11` (paired with the prior `0.0.14` / backend `0.0.10.post2`). `proxbox-api` is not a Python dependency of this plugin; the services communicate over HTTP.
 
+**Companion repos (cross-link map):**
+
+- Backend service: [`emersonfelipesp/proxbox-api`](https://github.com/emersonfelipesp/proxbox-api) — the HA REST shim and `overwrite_ip_address_dns_name` write paths in this release pair with `proxbox-api 0.0.11`. See its [`docs/api/cluster-ha.md`](https://github.com/emersonfelipesp/proxbox-api/blob/main/docs/api/cluster-ha.md) for the upstream contract this plugin proxies.
+- Workspace context: [`personal-context/claude-reference/netbox-proxbox.md`](https://github.com/emersonfelipesp/personal-context/blob/main/claude-reference/netbox-proxbox.md) — N-MultiCloud workspace-level notes (cross-repo deps, NetBox compatibility rotation policy).
+
 ## Architecture Summary
 
 - `ProxmoxEndpoint`, `NetBoxEndpoint`, `FastAPIEndpoint`, `ProxmoxCluster`, `ProxmoxNode`, `ProxmoxStorage`, `BackupRoutine`, `Replication`, `VMBackup`, `VMSnapshot`, `VMTaskHistory`, and `ProxboxPluginSettings` are the plugin's main persisted models.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Proxbox discovers and syncs the following from Proxmox into NetBox:
 
 Sync runs on-demand from the NetBox UI or scheduled automatically via NetBox's job system.
 
+## What's New in v0.0.15
+
+Paired with backend [`proxbox-api 0.0.11`](https://github.com/emersonfelipesp/proxbox-api):
+
+- **Cluster HA visibility** — new per-VM **HA tab** and cluster-wide **HA Status** page, both fetched live from `proxbox-api` (no persistence, no migration). See [HA feature](https://emersonfelipesp.github.io/netbox-proxbox/features/ha/).
+- **`Use HTTPS` decoupled from `Verify SSL`** on `FastAPIEndpoint` — supports the `*-nginx` image's self-signed mkcert TLS without disabling cert verification globally. See [Backend Setup](https://emersonfelipesp.github.io/netbox-proxbox/installation/backend-setup/).
+- **`proxbox_sync` headless command** — `python manage.py proxbox_sync` enqueues the same full-update job as the UI button; usable from cron, systemd timers, or CI. See [Headless Sync](https://emersonfelipesp.github.io/netbox-proxbox/operations/headless-sync/).
+- **Runtime sync tunables** on `ProxboxPluginSettings` (`bulk_batch_size`, `bulk_batch_delay_ms`, `backup_batch_size`, `backup_batch_delay_ms`, `vm_sync_max_concurrency`) plus the new `overwrite_vm_type` and `overwrite_ip_address_dns_name` flags. See [Plugin Settings](https://emersonfelipesp.github.io/netbox-proxbox/configuration/plugin-settings/) and [Sync Overwrite Flags](https://emersonfelipesp.github.io/netbox-proxbox/configuration/sync-overwrite-flags/).
+- **NetBox 4.6 auto-detect** — the VM type plugin pages branch automatically on the presence of NetBox 4.6's `VirtualMachineType` relation, keeping a working path for both 4.5.x and 4.6.x.
+
+Full notes: [Release Notes — v0.0.15](https://emersonfelipesp.github.io/netbox-proxbox/release-notes/version-0.0.15/).
+
 ## Compatibility Matrix
 
 | NetBox   | netbox-proxbox | proxbox-api | netbox-sdk     | proxmox-sdk    |

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -215,6 +215,7 @@ curl -X POST \
        "name": "proxbox-backend",
        "domain": "proxbox-api.example.com",
        "port": 8800,
+       "use_https": true,
        "verify_ssl": false,
        "use_websocket": true,
        "websocket_port": 8800
@@ -244,6 +245,7 @@ curl -H "Authorization: Token <token>" \
   "ip_address": null,
   "domain": "proxbox-api.example.com",
   "port": 8800,
+  "use_https": true,
   "verify_ssl": false,
   "token": "a1b2c3d4e5f6...",
   "use_websocket": true,
@@ -268,7 +270,8 @@ curl -H "Authorization: Token <token>" \
 | `ip_address` | nested IPAddress (nullable) | NetBox IPAddress object linked to this endpoint |
 | `domain` | string (nullable) | FQDN, hostname, or `localhost` |
 | `port` | integer | HTTP API port (default `8800`) |
-| `verify_ssl` | boolean | Whether to verify the backend TLS certificate |
+| `use_https` | boolean | URL scheme selector. `true` → `https://`, `false` → `http://`. Independent of `verify_ssl` since v0.0.15 (migration `0038`, [#352](https://github.com/emersonfelipesp/netbox-proxbox/issues/352)). See [Backend Setup → TLS combinations](../installation/backend-setup.md) and [v0.0.15 release notes](../release-notes/version-0.0.15.md). |
+| `verify_ssl` | boolean | Whether to verify the backend TLS certificate. Only meaningful when `use_https=true`. |
 | `token` | string (read-only) | Bearer token used to authenticate requests to the backend |
 | `use_websocket` | boolean | Whether to use a WebSocket connection for streaming |
 | `websocket_domain` | string | Override domain for WebSocket connections (defaults to `domain`) |

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -11,7 +11,7 @@ GET   /api/plugins/proxbox/settings/{id}/
 PATCH /api/plugins/proxbox/settings/{id}/
 ```
 
-For common API conventions (authentication, pagination, nested serializers), see [API Overview](index.md).
+For common API conventions (authentication, pagination, nested serializers), see [API Overview](index.md). For the human-readable description of every tunable (defaults, env-var overrides, resolution order), see [Plugin Settings configuration guide](../configuration/plugin-settings.md).
 
 ---
 
@@ -65,6 +65,8 @@ curl -X PATCH \
   "netbox_get_cache_ttl": "60.00",
   "bulk_batch_size": 50,
   "bulk_batch_delay_ms": 500,
+  "backup_batch_size": 5,
+  "backup_batch_delay_ms": 200,
   "vm_sync_max_concurrency": 4,
   "custom_fields_request_delay": "0.00",
   "backend_log_file_path": "/var/log/proxbox.log",
@@ -105,6 +107,8 @@ These fields are set by the system and cannot be modified via PATCH:
 | `vm_sync_max_concurrency` | integer | Maximum number of VMs synced in parallel per sync run |
 | `bulk_batch_size` | integer | Number of objects per batch in bulk NetBox write operations |
 | `bulk_batch_delay_ms` | integer | Delay in milliseconds between bulk write batches |
+| `backup_batch_size` | integer | Records per batch during backup/snapshot reconciliation (kept lower than bulk batches because each item triggers Proxmox calls). Default `5`. |
+| `backup_batch_delay_ms` | integer | Milliseconds to pause between backup batches. Default `200`. |
 | `custom_fields_request_delay` | decimal | Delay in seconds between custom field update requests |
 
 ### NetBox Client

--- a/docs/configuration/plugin-settings.md
+++ b/docs/configuration/plugin-settings.md
@@ -2,6 +2,9 @@
 
 Proxbox exposes a singleton **Plugin Settings** object for runtime behavior toggles. Create or edit it under **Plugins → Proxbox → Plugin Settings**.
 
+!!! tip "Programmatic access"
+    Every field below is also readable and writable through the [Plugin Settings API](../api/settings.md) (GET + PATCH).
+
 ## Runtime tunable resolution
 
 Most fields below are also readable by the paired `proxbox-api` backend through

--- a/docs/features/ha.md
+++ b/docs/features/ha.md
@@ -9,6 +9,13 @@ There are two entry points:
 
 Both views are **read-only** and **fetched live** from the proxbox-api backend on every request. There is no NetBox-side caching, no persisted HA model, and no migration. Stop the proxbox-api service and the pages render an inline error banner instead of a 500.
 
+!!! info "Backend floor"
+    HA views require **`proxbox-api >= 0.0.11`**. Older backends return `404` on the new routes and both views show an inline upgrade banner instead of failing. The full upstream contract lives in [`proxbox-api` Cluster HA API](https://github.com/emersonfelipesp/proxbox-api/blob/main/docs/api/cluster-ha.md).
+
+## Visibility
+
+The VM HA tab only registers when the VM has a resolvable `proxmox_vm_id` custom field. VMs that were never synced through Proxbox (or that lost the custom-field value) will not show the tab — that is expected behavior, not a misconfiguration. The cluster-wide HA Status page is always available under **Plugins → Proxbox → HA Status** regardless of any single VM's sync state.
+
 ## VM HA Tab
 
 The tab appears next to **Proxmox Config** on each `VirtualMachine` detail page (slot weight `1400`).

--- a/docs/models/others.md
+++ b/docs/models/others.md
@@ -4,7 +4,7 @@ The plugin's main plugin-specific models are:
 
 - `ProxmoxEndpoint`: Proxmox cluster or node credentials and connectivity settings (with per-endpoint sync overwrite flags and a Settings tab)
 - `NetBoxEndpoint`: target NetBox API endpoint and token configuration (singleton)
-- `FastAPIEndpoint`: `proxbox-api` backend connectivity settings (singleton)
+- `FastAPIEndpoint`: `proxbox-api` backend connectivity settings (singleton). Since v0.0.15 the model exposes `use_https` (URL scheme) and `verify_ssl` (certificate verification) as **independent** boolean flags — `use_https=true, verify_ssl=false` is the supported combination for the `*-nginx` image with a self-signed mkcert certificate. See [Backend Setup](../installation/backend-setup.md) for the full combination table and migration `0038_fastapiendpoint_use_https.py` for the upgrade-path backfill.
 - `ProxmoxCluster`: synchronized cluster metadata linked to NetBox `Cluster`
 - `ProxmoxNode`: synchronized hypervisor node metadata linked to NetBox `Device`
 - `ProxmoxStorage`: synchronized storage rows linked to NetBox clusters and virtual disks

--- a/docs/models/virtual-machine.md
+++ b/docs/models/virtual-machine.md
@@ -7,5 +7,6 @@ Proxbox stores synchronized compute inventory in NetBox's built-in `virtualizati
 - Proxmox QEMU guests and LXC containers are both represented as NetBox virtual machines.
 - The plugin separates them in the UI by filtering on Proxbox-managed metadata such as guest type.
 - Related plugin-side records include `VMBackup`, `VMSnapshot`, `VMTaskHistory`, and storage links through `ProxmoxStorage`.
+- VMs that carry a resolvable `proxmox_vm_id` (custom field set during sync) gain a read-only **HA** tab on the detail page, sibling to **Proxmox Config**. The tab queries the paired `proxbox-api` and is hidden when the VM has not been synced through Proxbox. See [High Availability (HA)](../features/ha.md).
 
 See [Virtual Machine](../features/virtual-machine.md) for the user-facing view split between VMs and containers.


### PR DESCRIPTION
## Summary
- Document `FastAPIEndpoint.use_https` (migration `0038`, #352) and its split from `verify_ssl` in `docs/api/endpoints.md` and `docs/models/others.md`.
- Surface `backup_batch_size` / `backup_batch_delay_ms` tunables in `docs/api/settings.md` and cross-link to `docs/configuration/plugin-settings.md`.
- Add HA tab visibility note (gated on `proxmox_vm_id`) and the `proxbox-api >= 0.0.11` floor to `docs/features/ha.md`; cross-reference from `docs/models/virtual-machine.md`.
- README "What's new in v0.0.15" block.
- Companion-repo cross-link block in `CLAUDE.md`.

## Test plan
- [x] `mkdocs build --strict` (8 warnings pre-existing, unrelated to this change).
- [x] Verified `use_https`, `backup_batch_*`, and HA route claims against `netbox_proxbox/` source.