### PR TITLE
fix(migrations): merge three 0040 leaf nodes

### DIFF
--- a/netbox_proxbox/migrations/0047_merge_0040_leaves.py
+++ b/netbox_proxbox/migrations/0047_merge_0040_leaves.py
@@ -1,0 +1,11 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_proxbox", "0040_pluginsettings_ensure_netbox_objects"),
+        ("netbox_proxbox", "0040_pluginsettings_parse_description_metadata"),
+        ("netbox_proxbox", "0046_pluginsettings_delete_orphans"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## Summary

PRs #397, #398, and the allow_writes / proxmox-actions PR each added a migration at `0040_*` depending on `0039`. Only `0040_proxmoxendpoint_allow_writes` became the linear chain leader; `0040_pluginsettings_ensure_netbox_objects` and `0040_pluginsettings_parse_description_metadata` are orphan leaves with no downstream consumer.

\`migrate\` still applies all three (they touch unrelated columns), but \`makemigrations --check\` and \`showmigrations\` flag the dangling heads. This Django merge migration consolidates them with the current tip (\`0046_pluginsettings_delete_orphans\`) into \`0047\` so the dependency graph has a single tip again before cutting v0.0.15.

## Why now

Surfaced in pre-release breadth review of #369 sub-issues. Cleanest to fix before tagging v0.0.15.

## Test plan

- [ ] CI green
- [ ] \`python manage.py makemigrations netbox_proxbox --check\` passes locally
- [ ] \`python manage.py showmigrations netbox_proxbox\` shows a single linear chain