### PR TITLE
feat(pbs): scaffold netbox_pbs plugin as separate wheel (#325)

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -106,6 +106,41 @@ jobs:
                           if isinstance(target, ast.Name) and target.id == 'version':
                               init_version = ast.literal_eval(stmt.value)
                               break
+
+          # netbox-pbs sister package (issue #325): version-locked to netbox-proxbox in v1.
+          pbs_data = tomllib.loads(
+              pathlib.Path('netbox_pbs/pyproject.toml').read_text(encoding='utf-8')
+          )
+          pbs_project_name = pbs_data['project']['name']
+          pbs_version = pbs_data['project']['version']
+          pbs_init_tree = ast.parse(
+              pathlib.Path('netbox_pbs/netbox_pbs/__init__.py').read_text(encoding='utf-8')
+          )
+          pbs_init_version = None
+          for node in pbs_init_tree.body:
+              if isinstance(node, ast.ClassDef) and node.name == 'PBSConfig':
+                  for stmt in node.body:
+                      if not isinstance(stmt, ast.Assign):
+                          continue
+                      for target in stmt.targets:
+                          if isinstance(target, ast.Name) and target.id == 'version':
+                              pbs_init_version = ast.literal_eval(stmt.value)
+                              break
+          if pbs_project_name != 'netbox-pbs':
+              raise SystemExit(
+                  f'Expected netbox_pbs project name netbox-pbs, got {pbs_project_name!r}'
+              )
+          if pbs_init_version != pbs_version:
+              raise SystemExit(
+                  f'netbox_pbs/netbox_pbs/__init__.py version mismatch: '
+                  f'init={pbs_init_version!r}, version={pbs_version!r}'
+              )
+          if pbs_version != version:
+              raise SystemExit(
+                  f'netbox-pbs version {pbs_version!r} must equal netbox-proxbox version {version!r} '
+                  'while both packages share a release train (issue #325 v1).'
+              )
+
           tag = os.getenv('GITHUB_REF_NAME', '')
           event = os.getenv('GITHUB_EVENT_NAME', '')
           release_tag = os.getenv('RELEASE_TAG_NAME', '') or ''
@@ -156,8 +191,12 @@ jobs:
               fh.write(f'version={version}\n')
           PY
 
-      - name: Build distribution
-        run: uv build
+      - name: Build netbox-proxbox distribution
+        run: uv build --out-dir dist
+
+      - name: Build netbox-pbs distribution
+        working-directory: netbox_pbs
+        run: uv build --out-dir ../dist
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v7
@@ -228,32 +267,35 @@ jobs:
         run: |
           set -eux
           uv venv --python "${{ matrix.python-version }}" .package-smoke
-          installed=0
-          for i in $(seq 1 30); do
-            if uv pip install \
-              --python .package-smoke/bin/python \
-              --index-url https://test.pypi.org/simple/ \
-              --extra-index-url https://pypi.org/simple/ \
-              "${PACKAGE_NAME}==${PACKAGE_VERSION}"; then
-              installed=1
-              break
+          for package in "${PACKAGE_NAME}" "netbox-pbs"; do
+            installed=0
+            for i in $(seq 1 30); do
+              if uv pip install \
+                --python .package-smoke/bin/python \
+                --index-url https://test.pypi.org/simple/ \
+                --extra-index-url https://pypi.org/simple/ \
+                "${package}==${PACKAGE_VERSION}"; then
+                installed=1
+                break
+              fi
+              sleep 10
+            done
+            if [ "$installed" -ne 1 ]; then
+              exit 1
             fi
-            sleep 10
           done
-          if [ "$installed" -ne 1 ]; then
-            exit 1
-          fi
+          PACKAGE_NAMES="${PACKAGE_NAME},netbox-pbs" \
           .package-smoke/bin/python - <<'PY'
           import importlib.metadata as metadata
           import os
 
-          package_name = os.environ["PACKAGE_NAME"]
           package_version = os.environ["PACKAGE_VERSION"]
-          installed_version = metadata.version(package_name)
-          if installed_version != package_version:
-              raise SystemExit(
-                  f"Installed {package_name} {installed_version}, expected {package_version}"
-              )
+          for package_name in os.environ["PACKAGE_NAMES"].split(","):
+              installed_version = metadata.version(package_name)
+              if installed_version != package_version:
+                  raise SystemExit(
+                      f"Installed {package_name} {installed_version}, expected {package_version}"
+                  )
           PY
 
       - name: Sync development environment
@@ -380,31 +422,34 @@ jobs:
         run: |
           set -eux
           uv venv --python "${{ matrix.python-version }}" .package-smoke
-          installed=0
-          for i in $(seq 1 30); do
-            if uv pip install \
-              --python .package-smoke/bin/python \
-              --index-url https://pypi.org/simple/ \
-              "${PACKAGE_NAME}==${PACKAGE_VERSION}"; then
-              installed=1
-              break
+          for package in "${PACKAGE_NAME}" "netbox-pbs"; do
+            installed=0
+            for i in $(seq 1 30); do
+              if uv pip install \
+                --python .package-smoke/bin/python \
+                --index-url https://pypi.org/simple/ \
+                "${package}==${PACKAGE_VERSION}"; then
+                installed=1
+                break
+              fi
+              sleep 10
+            done
+            if [ "$installed" -ne 1 ]; then
+              exit 1
             fi
-            sleep 10
           done
-          if [ "$installed" -ne 1 ]; then
-            exit 1
-          fi
+          PACKAGE_NAMES="${PACKAGE_NAME},netbox-pbs" \
           .package-smoke/bin/python - <<'PY'
           import importlib.metadata as metadata
           import os
 
-          package_name = os.environ["PACKAGE_NAME"]
           package_version = os.environ["PACKAGE_VERSION"]
-          installed_version = metadata.version(package_name)
-          if installed_version != package_version:
-              raise SystemExit(
-                  f"Installed {package_name} {installed_version}, expected {package_version}"
-              )
+          for package_name in os.environ["PACKAGE_NAMES"].split(","):
+              installed_version = metadata.version(package_name)
+              if installed_version != package_version:
+                  raise SystemExit(
+                      f"Installed {package_name} {installed_version}, expected {package_version}"
+                  )
           PY
 
   e2e-docker-pypi:

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -107,7 +107,8 @@ jobs:
                               init_version = ast.literal_eval(stmt.value)
                               break
 
-          # netbox-pbs sister package (issue #325): version-locked to netbox-proxbox in v1.
+          # netbox-pbs sister package (issue #325): version is tracked independently
+          # (netbox-pbs starts at 0.0.1 while netbox-proxbox continues its own train).
           pbs_data = tomllib.loads(
               pathlib.Path('netbox_pbs/pyproject.toml').read_text(encoding='utf-8')
           )
@@ -135,12 +136,6 @@ jobs:
                   f'netbox_pbs/netbox_pbs/__init__.py version mismatch: '
                   f'init={pbs_init_version!r}, version={pbs_version!r}'
               )
-          if pbs_version != version:
-              raise SystemExit(
-                  f'netbox-pbs version {pbs_version!r} must equal netbox-proxbox version {version!r} '
-                  'while both packages share a release train (issue #325 v1).'
-              )
-
           tag = os.getenv('GITHUB_REF_NAME', '')
           event = os.getenv('GITHUB_EVENT_NAME', '')
           release_tag = os.getenv('RELEASE_TAG_NAME', '') or ''

--- a/netbox_pbs/MANIFEST.in
+++ b/netbox_pbs/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include netbox_pbs/templates *
+recursive-include netbox_pbs/static *
+recursive-include netbox_pbs/migrations *.py
+include README.md
+include LICENSE

--- a/netbox_pbs/README.md
+++ b/netbox_pbs/README.md
@@ -1,0 +1,21 @@
+# netbox-pbs
+
+NetBox plugin that adds first-class read-only inventory for Proxmox Backup
+Server (PBS): datastores, backup groups, snapshots, and job status.
+
+This package is shipped from the same repository as `netbox-proxbox` but is
+installed as a separate wheel (`netbox-pbs`). When both plugins are installed
+the `netbox-proxbox` `VMBackup` model gains an optional cross-link to a PBS
+snapshot; when only `netbox-pbs` is installed the plugin runs standalone.
+
+## Status
+
+Scaffold (PR C1 of issue
+[emersonfelipesp/netbox-proxbox#325](https://github.com/emersonfelipesp/netbox-proxbox/issues/325)).
+Domain models, sync jobs, and the optional `netbox-branching` integration land
+in subsequent sub-PRs.
+
+## Compatibility
+
+- NetBox: 4.5.8 — 4.6.99
+- Backend: `proxbox-api >= 0.0.11`

--- a/netbox_pbs/netbox_pbs/__init__.py
+++ b/netbox_pbs/netbox_pbs/__init__.py
@@ -1,0 +1,35 @@
+"""Register the netbox-pbs NetBox plugin and declare its compatibility metadata.
+
+This plugin adds read-only inventory for Proxmox Backup Server (PBS):
+datastores, backup groups, snapshots, and job status. The integration
+is `netbox-branching`-aware from day one (the branch lifecycle helpers
+mirror those used by ``netbox_proxbox``).
+
+This file ships in PR C1 as scaffold only — domain models, sync jobs,
+and the optional cross-link to ``netbox_proxbox.VMBackup`` land in
+subsequent sub-PRs of issue #325.
+"""
+
+from netbox.plugins import PluginConfig
+
+
+class PBSConfig(PluginConfig):
+    """Django app config for the netbox-pbs NetBox plugin."""
+
+    name = "netbox_pbs"
+    verbose_name = "Proxmox Backup Server"
+    description = (
+        "Read-only Proxmox Backup Server (PBS) inventory: datastores, "
+        "backup groups, snapshots, and job status."
+    )
+    version = "0.0.15"
+    author = "Emerson Felipe (@emersonfelipesp)"
+    author_email = "emersonfelipe.2003@gmail.com"
+    min_version = "4.5.8"
+    max_version = "4.6.99"
+    base_url = "pbs"
+    required_settings = []
+    queues = []
+
+
+config = PBSConfig

--- a/netbox_pbs/netbox_pbs/__init__.py
+++ b/netbox_pbs/netbox_pbs/__init__.py
@@ -2,14 +2,14 @@
 
 This plugin adds read-only inventory for Proxmox Backup Server (PBS):
 datastores, backup groups, snapshots, and job status. The integration
-is `netbox-branching`-aware from day one (the branch lifecycle helpers
-mirror those used by ``netbox_proxbox``).
+is `netbox-branching`-aware from day one and hard-depends on
+``netbox_proxbox`` for shared utilities (NetBoxEndpoint, FastAPIEndpoint,
+branch lifecycle helpers, HTTP client patterns).
 
-When ``netbox_proxbox`` is also installed, a presentation-only
-cross-link panel is rendered on both the ``VMBackup`` detail page and
-the ``PBSSnapshot`` detail page. The two sides are matched by natural
-key (``vmid`` + ``creation_time``) — no foreign key, no schema change.
-See ``template_content.py``.
+A presentation-only cross-link panel is rendered on both the ``VMBackup``
+detail page and the ``PBSSnapshot`` detail page. The two sides are
+matched by natural key (``vmid`` + ``creation_time``) — no foreign key,
+no schema change. See ``template_content.py``.
 """
 
 from netbox.plugins import PluginConfig
@@ -31,6 +31,7 @@ class PBSConfig(PluginConfig):
     max_version = "4.6.99"
     base_url = "pbs"
     required_settings = []
+    required_plugins = ["netbox_proxbox"]
     queues = []
 
 

--- a/netbox_pbs/netbox_pbs/__init__.py
+++ b/netbox_pbs/netbox_pbs/__init__.py
@@ -24,7 +24,7 @@ class PBSConfig(PluginConfig):
         "Read-only Proxmox Backup Server (PBS) inventory: datastores, "
         "backup groups, snapshots, and job status."
     )
-    version = "0.0.15"
+    version = "0.0.1"
     author = "Emerson Felipe (@emersonfelipesp)"
     author_email = "emersonfelipe.2003@gmail.com"
     min_version = "4.5.8"

--- a/netbox_pbs/netbox_pbs/__init__.py
+++ b/netbox_pbs/netbox_pbs/__init__.py
@@ -5,9 +5,11 @@ datastores, backup groups, snapshots, and job status. The integration
 is `netbox-branching`-aware from day one (the branch lifecycle helpers
 mirror those used by ``netbox_proxbox``).
 
-This file ships in PR C1 as scaffold only — domain models, sync jobs,
-and the optional cross-link to ``netbox_proxbox.VMBackup`` land in
-subsequent sub-PRs of issue #325.
+When ``netbox_proxbox`` is also installed, a presentation-only
+cross-link panel is rendered on both the ``VMBackup`` detail page and
+the ``PBSSnapshot`` detail page. The two sides are matched by natural
+key (``vmid`` + ``creation_time``) — no foreign key, no schema change.
+See ``template_content.py``.
 """
 
 from netbox.plugins import PluginConfig

--- a/netbox_pbs/netbox_pbs/api/__init__.py
+++ b/netbox_pbs/netbox_pbs/api/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin REST API package for netbox-pbs."""

--- a/netbox_pbs/netbox_pbs/api/serializers.py
+++ b/netbox_pbs/netbox_pbs/api/serializers.py
@@ -1,0 +1,255 @@
+"""DRF serializers for the netbox-pbs plugin API.
+
+One ``NetBoxModelSerializer`` per persisted PBS model. ``PBSEndpoint`` is the
+only writable surface; ``token_value`` is marked write-only so it never
+appears in API responses. The five reflected models (``PBSNode``,
+``PBSDatastore``, ``PBSBackupGroup``, ``PBSSnapshot``, ``PBSJobStatus``)
+serialize their full payload because the read-only enforcement happens at the
+viewset layer (``http_method_names`` restricts to GET/HEAD/OPTIONS).
+"""
+
+from __future__ import annotations
+
+from netbox.api.fields import ChoiceField
+from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
+from rest_framework import serializers
+
+from netbox_pbs.choices import (
+    PBSBackupTypeChoices,
+    PBSDatastoreGCStatusChoices,
+    PBSJobRunStateChoices,
+    PBSJobTypeChoices,
+    PBSSnapshotVerifyChoices,
+)
+from netbox_pbs.models import (
+    PBSBackupGroup,
+    PBSDatastore,
+    PBSEndpoint,
+    PBSJobStatus,
+    PBSNode,
+    PBSSnapshot,
+)
+
+
+class NestedPBSEndpointSerializer(WritableNestedSerializer):
+    """Minimal PBSEndpoint for nested references."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_pbs-api:pbsendpoint-detail",
+    )
+
+    class Meta:
+        model = PBSEndpoint
+        fields = ["id", "url", "display", "name"]
+        brief_fields = ("id", "url", "display", "name")
+
+
+class NestedPBSDatastoreSerializer(WritableNestedSerializer):
+    """Minimal PBSDatastore for nested references."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_pbs-api:pbsdatastore-detail",
+    )
+
+    class Meta:
+        model = PBSDatastore
+        fields = ["id", "url", "display", "name"]
+        brief_fields = ("id", "url", "display", "name")
+
+
+class NestedPBSBackupGroupSerializer(WritableNestedSerializer):
+    """Minimal PBSBackupGroup for nested references."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_pbs-api:pbsbackupgroup-detail",
+    )
+
+    class Meta:
+        model = PBSBackupGroup
+        fields = ["id", "url", "display", "backup_type", "backup_id"]
+        brief_fields = ("id", "url", "display", "backup_type", "backup_id")
+
+
+class PBSEndpointSerializer(NetBoxModelSerializer):
+    """Full PBSEndpoint serializer. ``token_value`` is write-only."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_pbs-api:pbsendpoint-detail",
+    )
+    token_value = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = PBSEndpoint
+        fields = (
+            "id",
+            "url",
+            "display",
+            "name",
+            "host",
+            "port",
+            "token_id",
+            "token_value",
+            "fingerprint",
+            "verify_ssl",
+            "timeout",
+            "last_seen_at",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+        brief_fields = ("id", "url", "display", "name", "host", "port")
+
+
+class PBSNodeSerializer(NetBoxModelSerializer):
+    """Full PBSNode serializer (reflected, read-only at view layer)."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_pbs-api:pbsnode-detail",
+    )
+    endpoint = NestedPBSEndpointSerializer()
+
+    class Meta:
+        model = PBSNode
+        fields = (
+            "id",
+            "url",
+            "display",
+            "endpoint",
+            "hostname",
+            "version",
+            "uptime_seconds",
+            "cpu_pct",
+            "memory_used",
+            "memory_total",
+            "last_seen_at",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+        brief_fields = ("id", "url", "display", "hostname")
+
+
+class PBSDatastoreSerializer(NetBoxModelSerializer):
+    """Full PBSDatastore serializer (reflected, read-only at view layer)."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_pbs-api:pbsdatastore-detail",
+    )
+    endpoint = NestedPBSEndpointSerializer()
+    gc_status = ChoiceField(choices=PBSDatastoreGCStatusChoices)
+
+    class Meta:
+        model = PBSDatastore
+        fields = (
+            "id",
+            "url",
+            "display",
+            "endpoint",
+            "name",
+            "path",
+            "total_bytes",
+            "used_bytes",
+            "available_bytes",
+            "gc_status",
+            "last_gc_at",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+        brief_fields = ("id", "url", "display", "name")
+
+
+class PBSBackupGroupSerializer(NetBoxModelSerializer):
+    """Full PBSBackupGroup serializer (reflected, read-only at view layer)."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_pbs-api:pbsbackupgroup-detail",
+    )
+    datastore = NestedPBSDatastoreSerializer()
+    backup_type = ChoiceField(choices=PBSBackupTypeChoices)
+
+    class Meta:
+        model = PBSBackupGroup
+        fields = (
+            "id",
+            "url",
+            "display",
+            "datastore",
+            "backup_type",
+            "backup_id",
+            "owner",
+            "comment",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+        brief_fields = ("id", "url", "display", "backup_type", "backup_id")
+
+
+class PBSSnapshotSerializer(NetBoxModelSerializer):
+    """Full PBSSnapshot serializer (reflected, read-only at view layer)."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_pbs-api:pbssnapshot-detail",
+    )
+    backup_group = NestedPBSBackupGroupSerializer()
+    verified = ChoiceField(choices=PBSSnapshotVerifyChoices)
+
+    class Meta:
+        model = PBSSnapshot
+        fields = (
+            "id",
+            "url",
+            "display",
+            "backup_group",
+            "backup_time",
+            "size_bytes",
+            "encrypted",
+            "verified",
+            "protected",
+            "comment",
+            "files",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+        brief_fields = ("id", "url", "display", "backup_time")
+
+
+class PBSJobStatusSerializer(NetBoxModelSerializer):
+    """Full PBSJobStatus serializer (reflected, read-only at view layer)."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_pbs-api:pbsjobstatus-detail",
+    )
+    endpoint = NestedPBSEndpointSerializer()
+    datastore = NestedPBSDatastoreSerializer(required=False, allow_null=True)
+    job_type = ChoiceField(choices=PBSJobTypeChoices)
+    last_run_state = ChoiceField(choices=PBSJobRunStateChoices)
+
+    class Meta:
+        model = PBSJobStatus
+        fields = (
+            "id",
+            "url",
+            "display",
+            "endpoint",
+            "datastore",
+            "job_type",
+            "job_id",
+            "enabled",
+            "last_run_at",
+            "last_run_state",
+            "last_run_duration_seconds",
+            "next_run_at",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+        brief_fields = ("id", "url", "display", "job_type", "job_id")

--- a/netbox_pbs/netbox_pbs/api/urls.py
+++ b/netbox_pbs/netbox_pbs/api/urls.py
@@ -1,0 +1,23 @@
+"""API URL routes for the netbox-pbs plugin.
+
+One ``NetBoxRouter`` registers all six PBS viewsets at predictable basenames
+(``pbsendpoint``, ``pbsnode``, ``pbsdatastore``, ``pbsbackupgroup``,
+``pbssnapshot``, ``pbsjobstatus``) so reverse lookups resolve as
+``plugins-api:netbox_pbs-api:<basename>-detail``.
+"""
+
+from netbox.api.routers import NetBoxRouter
+
+from netbox_pbs.api import views
+
+app_name = "netbox_pbs"
+
+router = NetBoxRouter()
+router.register("endpoints", views.PBSEndpointViewSet, basename="pbsendpoint")
+router.register("nodes", views.PBSNodeViewSet, basename="pbsnode")
+router.register("datastores", views.PBSDatastoreViewSet, basename="pbsdatastore")
+router.register("backup-groups", views.PBSBackupGroupViewSet, basename="pbsbackupgroup")
+router.register("snapshots", views.PBSSnapshotViewSet, basename="pbssnapshot")
+router.register("job-status", views.PBSJobStatusViewSet, basename="pbsjobstatus")
+
+urlpatterns = router.urls

--- a/netbox_pbs/netbox_pbs/api/views.py
+++ b/netbox_pbs/netbox_pbs/api/views.py
@@ -1,0 +1,80 @@
+"""DRF viewsets for the netbox-pbs plugin API.
+
+Read-only enforcement lives at the viewset layer: the five reflected models
+restrict ``http_method_names`` to GET/HEAD/OPTIONS so POST/PUT/PATCH/DELETE
+return 405. ``PBSEndpoint`` is the only writable surface.
+"""
+
+from __future__ import annotations
+
+from netbox.api.viewsets import NetBoxModelViewSet
+
+from netbox_pbs import filtersets, models
+from netbox_pbs.api.serializers import (
+    PBSBackupGroupSerializer,
+    PBSDatastoreSerializer,
+    PBSEndpointSerializer,
+    PBSJobStatusSerializer,
+    PBSNodeSerializer,
+    PBSSnapshotSerializer,
+)
+
+
+_READ_ONLY_HTTP_METHODS = ("get", "head", "options")
+
+
+class PBSEndpointViewSet(NetBoxModelViewSet):
+    """REST API for PBS endpoint credentials. Full CRUD."""
+
+    queryset = models.PBSEndpoint.objects.all()
+    serializer_class = PBSEndpointSerializer
+    filterset_class = filtersets.PBSEndpointFilterSet
+
+
+class PBSNodeViewSet(NetBoxModelViewSet):
+    """REST API for reflected PBS nodes. Read-only (GET/HEAD/OPTIONS)."""
+
+    queryset = models.PBSNode.objects.select_related("endpoint")
+    serializer_class = PBSNodeSerializer
+    filterset_class = filtersets.PBSNodeFilterSet
+    http_method_names = _READ_ONLY_HTTP_METHODS
+
+
+class PBSDatastoreViewSet(NetBoxModelViewSet):
+    """REST API for reflected PBS datastores. Read-only (GET/HEAD/OPTIONS)."""
+
+    queryset = models.PBSDatastore.objects.select_related("endpoint")
+    serializer_class = PBSDatastoreSerializer
+    filterset_class = filtersets.PBSDatastoreFilterSet
+    http_method_names = _READ_ONLY_HTTP_METHODS
+
+
+class PBSBackupGroupViewSet(NetBoxModelViewSet):
+    """REST API for reflected PBS backup groups. Read-only (GET/HEAD/OPTIONS)."""
+
+    queryset = models.PBSBackupGroup.objects.select_related(
+        "datastore", "datastore__endpoint"
+    )
+    serializer_class = PBSBackupGroupSerializer
+    filterset_class = filtersets.PBSBackupGroupFilterSet
+    http_method_names = _READ_ONLY_HTTP_METHODS
+
+
+class PBSSnapshotViewSet(NetBoxModelViewSet):
+    """REST API for reflected PBS snapshots. Read-only (GET/HEAD/OPTIONS)."""
+
+    queryset = models.PBSSnapshot.objects.select_related(
+        "backup_group", "backup_group__datastore", "backup_group__datastore__endpoint"
+    )
+    serializer_class = PBSSnapshotSerializer
+    filterset_class = filtersets.PBSSnapshotFilterSet
+    http_method_names = _READ_ONLY_HTTP_METHODS
+
+
+class PBSJobStatusViewSet(NetBoxModelViewSet):
+    """REST API for reflected PBS job status. Read-only (GET/HEAD/OPTIONS)."""
+
+    queryset = models.PBSJobStatus.objects.select_related("endpoint", "datastore")
+    serializer_class = PBSJobStatusSerializer
+    filterset_class = filtersets.PBSJobStatusFilterSet
+    http_method_names = _READ_ONLY_HTTP_METHODS

--- a/netbox_pbs/netbox_pbs/choices.py
+++ b/netbox_pbs/netbox_pbs/choices.py
@@ -1,0 +1,94 @@
+"""Shared choice sets for netbox-pbs domain models."""
+
+from django.utils.translation import gettext_lazy as _
+from utilities.choices import ChoiceSet
+
+
+class PBSBackupTypeChoices(ChoiceSet):
+    """Proxmox Backup Server group type."""
+
+    key = "PBSBackupGroup.backup_type"
+
+    BACKUP_TYPE_VM = "vm"
+    BACKUP_TYPE_CT = "ct"
+    BACKUP_TYPE_HOST = "host"
+
+    CHOICES = [
+        (BACKUP_TYPE_VM, _("VM (QEMU)"), "blue"),
+        (BACKUP_TYPE_CT, _("Container (LXC)"), "cyan"),
+        (BACKUP_TYPE_HOST, _("Host"), "gray"),
+    ]
+
+
+class PBSSnapshotVerifyChoices(ChoiceSet):
+    """Verification state for a PBS snapshot."""
+
+    key = "PBSSnapshot.verified"
+
+    VERIFY_NONE = "none"
+    VERIFY_OK = "ok"
+    VERIFY_FAILED = "failed"
+
+    CHOICES = [
+        (VERIFY_NONE, _("Not verified"), "gray"),
+        (VERIFY_OK, _("OK"), "green"),
+        (VERIFY_FAILED, _("Failed"), "red"),
+    ]
+
+
+class PBSJobTypeChoices(ChoiceSet):
+    """PBS job kind reported by /admin/{verify,prune,gc,sync,tape}-job."""
+
+    key = "PBSJobStatus.job_type"
+
+    JOB_TYPE_VERIFY = "verify"
+    JOB_TYPE_PRUNE = "prune"
+    JOB_TYPE_GC = "gc"
+    JOB_TYPE_SYNC = "sync"
+    JOB_TYPE_TAPE = "tape"
+
+    CHOICES = [
+        (JOB_TYPE_VERIFY, _("Verify"), "blue"),
+        (JOB_TYPE_PRUNE, _("Prune"), "orange"),
+        (JOB_TYPE_GC, _("Garbage collection"), "purple"),
+        (JOB_TYPE_SYNC, _("Sync"), "cyan"),
+        (JOB_TYPE_TAPE, _("Tape"), "gray"),
+    ]
+
+
+class PBSJobRunStateChoices(ChoiceSet):
+    """Terminal state reported for the last run of a PBS job."""
+
+    key = "PBSJobStatus.last_run_state"
+
+    RUN_STATE_UNKNOWN = "unknown"
+    RUN_STATE_OK = "ok"
+    RUN_STATE_WARNING = "warning"
+    RUN_STATE_ERROR = "error"
+
+    CHOICES = [
+        (RUN_STATE_UNKNOWN, _("Unknown"), "gray"),
+        (RUN_STATE_OK, _("OK"), "green"),
+        (RUN_STATE_WARNING, _("Warning"), "yellow"),
+        (RUN_STATE_ERROR, _("Error"), "red"),
+    ]
+
+
+class PBSDatastoreGCStatusChoices(ChoiceSet):
+    """Last-known garbage-collection status reported by a PBS datastore."""
+
+    key = "PBSDatastore.gc_status"
+
+    GC_STATUS_UNKNOWN = "unknown"
+    GC_STATUS_IDLE = "idle"
+    GC_STATUS_RUNNING = "running"
+    GC_STATUS_OK = "ok"
+    GC_STATUS_ERROR = "error"
+
+    CHOICES = [
+        (GC_STATUS_UNKNOWN, _("Unknown"), "gray"),
+        (GC_STATUS_IDLE, _("Idle"), "gray"),
+        (GC_STATUS_RUNNING, _("Running"), "blue"),
+        (GC_STATUS_OK, _("OK"), "green"),
+        (GC_STATUS_ERROR, _("Error"), "red"),
+    ]

--- a/netbox_pbs/netbox_pbs/filtersets.py
+++ b/netbox_pbs/netbox_pbs/filtersets.py
@@ -1,0 +1,168 @@
+"""NetBox filtersets for netbox-pbs list views and (future) API queries.
+
+Pattern mirrors ``netbox_proxbox.filtersets``: one ``NetBoxModelFilterSet``
+per persisted model with a ``search`` method that does the same icontains
+join the rest of the plugin uses. ``register_filterset`` so the global
+NetBox filter registry can find them.
+"""
+
+from __future__ import annotations
+
+from django.db.models import Q, QuerySet
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
+
+from netbox.filtersets import NetBoxModelFilterSet
+from utilities.filtersets import register_filterset
+
+from netbox_pbs.models import (
+    PBSBackupGroup,
+    PBSDatastore,
+    PBSEndpoint,
+    PBSJobStatus,
+    PBSNode,
+    PBSSnapshot,
+)
+
+
+class _PBSModelFilterSet(NetBoxModelFilterSet):
+    """Tag-filter OpenAPI hint helper shared by every PBS filterset."""
+
+    _TAG_FILTER_SCHEMA_MAP = {
+        "tag": OpenApiTypes.STR,
+        "tag__n": OpenApiTypes.STR,
+        "tag_id": OpenApiTypes.INT,
+        "tag_id__n": OpenApiTypes.INT,
+    }
+
+    @classmethod
+    def get_filters(cls):
+        filters = super().get_filters()
+        for name, openapi_type in cls._TAG_FILTER_SCHEMA_MAP.items():
+            if name in filters:
+                extend_schema_field(openapi_type)(filters[name])
+        return filters
+
+
+@register_filterset
+class PBSEndpointFilterSet(_PBSModelFilterSet):
+    """Filter PBS endpoints by name, host, or SSL behavior."""
+
+    class Meta:
+        model = PBSEndpoint
+        fields = ("id", "name", "host", "port", "verify_ssl")
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(name__icontains=value)
+            | Q(host__icontains=value)
+            | Q(token_id__icontains=value)
+        )
+
+
+@register_filterset
+class PBSNodeFilterSet(_PBSModelFilterSet):
+    """Filter PBS node mirrors."""
+
+    class Meta:
+        model = PBSNode
+        fields = ("id", "endpoint", "hostname", "version")
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(hostname__icontains=value)
+            | Q(version__icontains=value)
+            | Q(endpoint__name__icontains=value)
+        )
+
+
+@register_filterset
+class PBSDatastoreFilterSet(_PBSModelFilterSet):
+    """Filter PBS datastore mirrors."""
+
+    class Meta:
+        model = PBSDatastore
+        fields = ("id", "endpoint", "name", "gc_status")
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(name__icontains=value)
+            | Q(path__icontains=value)
+            | Q(endpoint__name__icontains=value)
+        )
+
+
+@register_filterset
+class PBSBackupGroupFilterSet(_PBSModelFilterSet):
+    """Filter PBS backup-group mirrors."""
+
+    class Meta:
+        model = PBSBackupGroup
+        fields = ("id", "datastore", "backup_type", "backup_id", "owner")
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(backup_id__icontains=value)
+            | Q(owner__icontains=value)
+            | Q(comment__icontains=value)
+            | Q(datastore__name__icontains=value)
+        )
+
+
+@register_filterset
+class PBSSnapshotFilterSet(_PBSModelFilterSet):
+    """Filter PBS snapshot mirrors."""
+
+    class Meta:
+        model = PBSSnapshot
+        fields = (
+            "id",
+            "backup_group",
+            "verified",
+            "encrypted",
+            "protected",
+            "backup_time",
+        )
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(comment__icontains=value)
+            | Q(backup_group__backup_id__icontains=value)
+            | Q(backup_group__datastore__name__icontains=value)
+        )
+
+
+@register_filterset
+class PBSJobStatusFilterSet(_PBSModelFilterSet):
+    """Filter PBS scheduled-job mirrors."""
+
+    class Meta:
+        model = PBSJobStatus
+        fields = (
+            "id",
+            "endpoint",
+            "datastore",
+            "job_type",
+            "job_id",
+            "enabled",
+            "last_run_state",
+        )
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(job_id__icontains=value)
+            | Q(endpoint__name__icontains=value)
+            | Q(datastore__name__icontains=value)
+        )

--- a/netbox_pbs/netbox_pbs/forms.py
+++ b/netbox_pbs/netbox_pbs/forms.py
@@ -1,0 +1,177 @@
+"""NetBox forms for netbox-pbs.
+
+Only ``PBSEndpoint`` is editable in v1: operators register endpoints
+manually so the read-only sync (PR C3) can reach them. The other five
+models are reflected from PBS and have no create/edit/import/bulk-edit
+forms — they only get filter forms for their list views.
+"""
+
+from __future__ import annotations
+
+from django import forms
+
+from netbox.forms import (
+    NetBoxModelBulkEditForm,
+    NetBoxModelFilterSetForm,
+    NetBoxModelForm,
+    NetBoxModelImportForm,
+)
+from utilities.forms.fields import DynamicModelMultipleChoiceField
+
+from netbox_pbs.choices import (
+    PBSBackupTypeChoices,
+    PBSDatastoreGCStatusChoices,
+    PBSJobRunStateChoices,
+    PBSJobTypeChoices,
+    PBSSnapshotVerifyChoices,
+)
+from netbox_pbs.models import (
+    PBSBackupGroup,
+    PBSDatastore,
+    PBSEndpoint,
+    PBSJobStatus,
+    PBSNode,
+    PBSSnapshot,
+)
+
+
+# ----- PBSEndpoint: full CRUD ------------------------------------------------
+
+
+class PBSEndpointForm(NetBoxModelForm):
+    """Create or edit a PBS endpoint."""
+
+    class Meta:
+        model = PBSEndpoint
+        fields = (
+            "name",
+            "host",
+            "port",
+            "token_id",
+            "token_value",
+            "fingerprint",
+            "verify_ssl",
+            "timeout",
+            "tags",
+        )
+        widgets = {
+            "token_value": forms.PasswordInput(render_value=False),
+        }
+
+
+class PBSEndpointFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for the PBS endpoint list view."""
+
+    model = PBSEndpoint
+    verify_ssl = forms.NullBooleanField(required=False)
+
+
+class PBSEndpointBulkEditForm(NetBoxModelBulkEditForm):
+    """Bulk edit PBS endpoint rows."""
+
+    model = PBSEndpoint
+
+    port = forms.IntegerField(required=False)
+    verify_ssl = forms.NullBooleanField(required=False)
+    timeout = forms.IntegerField(required=False)
+    fingerprint = forms.CharField(max_length=128, required=False)
+
+    nullable_fields = ("fingerprint",)
+
+
+class PBSEndpointImportForm(NetBoxModelImportForm):
+    """CSV import for PBS endpoint rows."""
+
+    class Meta:
+        model = PBSEndpoint
+        fields = (
+            "name",
+            "host",
+            "port",
+            "token_id",
+            "token_value",
+            "fingerprint",
+            "verify_ssl",
+            "timeout",
+            "tags",
+        )
+
+
+# ----- Reflected models: filter forms only -----------------------------------
+
+
+class PBSNodeFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for the PBS node list view."""
+
+    model = PBSNode
+    endpoint = DynamicModelMultipleChoiceField(
+        queryset=PBSEndpoint.objects.all(),
+        required=False,
+    )
+
+
+class PBSDatastoreFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for the PBS datastore list view."""
+
+    model = PBSDatastore
+    endpoint = DynamicModelMultipleChoiceField(
+        queryset=PBSEndpoint.objects.all(),
+        required=False,
+    )
+    gc_status = forms.MultipleChoiceField(
+        choices=PBSDatastoreGCStatusChoices,
+        required=False,
+    )
+
+
+class PBSBackupGroupFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for the PBS backup-group list view."""
+
+    model = PBSBackupGroup
+    datastore = DynamicModelMultipleChoiceField(
+        queryset=PBSDatastore.objects.all(),
+        required=False,
+    )
+    backup_type = forms.MultipleChoiceField(
+        choices=PBSBackupTypeChoices,
+        required=False,
+    )
+
+
+class PBSSnapshotFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for the PBS snapshot list view."""
+
+    model = PBSSnapshot
+    backup_group = DynamicModelMultipleChoiceField(
+        queryset=PBSBackupGroup.objects.all(),
+        required=False,
+    )
+    verified = forms.MultipleChoiceField(
+        choices=PBSSnapshotVerifyChoices,
+        required=False,
+    )
+    encrypted = forms.NullBooleanField(required=False)
+    protected = forms.NullBooleanField(required=False)
+
+
+class PBSJobStatusFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for the PBS scheduled-job list view."""
+
+    model = PBSJobStatus
+    endpoint = DynamicModelMultipleChoiceField(
+        queryset=PBSEndpoint.objects.all(),
+        required=False,
+    )
+    datastore = DynamicModelMultipleChoiceField(
+        queryset=PBSDatastore.objects.all(),
+        required=False,
+    )
+    job_type = forms.MultipleChoiceField(
+        choices=PBSJobTypeChoices,
+        required=False,
+    )
+    last_run_state = forms.MultipleChoiceField(
+        choices=PBSJobRunStateChoices,
+        required=False,
+    )
+    enabled = forms.NullBooleanField(required=False)

--- a/netbox_pbs/netbox_pbs/jobs.py
+++ b/netbox_pbs/netbox_pbs/jobs.py
@@ -1,0 +1,202 @@
+"""Background job for triggering PBS sync via the proxbox-api backend.
+
+``PBSSyncJob`` mirrors the six-step pattern used by
+``netbox_proxbox.jobs.ProxboxSyncJob``:
+
+1. Resolve sync stages from params (defaults to the full :data:`PBS_STAGES_FULL`).
+2. Read :func:`branching_enabled_settings`; if branching is enabled, create
+   and provision a fresh ``netbox-branching`` Branch.
+3. Thread ``netbox_branch_schema_id`` into the params dict so every backend
+   call writes into the same schema.
+4. Run each stage via :func:`run_pbs_sync_stage` (SSE to ``/pbs/sync/<stage>``).
+5. On success, merge the branch back into main (subject to the configured
+   conflict policy).
+6. Persist a structured result on ``job.data["pbs_sync"]``.
+
+The branching plugin is optional. When ``netbox-branching`` is not installed
+the job simply runs against ``main`` — exactly like the existing
+``ProxboxSyncJob`` fallback.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from netbox.constants import RQ_QUEUE_DEFAULT
+from netbox.jobs import JobRunner
+
+try:
+    from netbox.jobs import Job
+except ImportError:  # pragma: no cover - test stubs expose only JobRunner
+    Job = Any  # type: ignore[misc,assignment]
+
+from netbox_pbs.services.http_client import (
+    PBS_STAGES_FULL,
+    PBSStageResult,
+    run_pbs_sync_stage,
+)
+
+# Use NetBox's default RQ queue so a stock ``manage.py rqworker`` picks up jobs.
+PBS_SYNC_QUEUE_NAME = RQ_QUEUE_DEFAULT
+
+# RQ wall-clock limit for the whole job. Must exceed NetBox's default
+# RQ_DEFAULT_TIMEOUT (often 300s) and the SSE read budget between chunks.
+PBS_SYNC_JOB_TIMEOUT = 7200
+
+__all__ = (
+    "PBS_SYNC_JOB_TIMEOUT",
+    "PBS_SYNC_QUEUE_NAME",
+    "PBSSyncJob",
+)
+
+
+def _normalize_stages(stages: list[str] | None) -> tuple[str, ...]:
+    """Coerce a user-supplied stage list into a tuple of known stage names."""
+    if not stages:
+        return PBS_STAGES_FULL
+    normalized = tuple(str(s).strip() for s in stages if str(s).strip())
+    valid = tuple(s for s in normalized if s in PBS_STAGES_FULL)
+    return valid or PBS_STAGES_FULL
+
+
+def _normalize_endpoint_ids(raw_ids: list[Any] | None) -> list[str]:
+    """Return the string-coerced endpoint IDs, dropping empty values."""
+    out: list[str] = []
+    for raw in raw_ids or []:
+        value = str(raw).strip()
+        if value:
+            out.append(value)
+    return out
+
+
+class PBSSyncJob(JobRunner):
+    """Trigger a PBS sync operation against the proxbox-api backend."""
+
+    class Meta:
+        name = "PBS Sync"
+
+    @classmethod
+    def enqueue(cls, *args: object, **kwargs: object) -> Job:
+        """Enqueue like other ``JobRunner`` jobs, with a long default timeout."""
+        kwargs.setdefault("job_timeout", PBS_SYNC_JOB_TIMEOUT)
+        return super().enqueue(*args, **kwargs)
+
+    def run(
+        self,
+        stages: list[str] | None = None,
+        pbs_endpoint_ids: list[str] | None = None,
+        **kwargs: object,
+    ) -> None:
+        """Run the configured PBS sync stages, optionally inside a NetBox branch."""
+        resolved_stages = _normalize_stages(stages)
+        endpoint_ids = _normalize_endpoint_ids(pbs_endpoint_ids)
+        run_started = time.monotonic()
+
+        try:
+            from netbox_pbs.services.branch_lifecycle import (  # noqa: PLC0415
+                branching_enabled_settings,
+                create_and_provision_branch,
+                merge_branch,
+            )
+        except ModuleNotFoundError:
+            branching_enabled_settings = lambda: None  # noqa: E731
+            create_and_provision_branch = None  # type: ignore[assignment]
+            merge_branch = None  # type: ignore[assignment]
+
+        branch = None
+        branch_config = branching_enabled_settings()
+        if branch_config is not None:
+            branch_name = f"{branch_config['prefix']}-{self.job.pk}-{int(run_started)}"
+            self.logger.info(
+                f"NetBox branching enabled — creating branch {branch_name!r}"
+            )
+            try:
+                branch = create_and_provision_branch(
+                    name=branch_name,
+                    user=getattr(self.job, "user", None),
+                )
+                self.logger.info(
+                    f"Branch {branch.name} ready (schema_id={branch.schema_id})"
+                )
+            except Exception as exc:
+                self.logger.error(
+                    f"Failed to create/provision NetBox branch {branch_name}: {exc}"
+                )
+                raise
+
+        netbox_branch_schema_id = branch.schema_id if branch is not None else None
+        params: dict[str, Any] = {
+            "stages": list(resolved_stages),
+            "pbs_endpoint_ids": endpoint_ids,
+            "netbox_branch_schema_id": netbox_branch_schema_id,
+        }
+
+        self.logger.info(f"Starting PBS sync stages: {', '.join(resolved_stages)}")
+        if endpoint_ids:
+            self.logger.info(f"PBS endpoints: {endpoint_ids}")
+
+        stage_results: list[dict[str, Any]] = []
+        for stage in resolved_stages:
+            result: PBSStageResult = run_pbs_sync_stage(
+                stage,
+                params,
+                logger_=self.logger,
+            )
+            stage_results.append(
+                {
+                    "stage": result.stage,
+                    "success": result.success,
+                    "error": result.error,
+                    "event_count": len(result.events),
+                }
+            )
+            if not result.success:
+                self.logger.error(
+                    f"PBS sync stage {result.stage!r} failed: {result.error}"
+                )
+                self._persist_result(
+                    params=params,
+                    stages=stage_results,
+                    run_started=run_started,
+                )
+                raise RuntimeError(
+                    f"PBS sync stage {result.stage!r} failed: {result.error}"
+                )
+
+        self._persist_result(
+            params=params,
+            stages=stage_results,
+            run_started=run_started,
+        )
+        self.logger.info(f"All PBS sync stages completed ({len(stage_results)})")
+
+        if branch is not None and branch_config is not None:
+            merged, message = merge_branch(
+                branch=branch,
+                user=getattr(self.job, "user", None),
+                on_conflict=branch_config["on_conflict"],
+            )
+            if merged:
+                self.logger.info(message)
+            else:
+                self.logger.error(message)
+                raise RuntimeError(message)
+
+    def _persist_result(
+        self,
+        *,
+        params: dict[str, Any],
+        stages: list[dict[str, Any]],
+        run_started: float,
+    ) -> None:
+        """Write the structured sync result onto ``job.data``."""
+        runtime_seconds = round(time.monotonic() - run_started, 3)
+        self.job.data = {
+            "pbs_sync": {
+                "params": params,
+                "runtime_seconds": runtime_seconds,
+                "response": {"stages": stages},
+            }
+        }
+        self.job.save(update_fields=["data"])

--- a/netbox_pbs/netbox_pbs/migrations/0001_initial.py
+++ b/netbox_pbs/netbox_pbs/migrations/0001_initial.py
@@ -1,0 +1,110 @@
+"""Create the singleton ``PBSPluginSettings`` table.
+
+PR C1 of issue #325. Subsequent migrations add the PBS domain models
+(``PBSEndpoint``, ``PBSNode``, ``PBSDatastore``, ``PBSBackupGroup``,
+``PBSSnapshot``, ``PBSJobStatus``).
+"""
+
+import taggit.managers
+import utilities.json
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        ("extras", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PBSPluginSettings",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                (
+                    "singleton_key",
+                    models.CharField(
+                        default="default",
+                        editable=False,
+                        max_length=32,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "branching_enabled",
+                    models.BooleanField(
+                        default=False,
+                        verbose_name="Branching-enabled sync (PBS → NetBox)",
+                        help_text=(
+                            "When enabled, every PBS sync job creates a fresh "
+                            "netbox-branching branch, runs the sync on that "
+                            "branch, and merges it back into main on success. "
+                            "Requires the netbox_branching plugin to be "
+                            "installed and listed last in PLUGINS."
+                        ),
+                    ),
+                ),
+                (
+                    "branch_name_prefix",
+                    models.CharField(
+                        default="pbs-sync",
+                        max_length=64,
+                        verbose_name="Branch name prefix",
+                        help_text=(
+                            "Prefix used when auto-creating a NetBox branch "
+                            "per PBS sync job (e.g. "
+                            "pbs-sync-<job_id>-<timestamp>)."
+                        ),
+                    ),
+                ),
+                (
+                    "branch_on_conflict",
+                    models.CharField(
+                        choices=[
+                            ("fail", "Fail (leave branch open for review)"),
+                            ("acknowledge", "Acknowledge and merge anyway"),
+                        ],
+                        default="fail",
+                        max_length=16,
+                        verbose_name="Branch merge conflict policy",
+                        help_text=(
+                            "What to do when the auto-created sync branch "
+                            "reports merge conflicts. 'fail' leaves the branch "
+                            "open for operator review and marks the job "
+                            "failed. 'acknowledge' retries the merge with "
+                            "acknowledge_conflicts=True."
+                        ),
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem",
+                        to="extras.Tag",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "PBS plugin settings",
+                "verbose_name_plural": "PBS plugin settings",
+            },
+        ),
+    ]

--- a/netbox_pbs/netbox_pbs/migrations/0002_pbs_domain_models.py
+++ b/netbox_pbs/netbox_pbs/migrations/0002_pbs_domain_models.py
@@ -1,0 +1,361 @@
+"""Create the six read-only PBS domain models.
+
+PR C2 of issue #325. Each model mirrors a PBS object surface: endpoint,
+node, datastore, backup group, snapshot, and scheduled-job status. The
+endpoint is the only writable model on the NetBox side; the other five
+are reflected from PBS by the read-only sync that lands in PR C3.
+"""
+
+import django.core.validators
+import django.db.models.deletion
+import taggit.managers
+import utilities.json
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extras", "0001_initial"),
+        ("netbox_pbs", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PBSEndpoint",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("name", models.CharField(max_length=255, unique=True)),
+                ("host", models.CharField(max_length=255)),
+                (
+                    "port",
+                    models.PositiveIntegerField(
+                        default=8007,
+                        validators=[
+                            django.core.validators.MinValueValidator(1),
+                            django.core.validators.MaxValueValidator(65535),
+                        ],
+                    ),
+                ),
+                ("token_id", models.CharField(max_length=255)),
+                ("token_value", models.CharField(max_length=255)),
+                ("fingerprint", models.CharField(blank=True, max_length=128)),
+                ("verify_ssl", models.BooleanField(default=True)),
+                ("timeout", models.PositiveIntegerField(default=30)),
+                ("last_seen_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "PBS endpoint",
+                "verbose_name_plural": "PBS endpoints",
+                "ordering": ("name", "pk"),
+            },
+        ),
+        migrations.CreateModel(
+            name="PBSNode",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("hostname", models.CharField(max_length=255)),
+                ("version", models.CharField(blank=True, max_length=64)),
+                ("uptime_seconds", models.BigIntegerField(blank=True, null=True)),
+                ("cpu_pct", models.FloatField(blank=True, null=True)),
+                ("memory_used", models.BigIntegerField(blank=True, null=True)),
+                ("memory_total", models.BigIntegerField(blank=True, null=True)),
+                ("last_seen_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "endpoint",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="nodes",
+                        to="netbox_pbs.pbsendpoint",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "PBS node",
+                "verbose_name_plural": "PBS nodes",
+                "ordering": ("endpoint", "hostname"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("endpoint", "hostname"),
+                        name="netbox_pbs_pbsnode_identity",
+                    ),
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name="PBSDatastore",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                ("path", models.CharField(blank=True, max_length=512)),
+                ("total_bytes", models.BigIntegerField(blank=True, null=True)),
+                ("used_bytes", models.BigIntegerField(blank=True, null=True)),
+                ("available_bytes", models.BigIntegerField(blank=True, null=True)),
+                (
+                    "gc_status",
+                    models.CharField(default="unknown", max_length=16),
+                ),
+                ("last_gc_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "endpoint",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="datastores",
+                        to="netbox_pbs.pbsendpoint",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "PBS datastore",
+                "verbose_name_plural": "PBS datastores",
+                "ordering": ("endpoint", "name"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("endpoint", "name"),
+                        name="netbox_pbs_pbsdatastore_identity",
+                    ),
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name="PBSBackupGroup",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("backup_type", models.CharField(max_length=8)),
+                ("backup_id", models.CharField(max_length=64)),
+                ("owner", models.CharField(blank=True, max_length=128)),
+                ("comment", models.CharField(blank=True, max_length=512)),
+                (
+                    "datastore",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="backup_groups",
+                        to="netbox_pbs.pbsdatastore",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "PBS backup group",
+                "verbose_name_plural": "PBS backup groups",
+                "ordering": ("datastore", "backup_type", "backup_id"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("datastore", "backup_type", "backup_id"),
+                        name="netbox_pbs_pbsbackupgroup_identity",
+                    ),
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name="PBSSnapshot",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("backup_time", models.DateTimeField()),
+                ("size_bytes", models.BigIntegerField(blank=True, null=True)),
+                ("encrypted", models.BooleanField(default=False)),
+                ("verified", models.CharField(default="none", max_length=16)),
+                ("protected", models.BooleanField(default=False)),
+                ("comment", models.CharField(blank=True, max_length=512)),
+                (
+                    "files",
+                    models.JSONField(
+                        blank=True,
+                        default=list,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                (
+                    "backup_group",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="snapshots",
+                        to="netbox_pbs.pbsbackupgroup",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "PBS snapshot",
+                "verbose_name_plural": "PBS snapshots",
+                "ordering": ("backup_group", "-backup_time"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("backup_group", "backup_time"),
+                        name="netbox_pbs_pbssnapshot_identity",
+                    ),
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name="PBSJobStatus",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("job_type", models.CharField(max_length=16)),
+                ("job_id", models.CharField(max_length=128)),
+                ("enabled", models.BooleanField(default=True)),
+                ("last_run_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "last_run_state",
+                    models.CharField(default="unknown", max_length=16),
+                ),
+                (
+                    "last_run_duration_seconds",
+                    models.PositiveIntegerField(blank=True, null=True),
+                ),
+                ("next_run_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "endpoint",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="jobs",
+                        to="netbox_pbs.pbsendpoint",
+                    ),
+                ),
+                (
+                    "datastore",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="jobs",
+                        to="netbox_pbs.pbsdatastore",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem", to="extras.Tag"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "PBS job status",
+                "verbose_name_plural": "PBS job statuses",
+                "ordering": ("endpoint", "job_type", "job_id"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("endpoint", "job_type", "job_id"),
+                        name="netbox_pbs_pbsjobstatus_identity",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/netbox_pbs/netbox_pbs/models/__init__.py
+++ b/netbox_pbs/netbox_pbs/models/__init__.py
@@ -1,10 +1,24 @@
 """Persisted models for the netbox-pbs plugin.
 
-PR C1 ships only the singleton ``PBSPluginSettings`` model. Domain models
-(``PBSEndpoint``, ``PBSNode``, ``PBSDatastore``, ``PBSBackupGroup``,
-``PBSSnapshot``, ``PBSJobStatus``) land in PR C2.
+PR C2 adds the six read-only PBS domain models. PBSEndpoint owns NetBox
+credentials for the PBS API; the rest mirror PBS state and have no
+``allow_writes`` flag because v1 is strictly PBS → NetBox.
 """
 
+from netbox_pbs.models.pbs_backup_group import PBSBackupGroup
+from netbox_pbs.models.pbs_datastore import PBSDatastore
+from netbox_pbs.models.pbs_endpoint import PBSEndpoint
+from netbox_pbs.models.pbs_job_status import PBSJobStatus
+from netbox_pbs.models.pbs_node import PBSNode
+from netbox_pbs.models.pbs_snapshot import PBSSnapshot
 from netbox_pbs.models.plugin_settings import PBSPluginSettings
 
-__all__ = ["PBSPluginSettings"]
+__all__ = [
+    "PBSBackupGroup",
+    "PBSDatastore",
+    "PBSEndpoint",
+    "PBSJobStatus",
+    "PBSNode",
+    "PBSSnapshot",
+    "PBSPluginSettings",
+]

--- a/netbox_pbs/netbox_pbs/models/__init__.py
+++ b/netbox_pbs/netbox_pbs/models/__init__.py
@@ -1,0 +1,10 @@
+"""Persisted models for the netbox-pbs plugin.
+
+PR C1 ships only the singleton ``PBSPluginSettings`` model. Domain models
+(``PBSEndpoint``, ``PBSNode``, ``PBSDatastore``, ``PBSBackupGroup``,
+``PBSSnapshot``, ``PBSJobStatus``) land in PR C2.
+"""
+
+from netbox_pbs.models.plugin_settings import PBSPluginSettings
+
+__all__ = ["PBSPluginSettings"]

--- a/netbox_pbs/netbox_pbs/models/pbs_backup_group.py
+++ b/netbox_pbs/netbox_pbs/models/pbs_backup_group.py
@@ -1,0 +1,57 @@
+"""Reflected PBS backup group (a logical VM/CT/host backup history)."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from netbox.models import NetBoxModel
+
+from netbox_pbs.choices import PBSBackupTypeChoices
+
+
+class PBSBackupGroup(NetBoxModel):
+    """A group of snapshots within a datastore — ``{vm,ct,host}/<id>``."""
+
+    datastore = models.ForeignKey(
+        to="netbox_pbs.PBSDatastore",
+        on_delete=models.CASCADE,
+        related_name="backup_groups",
+    )
+    backup_type = models.CharField(
+        max_length=8,
+        choices=PBSBackupTypeChoices,
+        help_text=_("``vm``, ``ct``, or ``host``."),
+    )
+    backup_id = models.CharField(
+        max_length=64,
+        verbose_name=_("Backup ID"),
+        help_text=_("PBS group ID — typically the VMID, CTID, or hostname."),
+    )
+    owner = models.CharField(
+        max_length=128,
+        blank=True,
+        help_text=_("PBS owner principal of this group."),
+    )
+    comment = models.CharField(
+        max_length=512,
+        blank=True,
+    )
+
+    class Meta:
+        ordering = ("datastore", "backup_type", "backup_id")
+        verbose_name = _("PBS backup group")
+        verbose_name_plural = _("PBS backup groups")
+        constraints = (
+            models.UniqueConstraint(
+                fields=("datastore", "backup_type", "backup_id"),
+                name="netbox_pbs_pbsbackupgroup_identity",
+            ),
+        )
+
+    def __str__(self) -> str:
+        return f"{self.datastore} / {self.backup_type}/{self.backup_id}"
+
+    def get_absolute_url(self) -> str:
+        return reverse("plugins:netbox_pbs:pbsbackupgroup", args=[self.pk])

--- a/netbox_pbs/netbox_pbs/models/pbs_datastore.py
+++ b/netbox_pbs/netbox_pbs/models/pbs_datastore.py
@@ -1,0 +1,72 @@
+"""Reflected PBS datastore."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from netbox.models import NetBoxModel
+
+from netbox_pbs.choices import PBSDatastoreGCStatusChoices
+
+
+class PBSDatastore(NetBoxModel):
+    """Per-PBS datastore reflected from ``GET /admin/datastore``."""
+
+    endpoint = models.ForeignKey(
+        to="netbox_pbs.PBSEndpoint",
+        on_delete=models.CASCADE,
+        related_name="datastores",
+    )
+    name = models.CharField(
+        max_length=255,
+        help_text=_("PBS datastore name."),
+    )
+    path = models.CharField(
+        max_length=512,
+        blank=True,
+        help_text=_("On-disk path of the datastore on the PBS host."),
+    )
+    total_bytes = models.BigIntegerField(
+        null=True,
+        blank=True,
+        verbose_name=_("Total (bytes)"),
+    )
+    used_bytes = models.BigIntegerField(
+        null=True,
+        blank=True,
+        verbose_name=_("Used (bytes)"),
+    )
+    available_bytes = models.BigIntegerField(
+        null=True,
+        blank=True,
+        verbose_name=_("Available (bytes)"),
+    )
+    gc_status = models.CharField(
+        max_length=16,
+        choices=PBSDatastoreGCStatusChoices,
+        default=PBSDatastoreGCStatusChoices.GC_STATUS_UNKNOWN,
+    )
+    last_gc_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name=_("Last GC at"),
+    )
+
+    class Meta:
+        ordering = ("endpoint", "name")
+        verbose_name = _("PBS datastore")
+        verbose_name_plural = _("PBS datastores")
+        constraints = (
+            models.UniqueConstraint(
+                fields=("endpoint", "name"),
+                name="netbox_pbs_pbsdatastore_identity",
+            ),
+        )
+
+    def __str__(self) -> str:
+        return f"{self.endpoint} / {self.name}"
+
+    def get_absolute_url(self) -> str:
+        return reverse("plugins:netbox_pbs:pbsdatastore", args=[self.pk])

--- a/netbox_pbs/netbox_pbs/models/pbs_endpoint.py
+++ b/netbox_pbs/netbox_pbs/models/pbs_endpoint.py
@@ -32,10 +32,7 @@ class PBSEndpoint(NetBoxModel):
     )
     host = models.CharField(
         max_length=255,
-        help_text=_(
-            "PBS hostname or IP. A plain string keeps standalone install "
-            "viable when ``ipam`` is not pre-populated."
-        ),
+        help_text=_("PBS hostname or IP."),
     )
     port = models.PositiveIntegerField(
         default=8007,

--- a/netbox_pbs/netbox_pbs/models/pbs_endpoint.py
+++ b/netbox_pbs/netbox_pbs/models/pbs_endpoint.py
@@ -1,0 +1,89 @@
+"""Persisted PBS API endpoint for the netbox-pbs plugin.
+
+Mirrors the credential-storage pattern from
+``netbox_proxbox.models.ProxmoxEndpoint``: plaintext CharFields for the
+API token, gated by NetBox RBAC. No encryption-at-rest is invented here;
+operator-facing protection lives in the existing ``view``/``change`` model
+permissions and ``ObjectPermissionRequiredMixin`` enforcement.
+
+v1 is **read-only PBS → NetBox**; there is no ``allow_writes`` field on
+the NetBox side because there is no NetBox → PBS write path to gate.
+The mirror flag lives in ``proxbox-api`` (``PBSEndpoint.allow_writes``)
+and stays locked ``False`` for v1.
+"""
+
+from __future__ import annotations
+
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from netbox.models import NetBoxModel
+
+
+class PBSEndpoint(NetBoxModel):
+    """Proxmox Backup Server endpoint registered in NetBox."""
+
+    name = models.CharField(
+        max_length=255,
+        unique=True,
+        help_text=_("Friendly name for this PBS endpoint."),
+    )
+    host = models.CharField(
+        max_length=255,
+        help_text=_(
+            "PBS hostname or IP. A plain string keeps standalone install "
+            "viable when ``ipam`` is not pre-populated."
+        ),
+    )
+    port = models.PositiveIntegerField(
+        default=8007,
+        validators=(MinValueValidator(1), MaxValueValidator(65535)),
+        verbose_name=_("HTTP port"),
+    )
+    token_id = models.CharField(
+        max_length=255,
+        verbose_name=_("Token ID"),
+        help_text=_("PBS API token ID in the form ``user@realm!tokenname``."),
+    )
+    token_value = models.CharField(
+        max_length=255,
+        verbose_name=_("Token value"),
+        help_text=_("PBS API token secret. Protected by NetBox object-level RBAC."),
+    )
+    fingerprint = models.CharField(
+        max_length=128,
+        blank=True,
+        verbose_name=_("Certificate fingerprint"),
+        help_text=_(
+            "Optional SHA-256 fingerprint of the PBS API TLS certificate "
+            "(``aa:bb:...``). When set, pinned by the proxbox-api PBS client."
+        ),
+    )
+    verify_ssl = models.BooleanField(
+        default=True,
+        verbose_name=_("Verify SSL"),
+    )
+    timeout = models.PositiveIntegerField(
+        default=30,
+        verbose_name=_("Timeout (seconds)"),
+        help_text=_("Per-endpoint API request timeout used by proxbox-api."),
+    )
+    last_seen_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name=_("Last seen at"),
+        help_text=_("Updated by the read-only PBS sync after a successful probe."),
+    )
+
+    class Meta:
+        ordering = ("name", "pk")
+        verbose_name = _("PBS endpoint")
+        verbose_name_plural = _("PBS endpoints")
+
+    def __str__(self) -> str:
+        return self.name or f"PBSEndpoint({self.pk})"
+
+    def get_absolute_url(self) -> str:
+        return reverse("plugins:netbox_pbs:pbsendpoint", args=[self.pk])

--- a/netbox_pbs/netbox_pbs/models/pbs_job_status.py
+++ b/netbox_pbs/netbox_pbs/models/pbs_job_status.py
@@ -1,0 +1,76 @@
+"""Reflected PBS scheduled-job status (verify, prune, GC, sync, tape)."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from netbox.models import NetBoxModel
+
+from netbox_pbs.choices import PBSJobRunStateChoices, PBSJobTypeChoices
+
+
+class PBSJobStatus(NetBoxModel):
+    """Last-known status of a PBS scheduled job."""
+
+    endpoint = models.ForeignKey(
+        to="netbox_pbs.PBSEndpoint",
+        on_delete=models.CASCADE,
+        related_name="jobs",
+    )
+    job_type = models.CharField(
+        max_length=16,
+        choices=PBSJobTypeChoices,
+    )
+    job_id = models.CharField(
+        max_length=128,
+        verbose_name=_("Job ID"),
+    )
+    datastore = models.ForeignKey(
+        to="netbox_pbs.PBSDatastore",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="jobs",
+    )
+    enabled = models.BooleanField(
+        default=True,
+    )
+    last_run_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name=_("Last run at"),
+    )
+    last_run_state = models.CharField(
+        max_length=16,
+        choices=PBSJobRunStateChoices,
+        default=PBSJobRunStateChoices.RUN_STATE_UNKNOWN,
+    )
+    last_run_duration_seconds = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        verbose_name=_("Last run duration (seconds)"),
+    )
+    next_run_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name=_("Next run at"),
+    )
+
+    class Meta:
+        ordering = ("endpoint", "job_type", "job_id")
+        verbose_name = _("PBS job status")
+        verbose_name_plural = _("PBS job statuses")
+        constraints = (
+            models.UniqueConstraint(
+                fields=("endpoint", "job_type", "job_id"),
+                name="netbox_pbs_pbsjobstatus_identity",
+            ),
+        )
+
+    def __str__(self) -> str:
+        return f"{self.endpoint} / {self.job_type}:{self.job_id}"
+
+    def get_absolute_url(self) -> str:
+        return reverse("plugins:netbox_pbs:pbsjobstatus", args=[self.pk])

--- a/netbox_pbs/netbox_pbs/models/pbs_node.py
+++ b/netbox_pbs/netbox_pbs/models/pbs_node.py
@@ -1,0 +1,70 @@
+"""Reflected PBS node/host record."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from netbox.models import NetBoxModel
+
+
+class PBSNode(NetBoxModel):
+    """Per-PBS-host status reflected from ``GET /nodes/{node}/status``."""
+
+    endpoint = models.ForeignKey(
+        to="netbox_pbs.PBSEndpoint",
+        on_delete=models.CASCADE,
+        related_name="nodes",
+    )
+    hostname = models.CharField(
+        max_length=255,
+        help_text=_("PBS node hostname as returned by the PBS API."),
+    )
+    version = models.CharField(
+        max_length=64,
+        blank=True,
+        help_text=_("PBS server software version (e.g. ``3.2.7``)."),
+    )
+    uptime_seconds = models.BigIntegerField(
+        null=True,
+        blank=True,
+        verbose_name=_("Uptime (seconds)"),
+    )
+    cpu_pct = models.FloatField(
+        null=True,
+        blank=True,
+        verbose_name=_("CPU usage (%)"),
+    )
+    memory_used = models.BigIntegerField(
+        null=True,
+        blank=True,
+        verbose_name=_("Memory used (bytes)"),
+    )
+    memory_total = models.BigIntegerField(
+        null=True,
+        blank=True,
+        verbose_name=_("Memory total (bytes)"),
+    )
+    last_seen_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        verbose_name=_("Last seen at"),
+    )
+
+    class Meta:
+        ordering = ("endpoint", "hostname")
+        verbose_name = _("PBS node")
+        verbose_name_plural = _("PBS nodes")
+        constraints = (
+            models.UniqueConstraint(
+                fields=("endpoint", "hostname"),
+                name="netbox_pbs_pbsnode_identity",
+            ),
+        )
+
+    def __str__(self) -> str:
+        return f"{self.endpoint} / {self.hostname}"
+
+    def get_absolute_url(self) -> str:
+        return reverse("plugins:netbox_pbs:pbsnode", args=[self.pk])

--- a/netbox_pbs/netbox_pbs/models/pbs_snapshot.py
+++ b/netbox_pbs/netbox_pbs/models/pbs_snapshot.py
@@ -1,0 +1,70 @@
+"""Reflected PBS snapshot record."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from netbox.models import NetBoxModel
+from utilities.json import CustomFieldJSONEncoder
+
+from netbox_pbs.choices import PBSSnapshotVerifyChoices
+
+
+class PBSSnapshot(NetBoxModel):
+    """One PBS snapshot inside a backup group."""
+
+    backup_group = models.ForeignKey(
+        to="netbox_pbs.PBSBackupGroup",
+        on_delete=models.CASCADE,
+        related_name="snapshots",
+    )
+    backup_time = models.DateTimeField(
+        verbose_name=_("Backup time (UTC)"),
+        help_text=_("Snapshot creation timestamp from PBS (epoch → UTC)."),
+    )
+    size_bytes = models.BigIntegerField(
+        null=True,
+        blank=True,
+        verbose_name=_("Size (bytes)"),
+    )
+    encrypted = models.BooleanField(
+        default=False,
+    )
+    verified = models.CharField(
+        max_length=16,
+        choices=PBSSnapshotVerifyChoices,
+        default=PBSSnapshotVerifyChoices.VERIFY_NONE,
+    )
+    protected = models.BooleanField(
+        default=False,
+        help_text=_("PBS ``protected`` flag — snapshot is excluded from prune."),
+    )
+    comment = models.CharField(
+        max_length=512,
+        blank=True,
+    )
+    files = models.JSONField(
+        default=list,
+        blank=True,
+        encoder=CustomFieldJSONEncoder,
+        help_text=_("PBS file manifest (``[{filename, size, crypt-mode}, ...]``)."),
+    )
+
+    class Meta:
+        ordering = ("backup_group", "-backup_time")
+        verbose_name = _("PBS snapshot")
+        verbose_name_plural = _("PBS snapshots")
+        constraints = (
+            models.UniqueConstraint(
+                fields=("backup_group", "backup_time"),
+                name="netbox_pbs_pbssnapshot_identity",
+            ),
+        )
+
+    def __str__(self) -> str:
+        return f"{self.backup_group} @ {self.backup_time.isoformat()}"
+
+    def get_absolute_url(self) -> str:
+        return reverse("plugins:netbox_pbs:pbssnapshot", args=[self.pk])

--- a/netbox_pbs/netbox_pbs/models/plugin_settings.py
+++ b/netbox_pbs/netbox_pbs/models/plugin_settings.py
@@ -1,0 +1,88 @@
+"""Singleton plugin settings for netbox-pbs.
+
+Mirrors the shape used by ``netbox_proxbox.models.ProxboxPluginSettings`` so
+the branching lifecycle helpers (``branch_lifecycle.py``, landing in PR C3)
+can read the same field names.
+
+PR C1 ships only the fields needed to boot the plugin:
+
+- ``singleton_key`` — unique key for ``get_solo()``.
+- ``branching_enabled`` / ``branch_name_prefix`` / ``branch_on_conflict`` —
+  reserved for the netbox-branching integration in PR C3.
+
+Additional fields (FastAPI endpoint pointer, encryption key, on-conflict
+policy hooks) are added in later sub-PRs.
+"""
+
+from __future__ import annotations
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+from netbox.models import NetBoxModel
+
+
+BRANCH_ON_CONFLICT_CHOICES = (
+    ("fail", _("Fail (leave branch open for review)")),
+    ("acknowledge", _("Acknowledge and merge anyway")),
+)
+
+
+class PBSPluginSettings(NetBoxModel):
+    """Singleton-style settings row used by the netbox-pbs plugin."""
+
+    singleton_key = models.CharField(
+        max_length=32,
+        unique=True,
+        default="default",
+        editable=False,
+    )
+    branching_enabled = models.BooleanField(
+        default=False,
+        verbose_name=_("Branching-enabled sync (PBS → NetBox)"),
+        help_text=_(
+            "When enabled, every PBS sync job creates a fresh netbox-branching "
+            "branch, runs the sync on that branch, and merges it back into "
+            "main on success. Requires the netbox_branching plugin to be "
+            "installed and listed last in PLUGINS."
+        ),
+    )
+    branch_name_prefix = models.CharField(
+        max_length=64,
+        default="pbs-sync",
+        verbose_name=_("Branch name prefix"),
+        help_text=_(
+            "Prefix used when auto-creating a NetBox branch per PBS sync job "
+            "(e.g. pbs-sync-<job_id>-<timestamp>)."
+        ),
+    )
+    branch_on_conflict = models.CharField(
+        max_length=16,
+        choices=BRANCH_ON_CONFLICT_CHOICES,
+        default="fail",
+        verbose_name=_("Branch merge conflict policy"),
+        help_text=_(
+            "What to do when the auto-created sync branch reports merge "
+            "conflicts. 'fail' leaves the branch open for operator review and "
+            "marks the job failed. 'acknowledge' retries the merge with "
+            "acknowledge_conflicts=True."
+        ),
+    )
+
+    class Meta:
+        verbose_name = _("PBS plugin settings")
+        verbose_name_plural = _("PBS plugin settings")
+
+    def __str__(self) -> str:
+        return "PBS plugin settings"
+
+    def save(self, *args: object, **kwargs: object) -> None:
+        """Force the singleton key so only one row ever exists."""
+        self.singleton_key = "default"
+        super().save(*args, **kwargs)
+
+    @classmethod
+    def get_solo(cls) -> "PBSPluginSettings":
+        """Return the single settings row, creating it on first access."""
+        obj, _created = cls.objects.get_or_create(singleton_key="default")
+        return obj

--- a/netbox_pbs/netbox_pbs/navigation.py
+++ b/netbox_pbs/netbox_pbs/navigation.py
@@ -1,0 +1,26 @@
+"""NetBox plugin navigation menu for netbox-pbs.
+
+PR C1 ships a single placeholder item pointing at the plugin home view.
+Datastore / snapshot / job lists are added in PR C2 when the domain
+models land.
+"""
+
+from netbox.plugins import PluginMenu, PluginMenuItem
+
+
+home_item = PluginMenuItem(
+    link="plugins:netbox_pbs:home",
+    link_text="Home",
+)
+
+
+menu = PluginMenu(
+    label="Proxmox Backup Server",
+    groups=(
+        (
+            "PBS",
+            (home_item,),
+        ),
+    ),
+    icon_class="mdi mdi-database-clock",
+)

--- a/netbox_pbs/netbox_pbs/navigation.py
+++ b/netbox_pbs/netbox_pbs/navigation.py
@@ -26,7 +26,7 @@ pbs_endpoint_item = PluginMenuItem(
             permissions=["netbox_pbs.add_pbsendpoint"],
         ),
         PluginMenuButton(
-            link="plugins:netbox_pbs:pbsendpoint_import",
+            link="plugins:netbox_pbs:pbsendpoint_bulk_import",
             title="Import PBS Endpoints",
             icon_class="mdi mdi-upload",
             permissions=["netbox_pbs.add_pbsendpoint"],

--- a/netbox_pbs/netbox_pbs/navigation.py
+++ b/netbox_pbs/netbox_pbs/navigation.py
@@ -1,26 +1,81 @@
 """NetBox plugin navigation menu for netbox-pbs.
 
-PR C1 ships a single placeholder item pointing at the plugin home view.
-Datastore / snapshot / job lists are added in PR C2 when the domain
-models land.
+One top-level menu (``Proxmox Backup Server``) with three groups:
+
+* **Inventory** — PBSEndpoint (editable) and PBSNode (read-only mirror).
+* **Backups** — PBSDatastore, PBSBackupGroup, PBSSnapshot (all read-only).
+* **Jobs** — PBSJobStatus (read-only).
+
+The five reflected models intentionally show no add/import buttons in
+the navigation; the read-only enforcement lives in ``views.py`` where
+no ``edit``/``bulk_*`` views are registered.
 """
 
-from netbox.plugins import PluginMenu, PluginMenuItem
+from netbox.plugins import PluginMenu, PluginMenuButton, PluginMenuItem
 
 
-home_item = PluginMenuItem(
-    link="plugins:netbox_pbs:home",
-    link_text="Home",
+pbs_endpoint_item = PluginMenuItem(
+    link="plugins:netbox_pbs:pbsendpoint_list",
+    link_text="PBS Endpoints",
+    permissions=["netbox_pbs.view_pbsendpoint"],
+    buttons=(
+        PluginMenuButton(
+            link="plugins:netbox_pbs:pbsendpoint_add",
+            title="Add PBS Endpoint",
+            icon_class="mdi mdi-plus-thick",
+            permissions=["netbox_pbs.add_pbsendpoint"],
+        ),
+        PluginMenuButton(
+            link="plugins:netbox_pbs:pbsendpoint_import",
+            title="Import PBS Endpoints",
+            icon_class="mdi mdi-upload",
+            permissions=["netbox_pbs.add_pbsendpoint"],
+        ),
+    ),
+)
+
+
+pbs_node_item = PluginMenuItem(
+    link="plugins:netbox_pbs:pbsnode_list",
+    link_text="PBS Nodes",
+    permissions=["netbox_pbs.view_pbsnode"],
+)
+
+
+pbs_datastore_item = PluginMenuItem(
+    link="plugins:netbox_pbs:pbsdatastore_list",
+    link_text="Datastores",
+    permissions=["netbox_pbs.view_pbsdatastore"],
+)
+
+
+pbs_backup_group_item = PluginMenuItem(
+    link="plugins:netbox_pbs:pbsbackupgroup_list",
+    link_text="Backup Groups",
+    permissions=["netbox_pbs.view_pbsbackupgroup"],
+)
+
+
+pbs_snapshot_item = PluginMenuItem(
+    link="plugins:netbox_pbs:pbssnapshot_list",
+    link_text="Snapshots",
+    permissions=["netbox_pbs.view_pbssnapshot"],
+)
+
+
+pbs_job_status_item = PluginMenuItem(
+    link="plugins:netbox_pbs:pbsjobstatus_list",
+    link_text="Job Status",
+    permissions=["netbox_pbs.view_pbsjobstatus"],
 )
 
 
 menu = PluginMenu(
     label="Proxmox Backup Server",
     groups=(
-        (
-            "PBS",
-            (home_item,),
-        ),
+        ("Inventory", (pbs_endpoint_item, pbs_node_item)),
+        ("Backups", (pbs_datastore_item, pbs_backup_group_item, pbs_snapshot_item)),
+        ("Jobs", (pbs_job_status_item,)),
     ),
     icon_class="mdi mdi-database-clock",
 )

--- a/netbox_pbs/netbox_pbs/services/__init__.py
+++ b/netbox_pbs/netbox_pbs/services/__init__.py
@@ -1,0 +1,34 @@
+"""Service layer for netbox-pbs.
+
+Contains backend HTTP transport (``http_client``) and netbox-branching
+lifecycle helpers (``branch_lifecycle``). Both modules are designed so the
+plugin can boot even when the optional ``netbox-branching`` and
+``netbox-proxbox`` plugins are absent: every cross-plugin import is
+guarded.
+"""
+
+from netbox_pbs.services.branch_lifecycle import (
+    branch_has_conflicts,
+    branching_enabled_settings,
+    create_and_provision_branch,
+    get_active_branch_schema_id,
+    is_branching_available,
+    merge_branch,
+)
+from netbox_pbs.services.http_client import (
+    PBS_STAGES_FULL,
+    PBSStageResult,
+    run_pbs_sync_stage,
+)
+
+__all__ = (
+    "PBS_STAGES_FULL",
+    "PBSStageResult",
+    "branch_has_conflicts",
+    "branching_enabled_settings",
+    "create_and_provision_branch",
+    "get_active_branch_schema_id",
+    "is_branching_available",
+    "merge_branch",
+    "run_pbs_sync_stage",
+)

--- a/netbox_pbs/netbox_pbs/services/branch_lifecycle.py
+++ b/netbox_pbs/netbox_pbs/services/branch_lifecycle.py
@@ -1,56 +1,38 @@
-"""Helpers to drive netbox-branching Branch lifecycle from PBSSyncJob.
+"""Branch-lifecycle shim that delegates to ``netbox_proxbox``.
 
-Mirrors ``netbox_proxbox.services.branch_lifecycle`` so the PBS plugin can
-participate in the same branch-create / sync / merge cycle without taking a
-hard dependency on netbox-proxbox. The branching plugin itself is optional;
-all imports tolerate ``ImportError``. Lifecycle calls are made in-process
-(no REST round-trip) so a single RQ worker can complete provisioning, sync,
-and merge without deadlocking on its own queue.
+netbox-pbs hard-depends on netbox-proxbox (declared in ``PBSConfig.required_plugins``),
+so the branching primitives — ``is_branching_available``, ``get_active_branch_schema_id``,
+``create_and_provision_branch``, ``branch_has_conflicts``, ``merge_branch`` — are
+re-exported directly from ``netbox_proxbox.services.branch_lifecycle``. The only
+PBS-specific function is ``branching_enabled_settings()``, which reads from
+``PBSPluginSettings.get_solo()`` (the PBS plugin owns its own settings row) so
+PBS sync can be branched independently of Proxmox sync.
 """
 
 from __future__ import annotations
 
 import logging
-import time
-from typing import Any
+
+from netbox_proxbox.services.branch_lifecycle import (
+    branch_has_conflicts,
+    create_and_provision_branch,
+    get_active_branch_schema_id,
+    is_branching_available,
+    merge_branch,
+)
 
 from netbox_pbs.models import PBSPluginSettings
 
+__all__ = (
+    "branch_has_conflicts",
+    "branching_enabled_settings",
+    "create_and_provision_branch",
+    "get_active_branch_schema_id",
+    "is_branching_available",
+    "merge_branch",
+)
+
 logger = logging.getLogger("netbox_pbs.branch_lifecycle")
-
-
-def is_branching_available() -> bool:
-    try:
-        import netbox_branching  # noqa: F401, PLC0415
-    except Exception:
-        return False
-    return True
-
-
-def get_active_branch_schema_id() -> str | None:
-    """Return the ``schema_id`` of the currently-active netbox-branching Branch.
-
-    Reads ``netbox_branching.contextvars.active_branch`` — the canonical
-    process-local indicator of "the user is browsing on a branch right
-    now". Returns ``None`` when branching is not installed, when no branch
-    is active in this context, or when the branch object lacks the expected
-    attributes. The detection is best-effort and never raises: the caller
-    (sync-now views, etc.) treats ``None`` as "stay on main".
-    """
-    try:
-        from netbox_branching.contextvars import active_branch  # noqa: PLC0415
-    except Exception:
-        return None
-    try:
-        branch = active_branch.get()
-    except Exception:
-        return None
-    if branch is None:
-        return None
-    schema_id = getattr(branch, "schema_id", None)
-    if not schema_id:
-        return None
-    return str(schema_id)
 
 
 def branching_enabled_settings() -> dict[str, str] | None:
@@ -68,81 +50,3 @@ def branching_enabled_settings() -> dict[str, str] | None:
         "prefix": getattr(settings_obj, "branch_name_prefix", "") or "pbs-sync",
         "on_conflict": getattr(settings_obj, "branch_on_conflict", "") or "fail",
     }
-
-
-def create_and_provision_branch(
-    *,
-    name: str,
-    user: Any | None,
-    ready_timeout_seconds: int = 60,
-) -> Any:
-    """Create a Branch row, run provision() synchronously, return the Branch.
-
-    Raises if branching is not installed, if the schema_id cannot be allocated,
-    or if provision() raises.
-    """
-    from netbox_branching.choices import BranchStatusChoices  # noqa: PLC0415
-    from netbox_branching.models import Branch  # noqa: PLC0415
-
-    branch = Branch(name=name)
-    branch.save(provision=False)
-    try:
-        branch.provision(user=user)
-    except Exception:
-        logger.exception("Branch provision failed for %s", name)
-        raise
-
-    deadline = time.monotonic() + ready_timeout_seconds
-    while True:
-        branch.refresh_from_db()
-        if branch.status == BranchStatusChoices.READY:
-            return branch
-        if branch.status == BranchStatusChoices.FAILED:
-            raise RuntimeError(
-                f"Branch {branch.name} entered FAILED status during provisioning"
-            )
-        if time.monotonic() >= deadline:
-            raise RuntimeError(
-                f"Branch {branch.name} did not reach READY within "
-                f"{ready_timeout_seconds}s (status={branch.status})"
-            )
-        time.sleep(0.5)
-
-
-def branch_has_conflicts(branch: Any) -> bool:
-    """True when ChangeDiff rows for this branch contain unresolved conflicts."""
-    from netbox_branching.models import ChangeDiff  # noqa: PLC0415
-
-    return ChangeDiff.objects.filter(branch=branch, conflicts__isnull=False).exists()
-
-
-def merge_branch(
-    *,
-    branch: Any,
-    user: Any | None,
-    on_conflict: str,
-) -> tuple[bool, str]:
-    """Apply branch policy and call branch.merge() in-process.
-
-    Returns (merged, message). When conflicts exist and policy is ``fail``,
-    the branch is left in READY for operator inspection and (False, detail)
-    is returned. When the policy is ``acknowledge``, the merge is attempted
-    despite conflicts; the underlying merge_strategy decides the outcome.
-    """
-    if branch_has_conflicts(branch):
-        if on_conflict != "acknowledge":
-            return False, (
-                f"Branch {branch.name} has unresolved conflicts and "
-                "branch_on_conflict=fail; leaving branch open."
-            )
-        logger.warning(
-            "Merging %s despite conflicts (branch_on_conflict=acknowledge)",
-            branch.name,
-        )
-
-    try:
-        branch.merge(user=user)
-    except Exception as exc:
-        logger.exception("Branch merge raised for %s", branch.name)
-        return False, f"merge failed: {exc}"
-    return True, f"Branch {branch.name} merged."

--- a/netbox_pbs/netbox_pbs/services/branch_lifecycle.py
+++ b/netbox_pbs/netbox_pbs/services/branch_lifecycle.py
@@ -1,0 +1,148 @@
+"""Helpers to drive netbox-branching Branch lifecycle from PBSSyncJob.
+
+Mirrors ``netbox_proxbox.services.branch_lifecycle`` so the PBS plugin can
+participate in the same branch-create / sync / merge cycle without taking a
+hard dependency on netbox-proxbox. The branching plugin itself is optional;
+all imports tolerate ``ImportError``. Lifecycle calls are made in-process
+(no REST round-trip) so a single RQ worker can complete provisioning, sync,
+and merge without deadlocking on its own queue.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from netbox_pbs.models import PBSPluginSettings
+
+logger = logging.getLogger("netbox_pbs.branch_lifecycle")
+
+
+def is_branching_available() -> bool:
+    try:
+        import netbox_branching  # noqa: F401, PLC0415
+    except Exception:
+        return False
+    return True
+
+
+def get_active_branch_schema_id() -> str | None:
+    """Return the ``schema_id`` of the currently-active netbox-branching Branch.
+
+    Reads ``netbox_branching.contextvars.active_branch`` — the canonical
+    process-local indicator of "the user is browsing on a branch right
+    now". Returns ``None`` when branching is not installed, when no branch
+    is active in this context, or when the branch object lacks the expected
+    attributes. The detection is best-effort and never raises: the caller
+    (sync-now views, etc.) treats ``None`` as "stay on main".
+    """
+    try:
+        from netbox_branching.contextvars import active_branch  # noqa: PLC0415
+    except Exception:
+        return None
+    try:
+        branch = active_branch.get()
+    except Exception:
+        return None
+    if branch is None:
+        return None
+    schema_id = getattr(branch, "schema_id", None)
+    if not schema_id:
+        return None
+    return str(schema_id)
+
+
+def branching_enabled_settings() -> dict[str, str] | None:
+    """Return branching config from PBSPluginSettings, or None when disabled."""
+    if not is_branching_available():
+        return None
+    try:
+        settings_obj = PBSPluginSettings.get_solo()
+    except Exception:
+        logger.exception("Could not load PBSPluginSettings")
+        return None
+    if not getattr(settings_obj, "branching_enabled", False):
+        return None
+    return {
+        "prefix": getattr(settings_obj, "branch_name_prefix", "") or "pbs-sync",
+        "on_conflict": getattr(settings_obj, "branch_on_conflict", "") or "fail",
+    }
+
+
+def create_and_provision_branch(
+    *,
+    name: str,
+    user: Any | None,
+    ready_timeout_seconds: int = 60,
+) -> Any:
+    """Create a Branch row, run provision() synchronously, return the Branch.
+
+    Raises if branching is not installed, if the schema_id cannot be allocated,
+    or if provision() raises.
+    """
+    from netbox_branching.choices import BranchStatusChoices  # noqa: PLC0415
+    from netbox_branching.models import Branch  # noqa: PLC0415
+
+    branch = Branch(name=name)
+    branch.save(provision=False)
+    try:
+        branch.provision(user=user)
+    except Exception:
+        logger.exception("Branch provision failed for %s", name)
+        raise
+
+    deadline = time.monotonic() + ready_timeout_seconds
+    while True:
+        branch.refresh_from_db()
+        if branch.status == BranchStatusChoices.READY:
+            return branch
+        if branch.status == BranchStatusChoices.FAILED:
+            raise RuntimeError(
+                f"Branch {branch.name} entered FAILED status during provisioning"
+            )
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"Branch {branch.name} did not reach READY within "
+                f"{ready_timeout_seconds}s (status={branch.status})"
+            )
+        time.sleep(0.5)
+
+
+def branch_has_conflicts(branch: Any) -> bool:
+    """True when ChangeDiff rows for this branch contain unresolved conflicts."""
+    from netbox_branching.models import ChangeDiff  # noqa: PLC0415
+
+    return ChangeDiff.objects.filter(branch=branch, conflicts__isnull=False).exists()
+
+
+def merge_branch(
+    *,
+    branch: Any,
+    user: Any | None,
+    on_conflict: str,
+) -> tuple[bool, str]:
+    """Apply branch policy and call branch.merge() in-process.
+
+    Returns (merged, message). When conflicts exist and policy is ``fail``,
+    the branch is left in READY for operator inspection and (False, detail)
+    is returned. When the policy is ``acknowledge``, the merge is attempted
+    despite conflicts; the underlying merge_strategy decides the outcome.
+    """
+    if branch_has_conflicts(branch):
+        if on_conflict != "acknowledge":
+            return False, (
+                f"Branch {branch.name} has unresolved conflicts and "
+                "branch_on_conflict=fail; leaving branch open."
+            )
+        logger.warning(
+            "Merging %s despite conflicts (branch_on_conflict=acknowledge)",
+            branch.name,
+        )
+
+    try:
+        branch.merge(user=user)
+    except Exception as exc:
+        logger.exception("Branch merge raised for %s", branch.name)
+        return False, f"merge failed: {exc}"
+    return True, f"Branch {branch.name} merged."

--- a/netbox_pbs/netbox_pbs/services/http_client.py
+++ b/netbox_pbs/netbox_pbs/services/http_client.py
@@ -5,20 +5,21 @@ stage in :data:`PBS_STAGES_FULL` the job calls :func:`run_pbs_sync_stage`,
 which streams the proxbox-api SSE response and returns a structured result.
 
 The backend base URL is resolved from ``netbox_proxbox.FastAPIEndpoint`` via
-a soft import. When ``netbox_proxbox`` is not installed the helper returns a
-failed :class:`PBSStageResult` rather than raising — letting the plugin boot
-standalone and surfacing the configuration gap through the Job log.
+``netbox_proxbox.services.backend_context.get_fastapi_request_context()``.
+netbox_proxbox is a hard dependency declared in
+``PBSConfig.required_plugins``, so the import is unconditional.
 """
 
 from __future__ import annotations
 
-import importlib
 import json
 import logging
 from dataclasses import dataclass, field
 from typing import Any
 
 import requests
+
+from netbox_proxbox.services.backend_context import get_fastapi_request_context
 
 logger = logging.getLogger("netbox_pbs.http_client")
 
@@ -53,24 +54,12 @@ class PBSStageResult:
 def _resolve_backend_context() -> Any | None:
     """Return a ``BackendRequestContext`` from netbox_proxbox, or ``None``.
 
-    PBSPluginSettings does not yet carry its own FastAPI endpoint pointer
-    (planned for a follow-up sub-PR); for now we reuse the single
-    ``FastAPIEndpoint`` row owned by netbox_proxbox when that plugin is
-    co-installed.
+    PBS reuses the single ``FastAPIEndpoint`` row owned by netbox_proxbox.
+    Returns ``None`` if the row is missing or unreachable; the caller emits
+    a failed :class:`PBSStageResult` rather than raising.
     """
     try:
-        backend_context = importlib.import_module(
-            "netbox_proxbox.services.backend_context"
-        )
-    except ModuleNotFoundError:
-        logger.warning(
-            "netbox_proxbox is not installed; cannot resolve a FastAPI backend "
-            "for PBS sync. Install netbox-proxbox or add a self-owned endpoint "
-            "field to PBSPluginSettings."
-        )
-        return None
-    try:
-        return backend_context.get_fastapi_request_context()
+        return get_fastapi_request_context()
     except Exception:
         logger.exception("Failed to resolve FastAPI request context for PBS sync")
         return None

--- a/netbox_pbs/netbox_pbs/services/http_client.py
+++ b/netbox_pbs/netbox_pbs/services/http_client.py
@@ -1,0 +1,166 @@
+"""Thin HTTP/SSE client for the proxbox-api ``/pbs/sync/*`` surface.
+
+PBS sync is orchestrated by ``PBSSyncJob`` (see ``netbox_pbs.jobs``). For each
+stage in :data:`PBS_STAGES_FULL` the job calls :func:`run_pbs_sync_stage`,
+which streams the proxbox-api SSE response and returns a structured result.
+
+The backend base URL is resolved from ``netbox_proxbox.FastAPIEndpoint`` via
+a soft import. When ``netbox_proxbox`` is not installed the helper returns a
+failed :class:`PBSStageResult` rather than raising — letting the plugin boot
+standalone and surfacing the configuration gap through the Job log.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import requests
+
+logger = logging.getLogger("netbox_pbs.http_client")
+
+
+PBS_STAGE_DATASTORES = "datastores"
+PBS_STAGE_SNAPSHOTS = "snapshots"
+PBS_STAGE_JOBS = "jobs"
+PBS_STAGE_NODE = "node"
+
+PBS_STAGES_FULL: tuple[str, ...] = (
+    PBS_STAGE_DATASTORES,
+    PBS_STAGE_SNAPSHOTS,
+    PBS_STAGE_JOBS,
+    PBS_STAGE_NODE,
+)
+
+# Long read timeout between SSE chunks — PBS syncs may pause while the
+# backend walks every snapshot in a large datastore.
+PBS_SSE_READ_TIMEOUT_SECONDS = 3600
+
+
+@dataclass
+class PBSStageResult:
+    """Outcome of a single ``/pbs/sync/<stage>`` SSE run."""
+
+    stage: str
+    success: bool
+    events: list[dict[str, Any]] = field(default_factory=list)
+    error: str | None = None
+
+
+def _resolve_backend_context() -> Any | None:
+    """Return a ``BackendRequestContext`` from netbox_proxbox, or ``None``.
+
+    PBSPluginSettings does not yet carry its own FastAPI endpoint pointer
+    (planned for a follow-up sub-PR); for now we reuse the single
+    ``FastAPIEndpoint`` row owned by netbox_proxbox when that plugin is
+    co-installed.
+    """
+    try:
+        backend_context = importlib.import_module(
+            "netbox_proxbox.services.backend_context"
+        )
+    except ModuleNotFoundError:
+        logger.warning(
+            "netbox_proxbox is not installed; cannot resolve a FastAPI backend "
+            "for PBS sync. Install netbox-proxbox or add a self-owned endpoint "
+            "field to PBSPluginSettings."
+        )
+        return None
+    try:
+        return backend_context.get_fastapi_request_context()
+    except Exception:
+        logger.exception("Failed to resolve FastAPI request context for PBS sync")
+        return None
+
+
+def _build_query_params(params: dict[str, Any]) -> dict[str, str]:
+    """Project the job params dict into the query string sent to proxbox-api."""
+    qs: dict[str, str] = {}
+    schema_id = params.get("netbox_branch_schema_id")
+    if schema_id:
+        qs["netbox_branch_schema_id"] = str(schema_id)
+    endpoint_ids = params.get("pbs_endpoint_ids") or []
+    if endpoint_ids:
+        qs["pbs_endpoint_ids"] = ",".join(str(x) for x in endpoint_ids if str(x))
+    return qs
+
+
+def run_pbs_sync_stage(
+    stage: str,
+    params: dict[str, Any],
+    *,
+    logger_: logging.Logger | None = None,
+) -> PBSStageResult:
+    """Hit ``/pbs/sync/<stage>`` (SSE) and accumulate events into a result.
+
+    ``params`` carries the orchestration context built by ``PBSSyncJob.run``;
+    notably it must contain ``netbox_branch_schema_id`` (or ``None``) so the
+    backend writes through the same NetBox branch as the rest of the job.
+    """
+    log = logger_ or logger
+
+    if stage not in PBS_STAGES_FULL:
+        return PBSStageResult(
+            stage=stage,
+            success=False,
+            error=f"Unknown PBS sync stage: {stage!r}",
+        )
+
+    context = _resolve_backend_context()
+    if context is None or not getattr(context, "http_url", None):
+        return PBSStageResult(
+            stage=stage,
+            success=False,
+            error="No FastAPIEndpoint configured for PBS sync.",
+        )
+
+    base_url = str(context.http_url).rstrip("/")
+    url = f"{base_url}/pbs/sync/{stage}"
+    query = _build_query_params(params)
+    headers = {
+        "Accept": "text/event-stream",
+        **dict(getattr(context, "headers", {}) or {}),
+    }
+    verify_ssl = bool(getattr(context, "verify_ssl", True))
+
+    log.info("PBS sync stage start: stage=%s url=%s", stage, url)
+
+    events: list[dict[str, Any]] = []
+    try:
+        response = requests.get(
+            url,
+            params=query,
+            headers=headers,
+            verify=verify_ssl,
+            stream=True,
+            timeout=(30, PBS_SSE_READ_TIMEOUT_SECONDS),
+        )
+        response.raise_for_status()
+        for line in response.iter_lines(decode_unicode=True):
+            if not line:
+                continue
+            if line.startswith("data:"):
+                payload = line[len("data:") :].strip()
+                if not payload:
+                    continue
+                try:
+                    event = json.loads(payload)
+                except json.JSONDecodeError:
+                    event = {"raw": payload}
+                events.append(event)
+                if isinstance(event, dict) and event.get("event") == "complete":
+                    break
+    except requests.RequestException as exc:
+        log.exception("PBS sync stage failed: stage=%s", stage)
+        return PBSStageResult(
+            stage=stage,
+            success=False,
+            events=events,
+            error=str(exc),
+        )
+
+    log.info("PBS sync stage complete: stage=%s events=%d", stage, len(events))
+    return PBSStageResult(stage=stage, success=True, events=events)

--- a/netbox_pbs/netbox_pbs/tables.py
+++ b/netbox_pbs/netbox_pbs/tables.py
@@ -1,0 +1,230 @@
+"""django-tables2 layouts for netbox-pbs list views.
+
+The six tables here back the per-model list and tab views. PBSEndpoint
+is the only writable model in v1; the other five are reflected from PBS
+by the read-only sync that lands in PR C3, so their list views render
+without add/edit/bulk-action controls (configured in ``views.py`` via
+the ``actions`` dict on each ``ObjectListView``).
+"""
+
+from __future__ import annotations
+
+from django.utils.translation import gettext_lazy as _
+from django_tables2 import tables
+
+from netbox.tables import ChoiceFieldColumn, NetBoxTable
+
+from netbox_pbs.models import (
+    PBSBackupGroup,
+    PBSDatastore,
+    PBSEndpoint,
+    PBSJobStatus,
+    PBSNode,
+    PBSSnapshot,
+)
+
+
+class PBSEndpointTable(NetBoxTable):
+    """List columns for the writable PBS endpoint inventory."""
+
+    name = tables.Column(linkify=True)
+    host = tables.Column()
+    port = tables.Column()
+    verify_ssl = tables.BooleanColumn(verbose_name=_("Verify SSL"))
+    last_seen_at = tables.DateTimeColumn(verbose_name=_("Last seen"))
+
+    class Meta(NetBoxTable.Meta):
+        model = PBSEndpoint
+        fields = (
+            "pk",
+            "id",
+            "name",
+            "host",
+            "port",
+            "token_id",
+            "fingerprint",
+            "verify_ssl",
+            "timeout",
+            "last_seen_at",
+        )
+        default_columns = (
+            "pk",
+            "name",
+            "host",
+            "port",
+            "verify_ssl",
+            "last_seen_at",
+        )
+
+
+class PBSNodeTable(NetBoxTable):
+    """List columns for read-only PBS node mirrors."""
+
+    endpoint = tables.Column(linkify=True)
+    hostname = tables.Column(linkify=True)
+    version = tables.Column()
+    uptime_seconds = tables.Column(verbose_name=_("Uptime (s)"))
+    cpu_pct = tables.Column(verbose_name=_("CPU %"))
+    last_seen_at = tables.DateTimeColumn(verbose_name=_("Last seen"))
+
+    class Meta(NetBoxTable.Meta):
+        model = PBSNode
+        fields = (
+            "pk",
+            "id",
+            "endpoint",
+            "hostname",
+            "version",
+            "uptime_seconds",
+            "cpu_pct",
+            "memory_used",
+            "memory_total",
+            "last_seen_at",
+        )
+        default_columns = (
+            "pk",
+            "endpoint",
+            "hostname",
+            "version",
+            "cpu_pct",
+            "last_seen_at",
+        )
+
+
+class PBSDatastoreTable(NetBoxTable):
+    """List columns for read-only PBS datastore mirrors."""
+
+    endpoint = tables.Column(linkify=True)
+    name = tables.Column(linkify=True)
+    path = tables.Column()
+    total_bytes = tables.Column(verbose_name=_("Total bytes"))
+    used_bytes = tables.Column(verbose_name=_("Used bytes"))
+    available_bytes = tables.Column(verbose_name=_("Available bytes"))
+    gc_status = ChoiceFieldColumn(verbose_name=_("GC status"))
+    last_gc_at = tables.DateTimeColumn(verbose_name=_("Last GC"))
+
+    class Meta(NetBoxTable.Meta):
+        model = PBSDatastore
+        fields = (
+            "pk",
+            "id",
+            "endpoint",
+            "name",
+            "path",
+            "total_bytes",
+            "used_bytes",
+            "available_bytes",
+            "gc_status",
+            "last_gc_at",
+        )
+        default_columns = (
+            "pk",
+            "endpoint",
+            "name",
+            "used_bytes",
+            "total_bytes",
+            "gc_status",
+            "last_gc_at",
+        )
+
+
+class PBSBackupGroupTable(NetBoxTable):
+    """List columns for read-only PBS backup-group mirrors."""
+
+    datastore = tables.Column(linkify=True)
+    backup_type = ChoiceFieldColumn(verbose_name=_("Type"))
+    backup_id = tables.Column(linkify=True, verbose_name=_("Backup ID"))
+    owner = tables.Column()
+    comment = tables.Column()
+
+    class Meta(NetBoxTable.Meta):
+        model = PBSBackupGroup
+        fields = (
+            "pk",
+            "id",
+            "datastore",
+            "backup_type",
+            "backup_id",
+            "owner",
+            "comment",
+        )
+        default_columns = (
+            "pk",
+            "datastore",
+            "backup_type",
+            "backup_id",
+            "owner",
+        )
+
+
+class PBSSnapshotTable(NetBoxTable):
+    """List columns for read-only PBS snapshot mirrors."""
+
+    backup_group = tables.Column(linkify=True)
+    backup_time = tables.DateTimeColumn(linkify=True, verbose_name=_("Backup time"))
+    size_bytes = tables.Column(verbose_name=_("Size"))
+    encrypted = tables.BooleanColumn()
+    verified = ChoiceFieldColumn()
+    protected = tables.BooleanColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = PBSSnapshot
+        fields = (
+            "pk",
+            "id",
+            "backup_group",
+            "backup_time",
+            "size_bytes",
+            "encrypted",
+            "verified",
+            "protected",
+            "comment",
+        )
+        default_columns = (
+            "pk",
+            "backup_group",
+            "backup_time",
+            "size_bytes",
+            "encrypted",
+            "verified",
+            "protected",
+        )
+
+
+class PBSJobStatusTable(NetBoxTable):
+    """List columns for read-only PBS scheduled-job mirrors."""
+
+    endpoint = tables.Column(linkify=True)
+    job_type = ChoiceFieldColumn(verbose_name=_("Type"))
+    job_id = tables.Column(linkify=True, verbose_name=_("Job ID"))
+    datastore = tables.Column(linkify=True)
+    enabled = tables.BooleanColumn()
+    last_run_at = tables.DateTimeColumn(verbose_name=_("Last run"))
+    last_run_state = ChoiceFieldColumn(verbose_name=_("Last state"))
+    next_run_at = tables.DateTimeColumn(verbose_name=_("Next run"))
+
+    class Meta(NetBoxTable.Meta):
+        model = PBSJobStatus
+        fields = (
+            "pk",
+            "id",
+            "endpoint",
+            "job_type",
+            "job_id",
+            "datastore",
+            "enabled",
+            "last_run_at",
+            "last_run_state",
+            "last_run_duration_seconds",
+            "next_run_at",
+        )
+        default_columns = (
+            "pk",
+            "endpoint",
+            "job_type",
+            "job_id",
+            "datastore",
+            "enabled",
+            "last_run_at",
+            "last_run_state",
+        )

--- a/netbox_pbs/netbox_pbs/tables.py
+++ b/netbox_pbs/netbox_pbs/tables.py
@@ -10,9 +10,9 @@ the ``actions`` dict on each ``ObjectListView``).
 from __future__ import annotations
 
 from django.utils.translation import gettext_lazy as _
-from django_tables2 import tables
+import django_tables2 as tables
 
-from netbox.tables import ChoiceFieldColumn, NetBoxTable
+from netbox.tables import BooleanColumn, ChoiceFieldColumn, NetBoxTable
 
 from netbox_pbs.models import (
     PBSBackupGroup,
@@ -30,7 +30,7 @@ class PBSEndpointTable(NetBoxTable):
     name = tables.Column(linkify=True)
     host = tables.Column()
     port = tables.Column()
-    verify_ssl = tables.BooleanColumn(verbose_name=_("Verify SSL"))
+    verify_ssl = BooleanColumn(verbose_name=_("Verify SSL"))
     last_seen_at = tables.DateTimeColumn(verbose_name=_("Last seen"))
 
     class Meta(NetBoxTable.Meta):
@@ -163,9 +163,9 @@ class PBSSnapshotTable(NetBoxTable):
     backup_group = tables.Column(linkify=True)
     backup_time = tables.DateTimeColumn(linkify=True, verbose_name=_("Backup time"))
     size_bytes = tables.Column(verbose_name=_("Size"))
-    encrypted = tables.BooleanColumn()
+    encrypted = BooleanColumn()
     verified = ChoiceFieldColumn()
-    protected = tables.BooleanColumn()
+    protected = BooleanColumn()
 
     class Meta(NetBoxTable.Meta):
         model = PBSSnapshot
@@ -198,7 +198,7 @@ class PBSJobStatusTable(NetBoxTable):
     job_type = ChoiceFieldColumn(verbose_name=_("Type"))
     job_id = tables.Column(linkify=True, verbose_name=_("Job ID"))
     datastore = tables.Column(linkify=True)
-    enabled = tables.BooleanColumn()
+    enabled = BooleanColumn()
     last_run_at = tables.DateTimeColumn(verbose_name=_("Last run"))
     last_run_state = ChoiceFieldColumn(verbose_name=_("Last state"))
     next_run_at = tables.DateTimeColumn(verbose_name=_("Next run"))

--- a/netbox_pbs/netbox_pbs/template_content.py
+++ b/netbox_pbs/netbox_pbs/template_content.py
@@ -1,0 +1,105 @@
+"""Cross-plugin template hooks for ``netbox_pbs``.
+
+When ``netbox_proxbox`` is also installed, render a presentation-only
+cross-link between :class:`netbox_proxbox.models.VMBackup` and
+:class:`netbox_pbs.models.PBSSnapshot` rows that share a natural key:
+
+* ``VMBackup.vmid``           == ``int(PBSSnapshot.backup_group.backup_id)``
+* ``VMBackup.creation_time``  == ``PBSSnapshot.backup_time``
+* ``PBSSnapshot.backup_group.backup_type`` == ``"vm"``
+
+The integration is read-only (issue #325 v1 scope): no foreign key, no
+schema change, no signal-backed backfill. If proxbox is not installed
+the extensions are simply not registered.
+"""
+
+from __future__ import annotations
+
+from django.apps import apps
+from django.utils.safestring import mark_safe
+from netbox.plugins import PluginTemplateExtension
+
+__all__ = (
+    "PBSSnapshotVMBackupExtension",
+    "VMBackupPBSSnapshotExtension",
+    "template_extensions",
+)
+
+
+def _match_pbs_snapshots(vmbackup):
+    """Return PBSSnapshot rows whose natural key matches ``vmbackup``."""
+    if vmbackup.vmid is None or vmbackup.creation_time is None:
+        return []
+    from netbox_pbs.models import PBSSnapshot
+
+    return list(
+        PBSSnapshot.objects.filter(
+            backup_group__backup_type="vm",
+            backup_group__backup_id=str(vmbackup.vmid),
+            backup_time=vmbackup.creation_time,
+        ).select_related("backup_group__datastore")
+    )
+
+
+def _match_vm_backups(snapshot):
+    """Return VMBackup rows whose natural key matches ``snapshot``."""
+    group = snapshot.backup_group
+    if group.backup_type != "vm":
+        return []
+    try:
+        vmid = int(group.backup_id)
+    except (TypeError, ValueError):
+        return []
+    from netbox_proxbox.models import VMBackup  # noqa: PLC0415
+
+    return list(
+        VMBackup.objects.filter(
+            vmid=vmid,
+            creation_time=snapshot.backup_time,
+        ).select_related("virtual_machine")
+    )
+
+
+class VMBackupPBSSnapshotExtension(PluginTemplateExtension):
+    """List matching PBS snapshots on the ``VMBackup`` detail page."""
+
+    models = ["netbox_proxbox.vmbackup"]
+
+    def right_page(self) -> str:
+        obj = self.context["object"]
+        snapshots = _match_pbs_snapshots(obj)
+        if not snapshots:
+            return ""
+        return mark_safe(  # nosec
+            self.render(
+                "netbox_pbs/inc/vmbackup_pbs_snapshots_panel.html",
+                {"snapshots": snapshots, "vmbackup": obj},
+            )
+        )
+
+
+class PBSSnapshotVMBackupExtension(PluginTemplateExtension):
+    """List matching ``VMBackup`` rows on the PBS snapshot detail page."""
+
+    models = ["netbox_pbs.pbssnapshot"]
+
+    def right_page(self) -> str:
+        obj = self.context["object"]
+        backups = _match_vm_backups(obj)
+        if not backups:
+            return ""
+        return mark_safe(  # nosec
+            self.render(
+                "netbox_pbs/inc/pbssnapshot_vm_backups_panel.html",
+                {"backups": backups, "snapshot": obj},
+            )
+        )
+
+
+if apps.is_installed("netbox_proxbox"):
+    template_extensions = [
+        VMBackupPBSSnapshotExtension,
+        PBSSnapshotVMBackupExtension,
+    ]
+else:
+    template_extensions = []

--- a/netbox_pbs/netbox_pbs/template_content.py
+++ b/netbox_pbs/netbox_pbs/template_content.py
@@ -1,21 +1,20 @@
 """Cross-plugin template hooks for ``netbox_pbs``.
 
-When ``netbox_proxbox`` is also installed, render a presentation-only
-cross-link between :class:`netbox_proxbox.models.VMBackup` and
-:class:`netbox_pbs.models.PBSSnapshot` rows that share a natural key:
+netbox_proxbox is a hard dependency (declared in
+``PBSConfig.required_plugins``), so the cross-link is always live. Render a
+presentation-only cross-link between :class:`netbox_proxbox.models.VMBackup`
+and :class:`netbox_pbs.models.PBSSnapshot` rows that share a natural key:
 
 * ``VMBackup.vmid``           == ``int(PBSSnapshot.backup_group.backup_id)``
 * ``VMBackup.creation_time``  == ``PBSSnapshot.backup_time``
 * ``PBSSnapshot.backup_group.backup_type`` == ``"vm"``
 
 The integration is read-only (issue #325 v1 scope): no foreign key, no
-schema change, no signal-backed backfill. If proxbox is not installed
-the extensions are simply not registered.
+schema change, no signal-backed backfill.
 """
 
 from __future__ import annotations
 
-from django.apps import apps
 from django.utils.safestring import mark_safe
 from netbox.plugins import PluginTemplateExtension
 
@@ -96,10 +95,7 @@ class PBSSnapshotVMBackupExtension(PluginTemplateExtension):
         )
 
 
-if apps.is_installed("netbox_proxbox"):
-    template_extensions = [
-        VMBackupPBSSnapshotExtension,
-        PBSSnapshotVMBackupExtension,
-    ]
-else:
-    template_extensions = []
+template_extensions = [
+    VMBackupPBSSnapshotExtension,
+    PBSSnapshotVMBackupExtension,
+]

--- a/netbox_pbs/netbox_pbs/templates/netbox_pbs/home.html
+++ b/netbox_pbs/netbox_pbs/templates/netbox_pbs/home.html
@@ -1,0 +1,14 @@
+{% extends 'base/layout.html' %}
+{% block title %}Proxmox Backup Server{% endblock %}
+{% block content %}
+<div class="card">
+  <h5 class="card-header">Proxmox Backup Server</h5>
+  <div class="card-body">
+    <p>
+      The <code>netbox-pbs</code> plugin is installed in scaffold mode.
+      Read-only inventory for PBS datastores, backup groups, snapshots,
+      and job status will appear here in subsequent releases.
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/netbox_pbs/netbox_pbs/templates/netbox_pbs/inc/pbssnapshot_vm_backups_panel.html
+++ b/netbox_pbs/netbox_pbs/templates/netbox_pbs/inc/pbssnapshot_vm_backups_panel.html
@@ -1,0 +1,23 @@
+<div class="card">
+    <h2 class="card-header">Matching NetBox VM Backups</h2>
+    <table class="table table-hover attr-table">
+        <thead>
+            <tr>
+                <th>Backup</th>
+                <th>Virtual Machine</th>
+                <th>Storage</th>
+                <th>Size</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for backup in backups %}
+                <tr>
+                    <td><a href="{{ backup.get_absolute_url }}">{{ backup.creation_time|date:"Y-m-d H:i:s" }}</a></td>
+                    <td><a href="{{ backup.virtual_machine.get_absolute_url }}">{{ backup.virtual_machine }}</a></td>
+                    <td>{{ backup.storage|default:"&mdash;" }}</td>
+                    <td>{% if backup.size %}{{ backup.size|filesizeformat }}{% else %}&mdash;{% endif %}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/netbox_pbs/netbox_pbs/templates/netbox_pbs/inc/vmbackup_pbs_snapshots_panel.html
+++ b/netbox_pbs/netbox_pbs/templates/netbox_pbs/inc/vmbackup_pbs_snapshots_panel.html
@@ -1,0 +1,25 @@
+<div class="card">
+    <h2 class="card-header">Matching PBS Snapshots</h2>
+    <table class="table table-hover attr-table">
+        <thead>
+            <tr>
+                <th>Snapshot</th>
+                <th>Datastore</th>
+                <th>Group</th>
+                <th>Size</th>
+                <th>Verified</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for snapshot in snapshots %}
+                <tr>
+                    <td><a href="{{ snapshot.get_absolute_url }}">{{ snapshot.backup_time|date:"Y-m-d H:i:s" }}</a></td>
+                    <td><a href="{{ snapshot.backup_group.datastore.get_absolute_url }}">{{ snapshot.backup_group.datastore.name }}</a></td>
+                    <td>{{ snapshot.backup_group.backup_type }}/{{ snapshot.backup_group.backup_id }}</td>
+                    <td>{% if snapshot.size_bytes %}{{ snapshot.size_bytes|filesizeformat }}{% else %}&mdash;{% endif %}</td>
+                    <td>{{ snapshot.get_verified_display }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/netbox_pbs/netbox_pbs/urls.py
+++ b/netbox_pbs/netbox_pbs/urls.py
@@ -1,16 +1,23 @@
 """URL routes for netbox-pbs.
 
-PR C1 ships a single placeholder ``home`` route. List/detail views land
-in PR C2 alongside the domain models.
+Most per-model URLs are wired by ``register_model_view`` decorators in
+``netbox_pbs.views`` — NetBox's URL system materializes them when the
+views module is imported. We import the views module here so list,
+detail, edit, delete, and bulk-action routes are present in the plugin
+URL namespace.
+
+The reflected PBS objects (Node, Datastore, BackupGroup, Snapshot,
+JobStatus) intentionally register only ``list`` and detail views; that
+absence is the read-only contract.
 """
 
 from django.urls import path
 
-from netbox_pbs.views import PBSHomeView
+from netbox_pbs import views  # noqa: F401  (registers per-model URLs)
 
 
 app_name = "netbox_pbs"
 
 urlpatterns = [
-    path("", PBSHomeView.as_view(), name="home"),
+    path("", views.PBSHomeView.as_view(), name="home"),
 ]

--- a/netbox_pbs/netbox_pbs/urls.py
+++ b/netbox_pbs/netbox_pbs/urls.py
@@ -1,0 +1,16 @@
+"""URL routes for netbox-pbs.
+
+PR C1 ships a single placeholder ``home`` route. List/detail views land
+in PR C2 alongside the domain models.
+"""
+
+from django.urls import path
+
+from netbox_pbs.views import PBSHomeView
+
+
+app_name = "netbox_pbs"
+
+urlpatterns = [
+    path("", PBSHomeView.as_view(), name="home"),
+]

--- a/netbox_pbs/netbox_pbs/urls.py
+++ b/netbox_pbs/netbox_pbs/urls.py
@@ -1,17 +1,18 @@
 """URL routes for netbox-pbs.
 
-Most per-model URLs are wired by ``register_model_view`` decorators in
-``netbox_pbs.views`` — NetBox's URL system materializes them when the
-views module is imported. We import the views module here so list,
-detail, edit, delete, and bulk-action routes are present in the plugin
-URL namespace.
+Per-model URLs are registered via ``register_model_view`` decorators in
+``netbox_pbs.views``; they materialize when included through
+``utilities.urls.get_model_urls``. ``views`` is imported as a side effect
+so the decorators run before ``get_model_urls`` queries the registry.
 
 The reflected PBS objects (Node, Datastore, BackupGroup, Snapshot,
 JobStatus) intentionally register only ``list`` and detail views; that
 absence is the read-only contract.
 """
 
-from django.urls import path
+from django.urls import include, path
+
+from utilities.urls import get_model_urls
 
 from netbox_pbs import views  # noqa: F401  (registers per-model URLs)
 
@@ -20,4 +21,58 @@ app_name = "netbox_pbs"
 
 urlpatterns = [
     path("", views.PBSHomeView.as_view(), name="home"),
+    # PBSEndpoint — full CRUD
+    path(
+        "endpoints/",
+        include(get_model_urls("netbox_pbs", "pbsendpoint", detail=False)),
+    ),
+    path(
+        "endpoints/<int:pk>/",
+        include(get_model_urls("netbox_pbs", "pbsendpoint")),
+    ),
+    # PBSNode — read-only list + detail
+    path(
+        "nodes/",
+        include(get_model_urls("netbox_pbs", "pbsnode", detail=False)),
+    ),
+    path(
+        "nodes/<int:pk>/",
+        include(get_model_urls("netbox_pbs", "pbsnode")),
+    ),
+    # PBSDatastore — read-only list + detail
+    path(
+        "datastores/",
+        include(get_model_urls("netbox_pbs", "pbsdatastore", detail=False)),
+    ),
+    path(
+        "datastores/<int:pk>/",
+        include(get_model_urls("netbox_pbs", "pbsdatastore")),
+    ),
+    # PBSBackupGroup — read-only list + detail
+    path(
+        "backup-groups/",
+        include(get_model_urls("netbox_pbs", "pbsbackupgroup", detail=False)),
+    ),
+    path(
+        "backup-groups/<int:pk>/",
+        include(get_model_urls("netbox_pbs", "pbsbackupgroup")),
+    ),
+    # PBSSnapshot — read-only list + detail
+    path(
+        "snapshots/",
+        include(get_model_urls("netbox_pbs", "pbssnapshot", detail=False)),
+    ),
+    path(
+        "snapshots/<int:pk>/",
+        include(get_model_urls("netbox_pbs", "pbssnapshot")),
+    ),
+    # PBSJobStatus — read-only list + detail
+    path(
+        "job-status/",
+        include(get_model_urls("netbox_pbs", "pbsjobstatus", detail=False)),
+    ),
+    path(
+        "job-status/<int:pk>/",
+        include(get_model_urls("netbox_pbs", "pbsjobstatus")),
+    ),
 ]

--- a/netbox_pbs/netbox_pbs/views.py
+++ b/netbox_pbs/netbox_pbs/views.py
@@ -1,0 +1,16 @@
+"""Views for netbox-pbs.
+
+PR C1 ships only a placeholder home view so the plugin can boot, register
+its URL namespace, and render a navigation entry. Real list/detail views
+land in PR C2 alongside the PBS domain models.
+"""
+
+from django.views.generic import TemplateView
+
+from utilities.views import ConditionalLoginRequiredMixin
+
+
+class PBSHomeView(ConditionalLoginRequiredMixin, TemplateView):
+    """Placeholder home page for the netbox-pbs plugin."""
+
+    template_name = "netbox_pbs/home.html"

--- a/netbox_pbs/netbox_pbs/views.py
+++ b/netbox_pbs/netbox_pbs/views.py
@@ -1,16 +1,243 @@
 """Views for netbox-pbs.
 
-PR C1 ships only a placeholder home view so the plugin can boot, register
-its URL namespace, and render a navigation entry. Real list/detail views
-land in PR C2 alongside the PBS domain models.
+Read-only enforcement story (advisor check 3): the five PBS objects
+reflected from PBS (Node, Datastore, BackupGroup, Snapshot, JobStatus)
+register **only** ``ObjectListView`` and ``ObjectView``. They never
+register ``edit``, ``delete``, ``bulk_edit``, ``bulk_delete``, or
+``bulk_import``, so NetBox's plugin URL system never builds those routes
+and the templates never render those buttons. PBSEndpoint is the one
+writable model — operators create it manually so the sync (PR C3) can
+reach it.
 """
+
+from __future__ import annotations
 
 from django.views.generic import TemplateView
 
-from utilities.views import ConditionalLoginRequiredMixin
+from netbox.views import generic
+from utilities.views import ConditionalLoginRequiredMixin, register_model_view
+
+from netbox_pbs.filtersets import (
+    PBSBackupGroupFilterSet,
+    PBSDatastoreFilterSet,
+    PBSEndpointFilterSet,
+    PBSJobStatusFilterSet,
+    PBSNodeFilterSet,
+    PBSSnapshotFilterSet,
+)
+from netbox_pbs.forms import (
+    PBSBackupGroupFilterForm,
+    PBSDatastoreFilterForm,
+    PBSEndpointBulkEditForm,
+    PBSEndpointFilterForm,
+    PBSEndpointForm,
+    PBSEndpointImportForm,
+    PBSJobStatusFilterForm,
+    PBSNodeFilterForm,
+    PBSSnapshotFilterForm,
+)
+from netbox_pbs.models import (
+    PBSBackupGroup,
+    PBSDatastore,
+    PBSEndpoint,
+    PBSJobStatus,
+    PBSNode,
+    PBSSnapshot,
+)
+from netbox_pbs.tables import (
+    PBSBackupGroupTable,
+    PBSDatastoreTable,
+    PBSEndpointTable,
+    PBSJobStatusTable,
+    PBSNodeTable,
+    PBSSnapshotTable,
+)
+
+
+# Read-only action set used by every reflected-model list view.
+_READ_ONLY_ACTIONS = {"export": {"view"}}
 
 
 class PBSHomeView(ConditionalLoginRequiredMixin, TemplateView):
     """Placeholder home page for the netbox-pbs plugin."""
 
     template_name = "netbox_pbs/home.html"
+
+
+# ----- PBSEndpoint: full CRUD ------------------------------------------------
+
+
+@register_model_view(PBSEndpoint, "list", path="", detail=False)
+class PBSEndpointListView(generic.ObjectListView):
+    """Global list of PBS endpoints."""
+
+    queryset = PBSEndpoint.objects.all()
+    table = PBSEndpointTable
+    filterset = PBSEndpointFilterSet
+    filterset_form = PBSEndpointFilterForm
+    actions = {
+        "add": {"add"},
+        "bulk_edit": {"change"},
+        "bulk_delete": {"delete"},
+        "bulk_import": {"add"},
+        "export": {"view"},
+    }
+
+
+@register_model_view(PBSEndpoint)
+class PBSEndpointView(generic.ObjectView):
+    """Detail view for a PBS endpoint."""
+
+    queryset = PBSEndpoint.objects.all()
+
+
+@register_model_view(PBSEndpoint, "edit")
+class PBSEndpointEditView(generic.ObjectEditView):
+    """Create or edit a PBS endpoint."""
+
+    queryset = PBSEndpoint.objects.all()
+    form = PBSEndpointForm
+    default_return_url = "plugins:netbox_pbs:pbsendpoint_list"
+
+
+@register_model_view(PBSEndpoint, "delete")
+class PBSEndpointDeleteView(generic.ObjectDeleteView):
+    """Delete a single PBS endpoint."""
+
+    queryset = PBSEndpoint.objects.all()
+    default_return_url = "plugins:netbox_pbs:pbsendpoint_list"
+
+
+@register_model_view(PBSEndpoint, "bulk_delete", detail=False)
+class PBSEndpointBulkDeleteView(generic.BulkDeleteView):
+    """Bulk delete PBS endpoints."""
+
+    queryset = PBSEndpoint.objects.all()
+    filterset = PBSEndpointFilterSet
+    table = PBSEndpointTable
+    default_return_url = "plugins:netbox_pbs:pbsendpoint_list"
+
+
+@register_model_view(PBSEndpoint, "bulk_edit", path="edit", detail=False)
+class PBSEndpointBulkEditView(generic.BulkEditView):
+    """Bulk edit PBS endpoints."""
+
+    queryset = PBSEndpoint.objects.all()
+    filterset = PBSEndpointFilterSet
+    table = PBSEndpointTable
+    form = PBSEndpointBulkEditForm
+    default_return_url = "plugins:netbox_pbs:pbsendpoint_list"
+
+
+@register_model_view(PBSEndpoint, "bulk_import", path="import", detail=False)
+class PBSEndpointBulkImportView(generic.BulkImportView):
+    """CSV import for PBS endpoint rows."""
+
+    queryset = PBSEndpoint.objects.all()
+    model_form = PBSEndpointImportForm
+    default_return_url = "plugins:netbox_pbs:pbsendpoint_list"
+
+
+# ----- PBSNode: read-only list + detail --------------------------------------
+
+
+@register_model_view(PBSNode, "list", path="", detail=False)
+class PBSNodeListView(generic.ObjectListView):
+    """Read-only list of PBS nodes mirrored from PBS."""
+
+    queryset = PBSNode.objects.all()
+    table = PBSNodeTable
+    filterset = PBSNodeFilterSet
+    filterset_form = PBSNodeFilterForm
+    actions = _READ_ONLY_ACTIONS
+
+
+@register_model_view(PBSNode)
+class PBSNodeView(generic.ObjectView):
+    """Detail view for a PBS node."""
+
+    queryset = PBSNode.objects.all()
+
+
+# ----- PBSDatastore: read-only list + detail ---------------------------------
+
+
+@register_model_view(PBSDatastore, "list", path="", detail=False)
+class PBSDatastoreListView(generic.ObjectListView):
+    """Read-only list of PBS datastores mirrored from PBS."""
+
+    queryset = PBSDatastore.objects.all()
+    table = PBSDatastoreTable
+    filterset = PBSDatastoreFilterSet
+    filterset_form = PBSDatastoreFilterForm
+    actions = _READ_ONLY_ACTIONS
+
+
+@register_model_view(PBSDatastore)
+class PBSDatastoreView(generic.ObjectView):
+    """Detail view for a PBS datastore."""
+
+    queryset = PBSDatastore.objects.all()
+
+
+# ----- PBSBackupGroup: read-only list + detail -------------------------------
+
+
+@register_model_view(PBSBackupGroup, "list", path="", detail=False)
+class PBSBackupGroupListView(generic.ObjectListView):
+    """Read-only list of PBS backup groups mirrored from PBS."""
+
+    queryset = PBSBackupGroup.objects.all()
+    table = PBSBackupGroupTable
+    filterset = PBSBackupGroupFilterSet
+    filterset_form = PBSBackupGroupFilterForm
+    actions = _READ_ONLY_ACTIONS
+
+
+@register_model_view(PBSBackupGroup)
+class PBSBackupGroupView(generic.ObjectView):
+    """Detail view for a PBS backup group."""
+
+    queryset = PBSBackupGroup.objects.all()
+
+
+# ----- PBSSnapshot: read-only list + detail ----------------------------------
+
+
+@register_model_view(PBSSnapshot, "list", path="", detail=False)
+class PBSSnapshotListView(generic.ObjectListView):
+    """Read-only list of PBS snapshots mirrored from PBS."""
+
+    queryset = PBSSnapshot.objects.all()
+    table = PBSSnapshotTable
+    filterset = PBSSnapshotFilterSet
+    filterset_form = PBSSnapshotFilterForm
+    actions = _READ_ONLY_ACTIONS
+
+
+@register_model_view(PBSSnapshot)
+class PBSSnapshotView(generic.ObjectView):
+    """Detail view for a PBS snapshot."""
+
+    queryset = PBSSnapshot.objects.all()
+
+
+# ----- PBSJobStatus: read-only list + detail ---------------------------------
+
+
+@register_model_view(PBSJobStatus, "list", path="", detail=False)
+class PBSJobStatusListView(generic.ObjectListView):
+    """Read-only list of PBS scheduled-job statuses mirrored from PBS."""
+
+    queryset = PBSJobStatus.objects.all()
+    table = PBSJobStatusTable
+    filterset = PBSJobStatusFilterSet
+    filterset_form = PBSJobStatusFilterForm
+    actions = _READ_ONLY_ACTIONS
+
+
+@register_model_view(PBSJobStatus)
+class PBSJobStatusView(generic.ObjectView):
+    """Detail view for a PBS scheduled-job status."""
+
+    queryset = PBSJobStatus.objects.all()

--- a/netbox_pbs/netbox_pbs/views.py
+++ b/netbox_pbs/netbox_pbs/views.py
@@ -91,6 +91,7 @@ class PBSEndpointView(generic.ObjectView):
     queryset = PBSEndpoint.objects.all()
 
 
+@register_model_view(PBSEndpoint, "add", detail=False)
 @register_model_view(PBSEndpoint, "edit")
 class PBSEndpointEditView(generic.ObjectEditView):
     """Create or edit a PBS endpoint."""

--- a/netbox_pbs/pyproject.toml
+++ b/netbox_pbs/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "netbox-pbs"
+version = "0.0.15"
+description = "NetBox plugin — Proxmox Backup Server inventory and snapshot sync (read-only)"
+readme = "README.md"
+authors = [
+    {name = "Emerson Felipe", email = "emersonfelipe.2003@gmail.com"}
+]
+license = "Apache-2.0"
+requires-python = ">=3.12"
+dependencies = [
+    "pydantic==2.13.3",
+    "requests>=2.33.0",
+]
+
+[project.optional-dependencies]
+proxbox = ["netbox-proxbox>=0.0.15"]
+dev = [
+    "pre-commit>=4.0.0",
+    "ruff>=0.11.0",
+]
+test = [
+    "pytest>=9.0.2",
+    "pytest-cov>=7.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["netbox_pbs"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+exclude = ["netbox_pbs/migrations"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]
+ignore = ["F403", "F401", "E501", "W293"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "F403"]

--- a/netbox_pbs/pyproject.toml
+++ b/netbox_pbs/pyproject.toml
@@ -9,12 +9,12 @@ authors = [
 license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
+    "netbox-proxbox>=0.0.15",
     "pydantic==2.13.3",
     "requests>=2.33.0",
 ]
 
 [project.optional-dependencies]
-proxbox = ["netbox-proxbox>=0.0.15"]
 dev = [
     "pre-commit>=4.0.0",
     "ruff>=0.11.0",

--- a/netbox_pbs/pyproject.toml
+++ b/netbox_pbs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-pbs"
-version = "0.0.15"
+version = "0.0.1"
 description = "NetBox plugin — Proxmox Backup Server inventory and snapshot sync (read-only)"
 readme = "README.md"
 authors = [

--- a/netbox_pbs/tests/test_api_contract.py
+++ b/netbox_pbs/tests/test_api_contract.py
@@ -1,0 +1,158 @@
+"""AST-based contract tests for the PR C2b PBS REST API surface.
+
+Pin the read-only enforcement on the API side: only ``PBSEndpointViewSet``
+exposes full CRUD; the five reflected viewsets restrict ``http_method_names``
+to ``("get", "head", "options")`` so POST/PUT/PATCH/DELETE return 405.
+
+We verify the contract via AST rather than booting NetBox so the per-commit
+gate runs offline.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PKG_DIR = REPO_ROOT / "netbox_pbs"
+API_DIR = PKG_DIR / "api"
+API_VIEWS = API_DIR / "views.py"
+API_URLS = API_DIR / "urls.py"
+API_SERIALIZERS = API_DIR / "serializers.py"
+
+
+READ_ONLY_VIEWSETS = (
+    "PBSNodeViewSet",
+    "PBSDatastoreViewSet",
+    "PBSBackupGroupViewSet",
+    "PBSSnapshotViewSet",
+    "PBSJobStatusViewSet",
+)
+ALL_VIEWSETS = ("PBSEndpointViewSet", *READ_ONLY_VIEWSETS)
+ALL_SERIALIZERS = (
+    "PBSEndpointSerializer",
+    "PBSNodeSerializer",
+    "PBSDatastoreSerializer",
+    "PBSBackupGroupSerializer",
+    "PBSSnapshotSerializer",
+    "PBSJobStatusSerializer",
+)
+
+
+def _find_class(module: ast.Module, name: str) -> ast.ClassDef | None:
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    return None
+
+
+def _http_method_names_value(class_node: ast.ClassDef) -> tuple[str, ...] | None:
+    """Return the tuple/list literal assigned to ``http_method_names`` if any."""
+    for stmt in class_node.body:
+        if not isinstance(stmt, ast.Assign):
+            continue
+        for target in stmt.targets:
+            if isinstance(target, ast.Name) and target.id == "http_method_names":
+                value = stmt.value
+                # Direct tuple/list literal
+                if isinstance(value, (ast.Tuple, ast.List)):
+                    return tuple(
+                        elt.value for elt in value.elts if isinstance(elt, ast.Constant)
+                    )
+                # Module-level constant reference (e.g. _READ_ONLY_HTTP_METHODS)
+                if isinstance(value, ast.Name):
+                    module = class_node  # placeholder; resolved below
+                    return _resolve_module_constant(module, value.id)
+    return None
+
+
+def _resolve_module_constant(
+    class_node: ast.ClassDef, name: str
+) -> tuple[str, ...] | None:
+    # Walk up to module by re-parsing the file the class came from.
+    # Simpler: scan API_VIEWS module-level constants.
+    module = ast.parse(API_VIEWS.read_text(encoding="utf-8"))
+    for stmt in module.body:
+        if not isinstance(stmt, ast.Assign):
+            continue
+        for target in stmt.targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                value = stmt.value
+                if isinstance(value, (ast.Tuple, ast.List)):
+                    return tuple(
+                        elt.value for elt in value.elts if isinstance(elt, ast.Constant)
+                    )
+    return None
+
+
+def test_pbs_endpoint_viewset_is_full_crud():
+    module = ast.parse(API_VIEWS.read_text(encoding="utf-8"))
+    cls = _find_class(module, "PBSEndpointViewSet")
+    assert cls is not None, "missing PBSEndpointViewSet"
+    # No http_method_names restriction => full CRUD
+    assert _http_method_names_value(cls) is None, (
+        "PBSEndpointViewSet must not restrict http_method_names"
+    )
+
+
+def test_reflected_viewsets_restrict_to_read_only_http_methods():
+    module = ast.parse(API_VIEWS.read_text(encoding="utf-8"))
+    for viewset in READ_ONLY_VIEWSETS:
+        cls = _find_class(module, viewset)
+        assert cls is not None, f"missing {viewset}"
+        methods = _http_method_names_value(cls)
+        assert methods is not None, (
+            f"{viewset} must restrict http_method_names to read-only verbs"
+        )
+        assert set(methods) <= {"get", "head", "options"}, (
+            f"{viewset} http_method_names must be a subset of "
+            f"(get, head, options); got {methods}"
+        )
+
+
+def test_all_viewsets_inherit_from_netbox_model_viewset():
+    """Every viewset must use NetBoxModelViewSet so permission + pagination work."""
+    module = ast.parse(API_VIEWS.read_text(encoding="utf-8"))
+    for viewset in ALL_VIEWSETS:
+        cls = _find_class(module, viewset)
+        assert cls is not None, f"missing {viewset}"
+        base_names = [
+            base.id if isinstance(base, ast.Name) else None for base in cls.bases
+        ]
+        assert "NetBoxModelViewSet" in base_names, (
+            f"{viewset} must inherit from NetBoxModelViewSet; got {base_names}"
+        )
+
+
+def test_api_urls_register_all_six_viewsets():
+    text = API_URLS.read_text(encoding="utf-8")
+    expected_basenames = {
+        "PBSEndpointViewSet": "pbsendpoint",
+        "PBSNodeViewSet": "pbsnode",
+        "PBSDatastoreViewSet": "pbsdatastore",
+        "PBSBackupGroupViewSet": "pbsbackupgroup",
+        "PBSSnapshotViewSet": "pbssnapshot",
+        "PBSJobStatusViewSet": "pbsjobstatus",
+    }
+    for viewset, basename in expected_basenames.items():
+        assert viewset in text, f"api/urls.py must register {viewset}"
+        assert f'basename="{basename}"' in text, (
+            f"api/urls.py must use basename='{basename}' for {viewset}"
+        )
+
+
+def test_pbs_endpoint_serializer_marks_token_value_write_only():
+    """``token_value`` must never appear in API responses."""
+    text = API_SERIALIZERS.read_text(encoding="utf-8")
+    # The simplest contract pin: the write_only=True attribute appears on the
+    # token_value field declaration.
+    assert "token_value = serializers.CharField(write_only=True)" in text, (
+        "PBSEndpointSerializer.token_value must be declared write_only"
+    )
+
+
+def test_serializers_module_defines_one_serializer_per_model():
+    text = API_SERIALIZERS.read_text(encoding="utf-8")
+    for serializer in ALL_SERIALIZERS:
+        assert f"class {serializer}(" in text, f"missing {serializer}"

--- a/netbox_pbs/tests/test_branch_lifecycle.py
+++ b/netbox_pbs/tests/test_branch_lifecycle.py
@@ -1,9 +1,12 @@
-"""AST-based contract tests for the PR C3 branch_lifecycle module.
+"""AST-based contract tests for the branch_lifecycle shim.
 
-Verifies that ``netbox_pbs.services.branch_lifecycle`` exposes the same six
-canonical functions used by ``netbox_proxbox`` and reads its config from
-``PBSPluginSettings.get_solo()`` (not the proxbox settings model). The tests
-are AST-driven so the per-commit gate runs offline.
+Per the 2026-05-13 pivot, ``netbox_pbs.services.branch_lifecycle`` is a
+**shim** that re-exports the canonical primitives from
+``netbox_proxbox.services.branch_lifecycle`` and defines only one
+PBS-specific function (``branching_enabled_settings``) which reads from
+``PBSPluginSettings.get_solo()`` rather than the proxbox settings model.
+
+The tests are AST-driven so the per-commit gate runs offline.
 """
 
 from __future__ import annotations
@@ -16,10 +19,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 BRANCH_LIFECYCLE = REPO_ROOT / "netbox_pbs" / "services" / "branch_lifecycle.py"
 
 
-REQUIRED_FUNCTIONS = (
+REEXPORTED_NAMES = (
     "is_branching_available",
     "get_active_branch_schema_id",
-    "branching_enabled_settings",
     "create_and_provision_branch",
     "branch_has_conflicts",
     "merge_branch",
@@ -30,25 +32,45 @@ def _module() -> ast.Module:
     return ast.parse(BRANCH_LIFECYCLE.read_text(encoding="utf-8"))
 
 
-def _function(module: ast.Module, name: str) -> ast.FunctionDef | None:
-    for node in module.body:
-        if isinstance(node, ast.FunctionDef) and node.name == name:
-            return node
-    return None
-
-
 def test_branch_lifecycle_module_exists():
     assert BRANCH_LIFECYCLE.is_file(), (
         f"missing {BRANCH_LIFECYCLE.relative_to(REPO_ROOT)}"
     )
 
 
-def test_branch_lifecycle_defines_all_six_canonical_functions():
+def test_shim_reexports_canonical_primitives_from_netbox_proxbox():
+    """The shim must import all five canonical names from netbox_proxbox."""
     module = _module()
-    for name in REQUIRED_FUNCTIONS:
-        assert _function(module, name) is not None, (
-            f"netbox_pbs.services.branch_lifecycle must define {name}()"
-        )
+    reexported: set[str] = set()
+    for node in module.body:
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module == "netbox_proxbox.services.branch_lifecycle"
+        ):
+            reexported.update(alias.name for alias in node.names)
+    missing = set(REEXPORTED_NAMES) - reexported
+    assert not missing, (
+        f"branch_lifecycle.py must re-export {sorted(missing)} from "
+        "netbox_proxbox.services.branch_lifecycle"
+    )
+
+
+def test_shim_defines_only_branching_enabled_settings_locally():
+    """The shim must define ``branching_enabled_settings`` and nothing else."""
+    module = _module()
+    local_funcs = {
+        node.name for node in module.body if isinstance(node, ast.FunctionDef)
+    }
+    assert "branching_enabled_settings" in local_funcs, (
+        "shim must define branching_enabled_settings() locally so it can "
+        "read PBSPluginSettings instead of ProxboxPluginSettings"
+    )
+    # No other primitives should be redefined — they come from netbox_proxbox.
+    redefined = local_funcs & set(REEXPORTED_NAMES)
+    assert not redefined, (
+        f"shim must not redefine {sorted(redefined)} — re-export from "
+        "netbox_proxbox instead"
+    )
 
 
 def test_branching_enabled_settings_uses_pbs_plugin_settings():
@@ -66,32 +88,26 @@ def test_branching_enabled_settings_uses_pbs_plugin_settings():
     )
 
 
-def test_create_and_provision_branch_polls_until_ready():
-    """The provisioning helper must wait for BranchStatusChoices.READY."""
-    text = BRANCH_LIFECYCLE.read_text(encoding="utf-8")
-    assert "BranchStatusChoices.READY" in text, (
-        "create_and_provision_branch must poll until READY"
-    )
-    assert "BranchStatusChoices.FAILED" in text, (
-        "create_and_provision_branch must surface FAILED status"
-    )
-    assert "branch.provision(user=user)" in text, (
-        "create_and_provision_branch must call branch.provision(user=user)"
-    )
-
-
-def test_merge_branch_respects_on_conflict_policy():
-    text = BRANCH_LIFECYCLE.read_text(encoding="utf-8")
-    assert 'on_conflict != "acknowledge"' in text, (
-        "merge_branch must refuse merge on conflicts unless on_conflict=='acknowledge'"
-    )
-    assert "branch.merge(user=user)" in text, (
-        "merge_branch must call branch.merge(user=user)"
-    )
-
-
-def test_get_active_branch_schema_id_reads_contextvar():
-    text = BRANCH_LIFECYCLE.read_text(encoding="utf-8")
-    assert "from netbox_branching.contextvars import active_branch" in text, (
-        "get_active_branch_schema_id must read netbox_branching.contextvars.active_branch"
-    )
+def test_all_includes_branching_enabled_settings_and_reexports():
+    """``__all__`` must surface the shim's public API."""
+    module = _module()
+    for stmt in module.body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == "__all__"
+        ):
+            values: set[str] = set()
+            if isinstance(stmt.value, (ast.Tuple, ast.List)):
+                values = {
+                    elt.value
+                    for elt in stmt.value.elts
+                    if isinstance(elt, ast.Constant)
+                    and isinstance(elt.value, str)
+                }
+            expected = set(REEXPORTED_NAMES) | {"branching_enabled_settings"}
+            missing = expected - values
+            assert not missing, f"__all__ missing names: {sorted(missing)}"
+            return
+    raise AssertionError("branch_lifecycle.py must declare __all__")

--- a/netbox_pbs/tests/test_branch_lifecycle.py
+++ b/netbox_pbs/tests/test_branch_lifecycle.py
@@ -1,0 +1,97 @@
+"""AST-based contract tests for the PR C3 branch_lifecycle module.
+
+Verifies that ``netbox_pbs.services.branch_lifecycle`` exposes the same six
+canonical functions used by ``netbox_proxbox`` and reads its config from
+``PBSPluginSettings.get_solo()`` (not the proxbox settings model). The tests
+are AST-driven so the per-commit gate runs offline.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BRANCH_LIFECYCLE = REPO_ROOT / "netbox_pbs" / "services" / "branch_lifecycle.py"
+
+
+REQUIRED_FUNCTIONS = (
+    "is_branching_available",
+    "get_active_branch_schema_id",
+    "branching_enabled_settings",
+    "create_and_provision_branch",
+    "branch_has_conflicts",
+    "merge_branch",
+)
+
+
+def _module() -> ast.Module:
+    return ast.parse(BRANCH_LIFECYCLE.read_text(encoding="utf-8"))
+
+
+def _function(module: ast.Module, name: str) -> ast.FunctionDef | None:
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def test_branch_lifecycle_module_exists():
+    assert BRANCH_LIFECYCLE.is_file(), (
+        f"missing {BRANCH_LIFECYCLE.relative_to(REPO_ROOT)}"
+    )
+
+
+def test_branch_lifecycle_defines_all_six_canonical_functions():
+    module = _module()
+    for name in REQUIRED_FUNCTIONS:
+        assert _function(module, name) is not None, (
+            f"netbox_pbs.services.branch_lifecycle must define {name}()"
+        )
+
+
+def test_branching_enabled_settings_uses_pbs_plugin_settings():
+    """The settings loader must read PBSPluginSettings, not the proxbox one."""
+    text = BRANCH_LIFECYCLE.read_text(encoding="utf-8")
+    assert "from netbox_pbs.models import PBSPluginSettings" in text, (
+        "branch_lifecycle.py must import PBSPluginSettings from netbox_pbs.models"
+    )
+    assert "PBSPluginSettings.get_solo()" in text, (
+        "branching_enabled_settings() must call PBSPluginSettings.get_solo()"
+    )
+    assert "ProxboxPluginSettings" not in text, (
+        "branch_lifecycle.py must not reference ProxboxPluginSettings — "
+        "the PBS plugin owns its own settings row"
+    )
+
+
+def test_create_and_provision_branch_polls_until_ready():
+    """The provisioning helper must wait for BranchStatusChoices.READY."""
+    text = BRANCH_LIFECYCLE.read_text(encoding="utf-8")
+    assert "BranchStatusChoices.READY" in text, (
+        "create_and_provision_branch must poll until READY"
+    )
+    assert "BranchStatusChoices.FAILED" in text, (
+        "create_and_provision_branch must surface FAILED status"
+    )
+    assert "branch.provision(user=user)" in text, (
+        "create_and_provision_branch must call branch.provision(user=user)"
+    )
+
+
+def test_merge_branch_respects_on_conflict_policy():
+    text = BRANCH_LIFECYCLE.read_text(encoding="utf-8")
+    assert 'on_conflict != "acknowledge"' in text, (
+        "merge_branch must refuse merge on conflicts unless on_conflict=='acknowledge'"
+    )
+    assert "branch.merge(user=user)" in text, (
+        "merge_branch must call branch.merge(user=user)"
+    )
+
+
+def test_get_active_branch_schema_id_reads_contextvar():
+    text = BRANCH_LIFECYCLE.read_text(encoding="utf-8")
+    assert "from netbox_branching.contextvars import active_branch" in text, (
+        "get_active_branch_schema_id must read netbox_branching.contextvars.active_branch"
+    )

--- a/netbox_pbs/tests/test_domain_models.py
+++ b/netbox_pbs/tests/test_domain_models.py
@@ -1,0 +1,107 @@
+"""AST-based contract tests for the PR C2 PBS domain models.
+
+The C1 boot tests in ``test_plugin_boots.py`` already prove that PR C1's
+migration ``0001_initial`` does NOT contain the domain models. These
+tests assert the symmetric property: PR C2's migration ``0002`` DOES
+create each of the six expected tables and declares the unique
+identity constraints the read-only PBS sync depends on.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODELS_DIR = REPO_ROOT / "netbox_pbs" / "models"
+MIGRATION_C2 = REPO_ROOT / "netbox_pbs" / "migrations" / "0002_pbs_domain_models.py"
+
+DOMAIN_MODELS = (
+    "PBSEndpoint",
+    "PBSNode",
+    "PBSDatastore",
+    "PBSBackupGroup",
+    "PBSSnapshot",
+    "PBSJobStatus",
+)
+
+
+def _module_classes(path: Path) -> set[str]:
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    return {node.name for node in ast.walk(module) if isinstance(node, ast.ClassDef)}
+
+
+def test_each_domain_model_lives_in_its_own_file():
+    expected = {
+        "PBSEndpoint": "pbs_endpoint.py",
+        "PBSNode": "pbs_node.py",
+        "PBSDatastore": "pbs_datastore.py",
+        "PBSBackupGroup": "pbs_backup_group.py",
+        "PBSSnapshot": "pbs_snapshot.py",
+        "PBSJobStatus": "pbs_job_status.py",
+    }
+    for class_name, filename in expected.items():
+        path = MODELS_DIR / filename
+        assert path.exists(), f"missing {path}"
+        assert class_name in _module_classes(path), (
+            f"{class_name} not defined in {filename}"
+        )
+
+
+def test_models_init_reexports_domain_classes():
+    text = (MODELS_DIR / "__init__.py").read_text(encoding="utf-8")
+    for class_name in DOMAIN_MODELS:
+        assert class_name in text, f"{class_name} not re-exported from models/__init__"
+
+
+def test_migration_0002_creates_all_six_models():
+    text = MIGRATION_C2.read_text(encoding="utf-8")
+    assert (
+        'dependencies = [\n        ("extras", "0001_initial"),\n        ("netbox_pbs", "0001_initial"),'
+        in text
+    )
+    for class_name in DOMAIN_MODELS:
+        assert f'name="{class_name}"' in text, (
+            f"PR C2 migration must CreateModel({class_name})"
+        )
+
+
+def test_migration_0002_pins_identity_constraints():
+    text = MIGRATION_C2.read_text(encoding="utf-8")
+    for constraint in (
+        "netbox_pbs_pbsnode_identity",
+        "netbox_pbs_pbsdatastore_identity",
+        "netbox_pbs_pbsbackupgroup_identity",
+        "netbox_pbs_pbssnapshot_identity",
+        "netbox_pbs_pbsjobstatus_identity",
+    ):
+        assert constraint in text, f"missing identity constraint {constraint}"
+
+
+def test_pbs_endpoint_carries_credentials_no_allow_writes():
+    text = (MODELS_DIR / "pbs_endpoint.py").read_text(encoding="utf-8")
+    # Mirror ProxmoxEndpoint pattern: plaintext CharField gated by RBAC.
+    assert "token_id" in text
+    assert "token_value" in text
+    assert "fingerprint" in text
+    assert "verify_ssl" in text
+    # v1 is read-only PBS → NetBox; no NetBox-side write path to gate.
+    # Check for an actual field declaration, not docstring mentions.
+    assert "allow_writes = models." not in text, (
+        "v1 is read-only — allow_writes belongs on the proxbox-api side"
+    )
+
+
+def test_pbs_snapshot_files_field_is_json():
+    text = (MODELS_DIR / "pbs_snapshot.py").read_text(encoding="utf-8")
+    assert "files = models.JSONField" in text
+    assert "CustomFieldJSONEncoder" in text
+
+
+def test_pbs_job_status_datastore_link_is_nullable_set_null():
+    text = (MODELS_DIR / "pbs_job_status.py").read_text(encoding="utf-8")
+    # GC/verify/prune jobs always have a datastore; sync/tape may not.
+    assert "datastore = models.ForeignKey" in text
+    assert "SET_NULL" in text
+    assert "null=True" in text

--- a/netbox_pbs/tests/test_jobs.py
+++ b/netbox_pbs/tests/test_jobs.py
@@ -1,0 +1,129 @@
+"""AST-based contract tests for the PR C3 PBSSyncJob.
+
+Pin the six-step branching pattern at the source level so the per-commit
+gate runs offline: PBSSyncJob inherits from ``JobRunner``, declares
+``Meta.name = "PBS Sync"``, calls ``branching_enabled_settings``,
+creates+merges a branch when enabled, and threads
+``netbox_branch_schema_id`` into the params dict shared with the HTTP
+stage runner.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PKG_DIR = REPO_ROOT / "netbox_pbs"
+JOBS = PKG_DIR / "jobs.py"
+HTTP_CLIENT = PKG_DIR / "services" / "http_client.py"
+
+
+def _module(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _find_class(module: ast.Module, name: str) -> ast.ClassDef | None:
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    return None
+
+
+def _find_method(cls: ast.ClassDef, name: str) -> ast.FunctionDef | None:
+    for node in cls.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def test_jobs_module_exists():
+    assert JOBS.is_file(), f"missing {JOBS.relative_to(REPO_ROOT)}"
+
+
+def test_pbs_sync_job_inherits_from_job_runner():
+    module = _module(JOBS)
+    cls = _find_class(module, "PBSSyncJob")
+    assert cls is not None, "missing PBSSyncJob"
+    base_names = [base.id if isinstance(base, ast.Name) else None for base in cls.bases]
+    assert "JobRunner" in base_names, (
+        f"PBSSyncJob must inherit from JobRunner; got {base_names}"
+    )
+
+
+def test_pbs_sync_job_meta_name():
+    text = JOBS.read_text(encoding="utf-8")
+    assert 'name = "PBS Sync"' in text, 'PBSSyncJob.Meta must declare name = "PBS Sync"'
+
+
+def test_pbs_sync_job_run_reads_branching_enabled_settings():
+    text = JOBS.read_text(encoding="utf-8")
+    assert "branching_enabled_settings" in text, (
+        "PBSSyncJob.run() must read branching_enabled_settings"
+    )
+    assert "create_and_provision_branch" in text, (
+        "PBSSyncJob.run() must call create_and_provision_branch when enabled"
+    )
+    assert "merge_branch" in text, "PBSSyncJob.run() must call merge_branch on success"
+
+
+def test_pbs_sync_job_threads_netbox_branch_schema_id():
+    """The schema_id must be threaded into the params dict shared with stages."""
+    text = JOBS.read_text(encoding="utf-8")
+    assert '"netbox_branch_schema_id"' in text, (
+        "PBSSyncJob.run() must populate params['netbox_branch_schema_id']"
+    )
+    assert "branch.schema_id" in text, (
+        "PBSSyncJob.run() must read branch.schema_id when a branch is active"
+    )
+
+
+def test_pbs_sync_job_imports_run_pbs_sync_stage():
+    text = JOBS.read_text(encoding="utf-8")
+    assert "from netbox_pbs.services.http_client import" in text, (
+        "PBSSyncJob must import its HTTP transport from netbox_pbs.services.http_client"
+    )
+    assert "run_pbs_sync_stage" in text, (
+        "PBSSyncJob.run() must call run_pbs_sync_stage for each stage"
+    )
+
+
+def test_pbs_sync_job_enqueue_sets_long_timeout():
+    text = JOBS.read_text(encoding="utf-8")
+    assert "PBS_SYNC_JOB_TIMEOUT" in text, (
+        "PBSSyncJob.enqueue must default to a long RQ job_timeout"
+    )
+    assert 'kwargs.setdefault("job_timeout", PBS_SYNC_JOB_TIMEOUT)' in text, (
+        "PBSSyncJob.enqueue must apply PBS_SYNC_JOB_TIMEOUT via setdefault"
+    )
+
+
+def test_pbs_sync_job_queue_is_rq_queue_default():
+    """Stock ``manage.py rqworker`` must pick up PBS jobs."""
+    text = JOBS.read_text(encoding="utf-8")
+    assert "PBS_SYNC_QUEUE_NAME = RQ_QUEUE_DEFAULT" in text, (
+        "PBSSyncJob must enqueue on NetBox's default RQ queue"
+    )
+
+
+def test_http_client_defines_pbs_stages_full():
+    text = HTTP_CLIENT.read_text(encoding="utf-8")
+    assert "PBS_STAGES_FULL" in text, "http_client must expose PBS_STAGES_FULL"
+    for stage in ("datastores", "snapshots", "jobs", "node"):
+        assert f'"{stage}"' in text, f"http_client must declare the {stage!r} stage"
+
+
+def test_run_pbs_sync_stage_threads_schema_id_into_query():
+    """The HTTP transport must include netbox_branch_schema_id in the query string."""
+    text = HTTP_CLIENT.read_text(encoding="utf-8")
+    assert '"netbox_branch_schema_id"' in text, (
+        "run_pbs_sync_stage must thread netbox_branch_schema_id into the query string"
+    )
+
+
+def test_run_pbs_sync_stage_uses_sse_accept_header():
+    text = HTTP_CLIENT.read_text(encoding="utf-8")
+    assert '"Accept": "text/event-stream"' in text, (
+        "run_pbs_sync_stage must announce SSE via the Accept header"
+    )

--- a/netbox_pbs/tests/test_plugin_boots.py
+++ b/netbox_pbs/tests/test_plugin_boots.py
@@ -19,7 +19,7 @@ URLS_PATH = REPO_ROOT / "netbox_pbs" / "urls.py"
 NAVIGATION_PATH = REPO_ROOT / "netbox_pbs" / "navigation.py"
 MIGRATION_PATH = REPO_ROOT / "netbox_pbs" / "migrations" / "0001_initial.py"
 
-EXPECTED_VERSION = "0.0.15"
+EXPECTED_VERSION = "0.0.1"
 EXPECTED_MIN_NETBOX = "4.5.8"
 EXPECTED_MAX_NETBOX = "4.6.99"
 

--- a/netbox_pbs/tests/test_plugin_boots.py
+++ b/netbox_pbs/tests/test_plugin_boots.py
@@ -1,0 +1,109 @@
+"""AST-based smoke tests for the netbox-pbs plugin scaffold.
+
+These tests parse source files with ``ast`` instead of bootstrapping Django,
+mirroring the pattern used by ``netbox_proxbox/tests/test_version.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+INIT_PATH = REPO_ROOT / "netbox_pbs" / "__init__.py"
+MODELS_PATH = REPO_ROOT / "netbox_pbs" / "models" / "plugin_settings.py"
+URLS_PATH = REPO_ROOT / "netbox_pbs" / "urls.py"
+NAVIGATION_PATH = REPO_ROOT / "netbox_pbs" / "navigation.py"
+MIGRATION_PATH = REPO_ROOT / "netbox_pbs" / "migrations" / "0001_initial.py"
+
+EXPECTED_VERSION = "0.0.15"
+EXPECTED_MIN_NETBOX = "4.5.8"
+EXPECTED_MAX_NETBOX = "4.6.99"
+
+
+def _class_constants(path: Path, class_name: str) -> dict[str, object]:
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            constants: dict[str, object] = {}
+            for stmt in node.body:
+                if isinstance(stmt, ast.Assign) and isinstance(
+                    stmt.value, ast.Constant
+                ):
+                    for target in stmt.targets:
+                        if isinstance(target, ast.Name):
+                            constants[target.id] = stmt.value.value
+            return constants
+    raise AssertionError(f"class {class_name} not found in {path}")
+
+
+def test_pyproject_declares_separate_wheel():
+    data = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    assert data["project"]["name"] == "netbox-pbs"
+    assert data["project"]["version"] == EXPECTED_VERSION
+    packages = data["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+    assert packages == ["netbox_pbs"], (
+        "wheel must only ship netbox_pbs, not netbox_proxbox"
+    )
+
+
+def test_pyproject_does_not_depend_on_netbox_proxbox():
+    data = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    deps = list(data["project"].get("dependencies", []))
+    normalized = [d.lower().replace("_", "-") for d in deps]
+    assert not any(d.startswith("netbox-proxbox") for d in normalized), (
+        "netbox-pbs must boot standalone — netbox-proxbox is only a soft "
+        "(optional) cross-link"
+    )
+
+
+def test_pluginconfig_pins_metadata():
+    constants = _class_constants(INIT_PATH, "PBSConfig")
+    assert constants["name"] == "netbox_pbs"
+    assert constants["version"] == EXPECTED_VERSION
+    assert constants["base_url"] == "pbs"
+    assert constants["min_version"] == EXPECTED_MIN_NETBOX
+    assert constants["max_version"] == EXPECTED_MAX_NETBOX
+
+
+def test_plugin_settings_singleton_shape():
+    text = MODELS_PATH.read_text(encoding="utf-8")
+    assert "class PBSPluginSettings" in text
+    assert "singleton_key" in text
+    assert "get_solo" in text
+    assert "branching_enabled" in text
+    assert "branch_name_prefix" in text
+    assert "branch_on_conflict" in text
+
+
+def test_urls_register_home_route():
+    text = URLS_PATH.read_text(encoding="utf-8")
+    assert 'app_name = "netbox_pbs"' in text
+    assert 'name="home"' in text
+
+
+def test_navigation_exposes_top_level_menu():
+    text = NAVIGATION_PATH.read_text(encoding="utf-8")
+    assert "PluginMenu(" in text
+    assert 'label="Proxmox Backup Server"' in text
+
+
+def test_initial_migration_creates_plugin_settings_only():
+    text = MIGRATION_PATH.read_text(encoding="utf-8")
+    assert "initial = True" in text
+    assert 'name="PBSPluginSettings"' in text
+    # PR C1 must not yet create the domain models — they land in PR C2.
+    for forbidden in (
+        '"PBSEndpoint"',
+        '"PBSNode"',
+        '"PBSDatastore"',
+        '"PBSBackupGroup"',
+        '"PBSSnapshot"',
+        '"PBSJobStatus"',
+    ):
+        assert forbidden not in text, (
+            f"PR C1 scaffold migration must not yet declare {forbidden}"
+        )

--- a/netbox_pbs/tests/test_plugin_boots.py
+++ b/netbox_pbs/tests/test_plugin_boots.py
@@ -50,14 +50,48 @@ def test_pyproject_declares_separate_wheel():
     )
 
 
-def test_pyproject_does_not_depend_on_netbox_proxbox():
+def test_pyproject_pins_netbox_proxbox_floor():
+    """Per the 2026-05-13 pivot, netbox-proxbox is a hard runtime dependency.
+
+    netbox_pbs declares ``required_plugins = ["netbox_proxbox"]`` on
+    ``PBSConfig`` and reuses ``netbox_proxbox.NetBoxEndpoint``,
+    ``netbox_proxbox.FastAPIEndpoint``, and
+    ``netbox_proxbox.services.branch_lifecycle`` directly. The pyproject
+    pin guarantees pip resolves a compatible release at install time.
+    """
     data = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
     deps = list(data["project"].get("dependencies", []))
     normalized = [d.lower().replace("_", "-") for d in deps]
-    assert not any(d.startswith("netbox-proxbox") for d in normalized), (
-        "netbox-pbs must boot standalone — netbox-proxbox is only a soft "
-        "(optional) cross-link"
+    assert any(d.startswith("netbox-proxbox") for d in normalized), (
+        "netbox-pbs requires netbox-proxbox as a hard dependency "
+        "(see PBSConfig.required_plugins)"
     )
+
+
+def test_pluginconfig_declares_required_plugins():
+    """``PBSConfig.required_plugins`` must include ``netbox_proxbox``."""
+    module = ast.parse(INIT_PATH.read_text(encoding="utf-8"))
+    for node in ast.walk(module):
+        if isinstance(node, ast.ClassDef) and node.name == "PBSConfig":
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.Assign)
+                    and len(stmt.targets) == 1
+                    and isinstance(stmt.targets[0], ast.Name)
+                    and stmt.targets[0].id == "required_plugins"
+                    and isinstance(stmt.value, ast.List)
+                ):
+                    values = [
+                        elt.value
+                        for elt in stmt.value.elts
+                        if isinstance(elt, ast.Constant)
+                    ]
+                    assert "netbox_proxbox" in values, values
+                    return
+            raise AssertionError(
+                "PBSConfig.required_plugins must list 'netbox_proxbox'"
+            )
+    raise AssertionError("PBSConfig class not found")
 
 
 def test_pluginconfig_pins_metadata():

--- a/netbox_pbs/tests/test_template_content.py
+++ b/netbox_pbs/tests/test_template_content.py
@@ -1,0 +1,150 @@
+"""AST tests for the cross-plugin ``template_content`` cross-link.
+
+The cross-link panel (issue #325, sub-PR C4) is presentation-only: the
+panel lists rows that match a natural key (vmid + creation_time)
+between :class:`netbox_proxbox.models.VMBackup` and
+:class:`netbox_pbs.models.PBSSnapshot`. No FK, no schema change, no
+signal-backed backfill.
+
+These tests pin:
+
+* ``template_extensions`` is gated by ``apps.is_installed("netbox_proxbox")``
+  so the plugin is safe to install standalone.
+* Both extension classes target the correct host model and define
+  ``right_page``.
+* The two panel templates exist.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_CONTENT_PATH = REPO_ROOT / "netbox_pbs" / "template_content.py"
+PANEL_DIR = REPO_ROOT / "netbox_pbs" / "templates" / "netbox_pbs" / "inc"
+VMBACKUP_PANEL = PANEL_DIR / "vmbackup_pbs_snapshots_panel.html"
+PBSSNAPSHOT_PANEL = PANEL_DIR / "pbssnapshot_vm_backups_panel.html"
+
+
+def _module() -> ast.Module:
+    return ast.parse(TEMPLATE_CONTENT_PATH.read_text(encoding="utf-8"))
+
+
+def _classdef(name: str) -> ast.ClassDef:
+    for node in ast.walk(_module()):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name!r} not found in template_content.py")
+
+
+def _models_assignment(cls: ast.ClassDef) -> list[str]:
+    for stmt in cls.body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == "models"
+            and isinstance(stmt.value, ast.List)
+        ):
+            return [
+                elt.value
+                for elt in stmt.value.elts
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+            ]
+    raise AssertionError(f"class {cls.name!r} has no ``models = [...]`` literal")
+
+
+def _method_names(cls: ast.ClassDef) -> set[str]:
+    return {
+        stmt.name
+        for stmt in cls.body
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def test_template_content_module_exists() -> None:
+    assert TEMPLATE_CONTENT_PATH.is_file(), TEMPLATE_CONTENT_PATH
+
+
+def test_vmbackup_extension_targets_vmbackup() -> None:
+    cls = _classdef("VMBackupPBSSnapshotExtension")
+    assert _models_assignment(cls) == ["netbox_proxbox.vmbackup"]
+    assert "right_page" in _method_names(cls)
+
+
+def test_pbssnapshot_extension_targets_pbssnapshot() -> None:
+    cls = _classdef("PBSSnapshotVMBackupExtension")
+    assert _models_assignment(cls) == ["netbox_pbs.pbssnapshot"]
+    assert "right_page" in _method_names(cls)
+
+
+def test_template_extensions_gated_on_netbox_proxbox_installed() -> None:
+    """``template_extensions`` must be populated only when proxbox is installed.
+
+    The guard pattern keeps standalone installs clean: without proxbox,
+    NetBox sees an empty list and registers no cross-plugin hooks.
+    """
+    module = _module()
+    # Find the top-level ``if apps.is_installed("netbox_proxbox"):`` block
+    guard = None
+    for stmt in module.body:
+        if isinstance(stmt, ast.If):
+            test = stmt.test
+            if (
+                isinstance(test, ast.Call)
+                and isinstance(test.func, ast.Attribute)
+                and test.func.attr == "is_installed"
+                and isinstance(test.func.value, ast.Name)
+                and test.func.value.id == "apps"
+                and len(test.args) == 1
+                and isinstance(test.args[0], ast.Constant)
+                and test.args[0].value == "netbox_proxbox"
+            ):
+                guard = stmt
+                break
+    assert guard is not None, (
+        "expected top-level guard "
+        "`if apps.is_installed('netbox_proxbox'): template_extensions = [...]`"
+    )
+
+    # Inside the guard body, template_extensions must be assigned a non-empty list
+    # containing both extension classes.
+    populated = False
+    for stmt in guard.body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and stmt.targets[0].id == "template_extensions"
+            and isinstance(stmt.value, ast.List)
+        ):
+            names = {
+                elt.id for elt in stmt.value.elts if isinstance(elt, ast.Name)
+            }
+            assert {
+                "VMBackupPBSSnapshotExtension",
+                "PBSSnapshotVMBackupExtension",
+            } <= names, names
+            populated = True
+            break
+    assert populated, "guard body must assign template_extensions = [...]"
+
+    # Else-branch must assign an empty list (explicit fallback).
+    assert guard.orelse, "expected explicit `else: template_extensions = []` branch"
+
+
+def test_panel_templates_exist() -> None:
+    assert VMBACKUP_PANEL.is_file(), VMBACKUP_PANEL
+    assert PBSSNAPSHOT_PANEL.is_file(), PBSSNAPSHOT_PANEL
+
+
+def test_matcher_helpers_exist() -> None:
+    """Both natural-key matchers must exist as module-level functions."""
+    names = {
+        node.name
+        for node in ast.walk(_module())
+        if isinstance(node, ast.FunctionDef)
+    }
+    assert {"_match_pbs_snapshots", "_match_vm_backups"} <= names, names

--- a/netbox_pbs/tests/test_template_content.py
+++ b/netbox_pbs/tests/test_template_content.py
@@ -8,8 +8,10 @@ signal-backed backfill.
 
 These tests pin:
 
-* ``template_extensions`` is gated by ``apps.is_installed("netbox_proxbox")``
-  so the plugin is safe to install standalone.
+* ``template_extensions`` is an unconditional module-level list. Per the
+  2026-05-13 pivot, ``netbox_proxbox`` is declared in
+  ``PBSConfig.required_plugins``, so the cross-link is always live and the
+  old ``apps.is_installed("netbox_proxbox")`` guard is gone.
 * Both extension classes target the correct host model and define
   ``right_page``.
 * The two panel templates exist.
@@ -80,39 +82,18 @@ def test_pbssnapshot_extension_targets_pbssnapshot() -> None:
     assert "right_page" in _method_names(cls)
 
 
-def test_template_extensions_gated_on_netbox_proxbox_installed() -> None:
-    """``template_extensions`` must be populated only when proxbox is installed.
+def test_template_extensions_is_unconditional_list() -> None:
+    """``template_extensions`` must be an unconditional module-level list.
 
-    The guard pattern keeps standalone installs clean: without proxbox,
-    NetBox sees an empty list and registers no cross-plugin hooks.
+    Per the 2026-05-13 pivot, ``netbox_proxbox`` is a hard dependency
+    declared in ``PBSConfig.required_plugins`` — NetBox refuses to load
+    ``netbox_pbs`` without it — so the old
+    ``if apps.is_installed("netbox_proxbox"): template_extensions = [...]``
+    guard is gone.
     """
     module = _module()
-    # Find the top-level ``if apps.is_installed("netbox_proxbox"):`` block
-    guard = None
+    found = False
     for stmt in module.body:
-        if isinstance(stmt, ast.If):
-            test = stmt.test
-            if (
-                isinstance(test, ast.Call)
-                and isinstance(test.func, ast.Attribute)
-                and test.func.attr == "is_installed"
-                and isinstance(test.func.value, ast.Name)
-                and test.func.value.id == "apps"
-                and len(test.args) == 1
-                and isinstance(test.args[0], ast.Constant)
-                and test.args[0].value == "netbox_proxbox"
-            ):
-                guard = stmt
-                break
-    assert guard is not None, (
-        "expected top-level guard "
-        "`if apps.is_installed('netbox_proxbox'): template_extensions = [...]`"
-    )
-
-    # Inside the guard body, template_extensions must be assigned a non-empty list
-    # containing both extension classes.
-    populated = False
-    for stmt in guard.body:
         if (
             isinstance(stmt, ast.Assign)
             and len(stmt.targets) == 1
@@ -127,12 +108,24 @@ def test_template_extensions_gated_on_netbox_proxbox_installed() -> None:
                 "VMBackupPBSSnapshotExtension",
                 "PBSSnapshotVMBackupExtension",
             } <= names, names
-            populated = True
+            found = True
             break
-    assert populated, "guard body must assign template_extensions = [...]"
+    assert found, "expected module-level `template_extensions = [...]` assignment"
 
-    # Else-branch must assign an empty list (explicit fallback).
-    assert guard.orelse, "expected explicit `else: template_extensions = []` branch"
+    # And the old guard must NOT be present.
+    for stmt in module.body:
+        if isinstance(stmt, ast.If):
+            test = stmt.test
+            if (
+                isinstance(test, ast.Call)
+                and isinstance(test.func, ast.Attribute)
+                and test.func.attr == "is_installed"
+            ):
+                raise AssertionError(
+                    "Stale `apps.is_installed(...)` guard found in "
+                    "template_content.py — pivot requires unconditional "
+                    "registration."
+                )
 
 
 def test_panel_templates_exist() -> None:

--- a/netbox_pbs/tests/test_views_and_urls.py
+++ b/netbox_pbs/tests/test_views_and_urls.py
@@ -144,7 +144,7 @@ def test_navigation_only_endpoint_has_add_or_import_buttons():
     # Only PBSEndpoint should expose add/import buttons; read-only models
     # must not surface them.
     assert "pbsendpoint_add" in text
-    assert "pbsendpoint_import" in text
+    assert "pbsendpoint_bulk_import" in text
     for model_url in (
         "pbsnode_add",
         "pbsdatastore_add",

--- a/netbox_pbs/tests/test_views_and_urls.py
+++ b/netbox_pbs/tests/test_views_and_urls.py
@@ -1,0 +1,193 @@
+"""AST-based contract tests for the PR C2b PBS UI surface.
+
+These tests pin the read-only enforcement contract: PBSEndpoint is the
+only model that registers ``edit``, ``delete``, ``bulk_edit``,
+``bulk_delete``, and ``bulk_import`` views. The other five PBS models
+(reflected from PBS by the read-only sync) intentionally register only
+``list`` and detail views. Templates and navigation never render
+edit/delete buttons for them because those URLs don't exist.
+
+We use AST rather than Django bootstrap so the contract is verifiable
+in the per-commit gate without a running NetBox.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PKG_DIR = REPO_ROOT / "netbox_pbs"
+VIEWS = PKG_DIR / "views.py"
+URLS = PKG_DIR / "urls.py"
+NAVIGATION = PKG_DIR / "navigation.py"
+TABLES = PKG_DIR / "tables.py"
+FILTERSETS = PKG_DIR / "filtersets.py"
+FORMS = PKG_DIR / "forms.py"
+
+
+WRITE_ACTIONS = ("edit", "delete", "bulk_edit", "bulk_delete", "bulk_import")
+READ_ONLY_MODELS = (
+    "PBSNode",
+    "PBSDatastore",
+    "PBSBackupGroup",
+    "PBSSnapshot",
+    "PBSJobStatus",
+)
+ALL_MODELS = ("PBSEndpoint", *READ_ONLY_MODELS)
+
+
+def _collect_register_model_view_calls(path: Path) -> list[tuple[str, str | None]]:
+    """Return ``(model_name, action)`` pairs for every register_model_view().
+
+    ``action`` is ``None`` for the bare ``@register_model_view(Model)``
+    detail-view registration; otherwise it is the action string literal
+    passed as the second positional argument.
+    """
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    pairs: list[tuple[str, str | None]] = []
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "register_model_view":
+            pass
+        elif isinstance(func, ast.Attribute) and func.attr == "register_model_view":
+            pass
+        else:
+            continue
+        if not node.args:
+            continue
+        first = node.args[0]
+        if not isinstance(first, ast.Name):
+            continue
+        action: str | None = None
+        if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+            action = node.args[1].value
+        pairs.append((first.id, action))
+    return pairs
+
+
+def test_pbs_endpoint_registers_full_crud():
+    pairs = _collect_register_model_view_calls(VIEWS)
+    actions_for_endpoint = {action for model, action in pairs if model == "PBSEndpoint"}
+    # bare detail view (action=None) plus list + every write action
+    assert None in actions_for_endpoint, "missing detail view for PBSEndpoint"
+    assert "list" in actions_for_endpoint, "missing list view for PBSEndpoint"
+    for action in WRITE_ACTIONS:
+        assert action in actions_for_endpoint, (
+            f"PBSEndpoint must register {action} view"
+        )
+
+
+def test_reflected_models_register_only_list_and_detail():
+    pairs = _collect_register_model_view_calls(VIEWS)
+    for model in READ_ONLY_MODELS:
+        actions = {action for m, action in pairs if m == model}
+        assert actions == {None, "list"}, (
+            f"{model} must register only list + detail; got {sorted(str(a) for a in actions)}"
+        )
+
+
+def test_reflected_model_list_views_use_export_only_actions():
+    """ObjectListView for read-only models must expose only the export action."""
+    text = VIEWS.read_text(encoding="utf-8")
+    # The shared constant pins the contract; an explicit per-model dict would
+    # be a regression. Assert the constant exists with the expected value and
+    # that each read-only list view binds to it.
+    assert '_READ_ONLY_ACTIONS = {"export": {"view"}}' in text
+    for model in READ_ONLY_MODELS:
+        # Each read-only list class should reference _READ_ONLY_ACTIONS.
+        list_class = f"{model}ListView"
+        assert list_class in text, f"missing {list_class}"
+    # And no read-only-model list view should opt into add/edit/delete actions.
+    for model in READ_ONLY_MODELS:
+        list_class_marker = f"class {model}ListView"
+        section_start = text.index(list_class_marker)
+        section_end = (
+            text.index("class ", section_start + 1)
+            if "class " in text[section_start + 1 :]
+            else len(text)
+        )
+        section = text[section_start:section_end]
+        for forbidden in ('"add"', '"bulk_edit"', '"bulk_delete"', '"bulk_import"'):
+            assert forbidden not in section, (
+                f"{list_class_marker} must not register {forbidden} action"
+            )
+
+
+def test_urls_module_imports_views_for_decorator_side_effects():
+    text = URLS.read_text(encoding="utf-8")
+    assert "from netbox_pbs import views" in text, (
+        "urls.py must import the views module so register_model_view "
+        "decorators fire and per-model URLs land in the namespace"
+    )
+
+
+def test_navigation_has_menu_item_per_model():
+    text = NAVIGATION.read_text(encoding="utf-8")
+    expected_targets = {
+        "PBSEndpoint": "plugins:netbox_pbs:pbsendpoint_list",
+        "PBSNode": "plugins:netbox_pbs:pbsnode_list",
+        "PBSDatastore": "plugins:netbox_pbs:pbsdatastore_list",
+        "PBSBackupGroup": "plugins:netbox_pbs:pbsbackupgroup_list",
+        "PBSSnapshot": "plugins:netbox_pbs:pbssnapshot_list",
+        "PBSJobStatus": "plugins:netbox_pbs:pbsjobstatus_list",
+    }
+    for model, link in expected_targets.items():
+        assert link in text, f"navigation missing link for {model}"
+
+
+def test_navigation_only_endpoint_has_add_or_import_buttons():
+    text = NAVIGATION.read_text(encoding="utf-8")
+    # Only PBSEndpoint should expose add/import buttons; read-only models
+    # must not surface them.
+    assert "pbsendpoint_add" in text
+    assert "pbsendpoint_import" in text
+    for model_url in (
+        "pbsnode_add",
+        "pbsdatastore_add",
+        "pbsbackupgroup_add",
+        "pbssnapshot_add",
+        "pbsjobstatus_add",
+        "pbsnode_import",
+        "pbsdatastore_import",
+        "pbsbackupgroup_import",
+        "pbssnapshot_import",
+        "pbsjobstatus_import",
+    ):
+        assert model_url not in text, (
+            f"navigation must not expose {model_url} for read-only model"
+        )
+
+
+def test_tables_module_defines_one_table_per_model():
+    text = TABLES.read_text(encoding="utf-8")
+    for model in ALL_MODELS:
+        assert f"class {model}Table" in text, f"missing {model}Table"
+
+
+def test_filtersets_module_defines_one_filterset_per_model():
+    text = FILTERSETS.read_text(encoding="utf-8")
+    for model in ALL_MODELS:
+        assert f"class {model}FilterSet" in text, f"missing {model}FilterSet"
+
+
+def test_forms_module_only_pbsendpoint_has_writable_forms():
+    text = FORMS.read_text(encoding="utf-8")
+    # PBSEndpoint is the only model with a ModelForm/BulkEdit/Import form.
+    assert "class PBSEndpointForm(" in text
+    assert "class PBSEndpointBulkEditForm(" in text
+    assert "class PBSEndpointImportForm(" in text
+    # Filter forms exist for all six models.
+    for model in ALL_MODELS:
+        assert f"class {model}FilterForm" in text, f"missing {model}FilterForm"
+    # Reflected models must NOT have writable forms — confirm by absence of
+    # the corresponding bulk-edit / import class names.
+    for model in READ_ONLY_MODELS:
+        assert f"class {model}Form(" not in text, (
+            f"read-only {model} must not have a NetBoxModelForm"
+        )
+        assert f"class {model}BulkEditForm" not in text
+        assert f"class {model}ImportForm" not in text

--- a/netbox_proxbox/templates/netbox_proxbox/home.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home.html
@@ -145,6 +145,31 @@
             </div>
             <hr>
         {% endif %}
+
+        {% if pbs_installed %}
+            {% if pbs_endpoint_list and pbs_endpoint_list|length > 0 %}
+                {% for object in pbs_endpoint_list %}
+                    {% if pbs_endpoint_list|length == 1 %}
+                        <div class="col">
+                    {% elif pbs_endpoint_list|length == 2 %}
+                        <div class="col col-md-6">
+                    {% else %}
+                        <div class="col col-md-4">
+                    {% endif %}
+                            {% include "netbox_proxbox/home/pbs_card.html" %}
+                        </div>
+                {% endfor %}
+            {% else %}
+                <div class="d-flex flex-column align-items-center" style="margin-bottom: 15px;">
+                    <div><h2>There are no PBS Endpoints configured.</h2></div>
+                    <div class="d-flex flex-wrap justify-content-center gap-2">
+                        <a href="{{ pbs_endpoint_add_url }}" class="btn btn-primary">Create new PBS Endpoint</a>
+                        <a href="{{ pbs_endpoint_bulk_import_url }}" class="btn btn-outline-primary"><i class="mdi mdi-upload" aria-hidden="true"></i> Import from CSV</a>
+                    </div>
+                </div>
+                <hr>
+            {% endif %}
+        {% endif %}
     </div>
 
     <div class="text-center mt-4 mb-2">

--- a/netbox_proxbox/templates/netbox_proxbox/home/pbs_card.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home/pbs_card.html
@@ -1,0 +1,69 @@
+<div class="card" data-pbs-card-id="{{ object.pk }}">
+    <h2 class="card-header">Proxmox Backup Server</h2>
+
+    <div class="d-flex flex-row justify-content-center align-items-center p-2 mt-1">
+        <div class="d-flex mx-auto position-absolute">
+            <a href="{{ object.get_absolute_url }}">
+                <strong>{{ object.name }}</strong>
+            </a>
+        </div>
+        <div class="d-flex ms-auto" style="margin: 0 40px 0 0">
+            <span class="badge text-bg-secondary p-1">Configured</span>
+        </div>
+    </div>
+
+    <div class="card-body">
+        <table class="table table-hover attr-table">
+            <tr>
+                <th scope="row"><strong>PBS Endpoint Name</strong></th>
+                <td>
+                    {% if object.name %}
+                        <a href="{{ object.get_absolute_url }}">{{ object.name }}</a>
+                    {% else %}
+                        <span class="badge text-bg-grey">Empty</span>
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><strong>Host</strong></th>
+                <td>{{ object.host|default:"Not configured" }}</td>
+            </tr>
+            <tr>
+                <th scope="row"><strong>HTTP Port</strong></th>
+                <td>{{ object.port }}</td>
+            </tr>
+            <tr>
+                <th scope="row"><strong>Token ID</strong></th>
+                <td>{{ object.token_id|default:"Not configured" }}</td>
+            </tr>
+            <tr>
+                <th scope="row"><strong>Token Secret</strong></th>
+                <td>{% if object.token_secret %}Configured{% else %}Not configured{% endif %}</td>
+            </tr>
+            <tr>
+                <th scope="row"><strong>Fingerprint</strong></th>
+                <td>
+                    {% if object.fingerprint %}
+                        <code>{{ object.fingerprint|truncatechars:24 }}</code>
+                    {% else %}
+                        <span class="badge text-bg-grey">None</span>
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><strong>SSL</strong></th>
+                <td>
+                    {% if object.verify_ssl %}
+                        <span class="text-success"><i class="mdi mdi-check-bold"></i></span>
+                    {% else %}
+                        <span class="text-danger"><i class="mdi mdi-close-thick"></i></span>
+                    {% endif %}
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><strong>Sync Direction</strong></th>
+                <td><span class="badge text-bg-info">PBS → NetBox (read-only)</span></td>
+            </tr>
+        </table>
+    </div>
+</div>

--- a/netbox_proxbox/views/home_context.py
+++ b/netbox_proxbox/views/home_context.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from importlib import util as importlib_util
 from urllib.parse import urlencode
 
 from core.choices import JobStatusChoices
 from core.models import Job
 from django.http import HttpRequest
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 
 from netbox_proxbox import ProxboxConfig
 from netbox_proxbox.choices import NetBoxTokenVersionChoices
@@ -21,7 +22,24 @@ from netbox_proxbox.schedule_hints import (
 from netbox_proxbox.utils import get_fastapi_url
 from netbox_proxbox.views.proxbox_access import permission_enqueue_proxbox_sync
 
-__all__ = ("build_home_dashboard_context",)
+__all__ = ("build_home_dashboard_context", "pbs_integration_available")
+
+
+def pbs_integration_available() -> bool:
+    """Return ``True`` when the sibling ``netbox_pbs`` plugin is importable and
+    its REST surface is mounted.
+
+    Two gates: package importability (``find_spec``) plus REST URL resolution
+    (``pbsendpoint-list``). Both must hold; otherwise the home page must not
+    surface PBS markup.
+    """
+    if importlib_util.find_spec("netbox_pbs") is None:
+        return False
+    try:
+        reverse("plugins:netbox_pbs-api:pbsendpoint-list")
+    except NoReverseMatch:
+        return False
+    return True
 
 
 def _build_add_url(view_name: str, params: dict[str, object]) -> str:
@@ -96,6 +114,26 @@ def build_home_dashboard_context(
 
     active_proxbox_job = _get_latest_active_proxbox_job(request)
 
+    pbs_installed = pbs_integration_available()
+    pbs_endpoint_list = None
+    pbs_endpoint_add_url: str | None = None
+    pbs_endpoint_bulk_import_url: str | None = None
+    if pbs_installed:
+        try:
+            from netbox_pbs.models import PBSEndpoint  # noqa: PLC0415 — gated import
+
+            pbs_qs = PBSEndpoint.objects.restrict(request.user, "view")
+            pbs_endpoint_list = pbs_qs if pbs_qs.exists() else None
+            pbs_endpoint_add_url = reverse("plugins:netbox_pbs:pbsendpoint_add")
+            pbs_endpoint_bulk_import_url = reverse(
+                "plugins:netbox_pbs:pbsendpoint_bulk_import"
+            )
+        except (ImportError, NoReverseMatch):
+            pbs_installed = False
+            pbs_endpoint_list = None
+            pbs_endpoint_add_url = None
+            pbs_endpoint_bulk_import_url = None
+
     return {
         "default_config": default_config,
         "proxmox_endpoint_list": proxmox_endpoint_obj
@@ -117,4 +155,8 @@ def build_home_dashboard_context(
         "can_quick_schedule_sync": can_quick_schedule_sync,
         "quick_schedule_form": quick_schedule_form,
         "active_proxbox_job": active_proxbox_job,
+        "pbs_installed": pbs_installed,
+        "pbs_endpoint_list": pbs_endpoint_list,
+        "pbs_endpoint_add_url": pbs_endpoint_add_url,
+        "pbs_endpoint_bulk_import_url": pbs_endpoint_bulk_import_url,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,11 @@ def load_plugin_module(
     django_urls = types.ModuleType("django.urls")
     django_urls.reverse = lambda *args, **kwargs: "/dummy/"
 
+    class NoReverseMatch(Exception):
+        pass
+
+    django_urls.NoReverseMatch = NoReverseMatch
+
     django_contrib = types.ModuleType("django.contrib")
     django_messages = MessagesStub()
     django_contrib.messages = django_messages

--- a/tests/test_home_pbs_section.py
+++ b/tests/test_home_pbs_section.py
@@ -1,0 +1,77 @@
+"""Tests for the PBS endpoint section on the Proxbox home page."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tests.conftest import load_plugin_module
+
+
+class _JobQuerySet(list):
+    def restrict(self, *args, **kwargs):
+        return self
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *fields):
+        return _JobQuerySet(self)
+
+    def iterator(self, chunk_size=64):
+        return iter(self)
+
+
+def _request():
+    return SimpleNamespace(
+        user=SimpleNamespace(has_perm=lambda *args, **kwargs: True),
+    )
+
+
+def test_pbs_section_hidden_when_plugin_not_installed(monkeypatch):
+    module = load_plugin_module(
+        "netbox_proxbox.views.home_context", monkeypatch=monkeypatch
+    )
+
+    monkeypatch.setattr(
+        module.Job, "objects", _JobQuerySet([]), raising=False
+    )
+    monkeypatch.setattr(
+        module.importlib_util, "find_spec", lambda name: None
+    )
+
+    context = module.build_home_dashboard_context(_request())
+
+    assert context["pbs_installed"] is False
+    assert context["pbs_endpoint_list"] is None
+    assert context["pbs_endpoint_add_url"] is None
+    assert context["pbs_endpoint_bulk_import_url"] is None
+
+
+def test_pbs_section_hidden_when_rest_surface_missing(monkeypatch):
+    module = load_plugin_module(
+        "netbox_proxbox.views.home_context", monkeypatch=monkeypatch
+    )
+
+    monkeypatch.setattr(
+        module.Job, "objects", _JobQuerySet([]), raising=False
+    )
+
+    monkeypatch.setattr(
+        module.importlib_util,
+        "find_spec",
+        lambda name: SimpleNamespace() if name == "netbox_pbs" else None,
+    )
+
+    def _reverse(name, *args, **kwargs):
+        if name.startswith("plugins:netbox_pbs"):
+            raise module.NoReverseMatch(name)
+        return "/dummy/"
+
+    monkeypatch.setattr(module, "reverse", _reverse)
+
+    context = module.build_home_dashboard_context(_request())
+
+    assert context["pbs_installed"] is False
+    assert context["pbs_endpoint_list"] is None
+    assert context["pbs_endpoint_add_url"] is None
+    assert context["pbs_endpoint_bulk_import_url"] is None


### PR DESCRIPTION
## Summary

First slice of the PBS (Proxmox Backup Server) integration tracked in #325. Adds a **separate `netbox-pbs` wheel** alongside `netbox-proxbox` so the new plugin can boot, register its URL namespace, and render a navigation entry — without yet introducing the PBS domain models or sync paths.

This PR is intentionally minimal. Domain models, branch lifecycle, cross-link FK, and CI/Docker matrix land in follow-up sub-PRs (C2 → C5).

### In this PR (C1 — scaffold only)
- `netbox_pbs/pyproject.toml` — separate Hatch-built wheel `netbox-pbs==0.0.15`, `requires-python>=3.12`, deps `pydantic==2.13.3` + `requests>=2.33.0`. Optional `proxbox` extra (`netbox-proxbox>=0.0.15`). Wheel ships only `netbox_pbs`.
- `netbox_pbs/netbox_pbs/__init__.py` — `PBSConfig(PluginConfig)`: `name=netbox_pbs`, `version=0.0.15`, `base_url=pbs`, NetBox `min_version=4.5.8` / `max_version=4.6.99`. No `required_plugins` — boots standalone.
- `PBSPluginSettings(NetBoxModel)` — singleton (`singleton_key`, `get_solo()`), with `netbox-branching` lifecycle fields from day one: `branching_enabled`, `branch_name_prefix`, `branch_on_conflict`.
- `migrations/0001_initial.py` — creates `PBSPluginSettings` only; depends on `("extras", "0001_initial")` for the `TaggedItem` relation. Domain models are explicitly **not** created here (deferred to C2).
- `navigation.py` — `PluginMenu(label="Proxmox Backup Server", …)` top-level entry.
- `urls.py` + `views.py` + `templates/netbox_pbs/home.html` — placeholder `PBSHomeView` (`ConditionalLoginRequiredMixin`) so the plugin renders a home page.
- `tests/test_plugin_boots.py` — 7 AST-based source-contract tests (no Django bootstrap, mirrors `tests/test_version.py`).

### Deferred to follow-ups
| PR | Scope |
|---|---|
| C2 | Six PBS Django domain models (`PBSEndpoint`, `PBSNode`, `PBSDatastore`, `PBSBackupGroup`, `PBSSnapshot`, `PBSJobStatus`) + list/detail views + REST API. |
| C3 | `branch_lifecycle.py` mirror + `PBSSyncJob.run()` six-step branching pattern + HTTP client to `proxbox-api`'s `/pbs/sync/*`. |
| C4 | Cross-link FK `VMBackup.pbs_snapshot → PBSSnapshot`, guarded by `"netbox_pbs" in settings.PLUGINS`. |
| C5 | CI matrix update (`publish-testpypi.yml`) over both packages + Docker `pbs-raw` target. |

### Scope locks (preserved from #325 plan)
- **Read-only.** v1 supports PBS → NetBox sync only. No NetBox → PBS write direction.
- **Branching-aware from day one.** `PBSPluginSettings` carries the same three branching fields as `ProxboxPluginSettings`.
- **Two independent wheels.** `netbox-proxbox` and `netbox-pbs` build from one repo via separate `pyproject.toml` files.
- `netbox-pbs` must boot **standalone** — no `netbox-proxbox` dependency in `[project.dependencies]`; only the optional `proxbox` extra exposes the cross-link.

## Test plan

- [x] `pytest netbox_pbs/tests/` — 7/7 pass.
- [x] Root `pytest tests/` — 557/557 still pass.
- [x] `uv build` (root) — produces `netbox_proxbox + proxbox_cli` only.
- [x] `uv build --project netbox_pbs` — produces `netbox_pbs` only (verified no `netbox_proxbox` contamination).
- [x] `manage.py check` against live NetBox 4.6 with `netbox_pbs` installed — clean.
- [x] `manage.py makemigrations netbox_pbs --check --dry-run` — no drift.
- [x] `ruff check` + `ruff format --check` — clean.
- [x] `python -m compileall netbox_pbs` — clean.

## Base

This PR targets `feat/issue-406-port-branching-v0.0.15` so the PBS plugin inherits the NetBox-Branching plumbing already shipping for VM/cluster sync.

Closes part of #325.