### PR TITLE
docs: close v0.0.15 documentation coverage gaps for #369

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -98,9 +98,13 @@ curl -H "Authorization: Token <token>" \
 | `token_name` | string | Proxmox API token name |
 | `token_value` | string (write-only) | Proxmox API token secret |
 | `verify_ssl` | boolean | Whether to verify the Proxmox TLS certificate (default `false`) |
+| `allow_writes` | boolean | Gate for the operational verb routes on the paired `proxbox-api` (start/stop/snapshot/migrate). Defaults to `false`. When `false`, `proxbox-api` returns `403 {"reason": "writes_disabled_for_endpoint"}` for verb POSTs against this endpoint even with a valid API key and `X-Proxbox-Actor` header. Flip to `true` per-endpoint to opt that Proxmox cluster into write access. |
 
 !!! warning "Validation"
     At least one of `domain` or `ip_address` must be provided. Omitting both returns a 400 error on both fields.
+
+!!! tip "Operational verbs"
+    `allow_writes` does **not** gate any of the read-side sync paths. It only controls the POST verb routes (`/proxmox/qemu/{vmid}/{start,stop,snapshot,migrate}` and the LXC equivalents) on the paired `proxbox-api`. See [Operational verbs design](../design/operational-verbs.md) and the [Endpoint Operations API](./operations.md).
 
 ---
 

--- a/docs/configuration/plugin-settings.md
+++ b/docs/configuration/plugin-settings.md
@@ -30,8 +30,21 @@ shadows the field.
 | **Use guest agent interface name** | `true` | _(plugin only)_ | Use QEMU guest-agent interface names (e.g. `ens18`) instead of generic Proxmox labels (e.g. `net0`). |
 | **Proxmox fetch max concurrency** | `8` | `PROXBOX_FETCH_MAX_CONCURRENCY` | Maximum parallel Proxmox fetch operations per sync stage. Raise for multi-cluster speed; lower if Proxmox load is a concern. |
 | **Ignore IPv6 link-local addresses** | `true` | _(plugin only)_ | Skip `fe80::/64` addresses during VM interface IP selection. |
+| **Ensure NetBox supporting objects on startup** | `true` | _(plugin only)_ | When enabled, proxbox-api runs an idempotent NetBox-side bootstrap pass on each process start that ensures the supporting objects the plugin relies on (cluster type, device roles, manufacturer, device type, VM type, custom fields, discovery tags) exist. Disable to leave hand-curated NetBox installs untouched. |
 | **Delete orphan VMs** | `false` | `PROXBOX_DELETE_ORPHANS` | Delete Proxbox-discovered VMs that were not touched by the current full-update run. Review `/full-update/stream?dry_run=true` before enabling in production. |
+| **Parse description metadata** | `false` | _(plugin only)_ | When enabled, proxbox-api reads each Proxmox object's description for a fenced `netbox-metadata` JSON block and applies the parsed primary-key ids to the matching NetBox fields. Per-field `overwrite_*` flags still gate keys they cover. |
 | **Primary IP preference** | `ipv4` | _(plugin only)_ | Whether the sync should prefer IPv4 or IPv6 when assigning primary IP on NetBox VMs. |
+
+### Default VM roles
+
+`default_role_qemu` and `default_role_lxc` provide global fallback DeviceRoles used when a synced VM has no role assignment yet. They are FK choices restricted to `DeviceRole` rows with `vm_role=True`.
+
+| Field | Default | Env override | Description |
+|---|---|---|---|
+| **Default QEMU VM role** | `virtual-machine-qemu` (seeded by migration) | _(plugin only)_ | DeviceRole assigned to QEMU VMs synced from Proxmox when no per-Endpoint or per-Node override applies. Operator edits on a specific VM are preserved by the `proxmox_last_synced_role_id` snapshot lock. |
+| **Default LXC container role** | `container-lxc` (seeded by migration) | _(plugin only)_ | DeviceRole assigned to LXC containers synced from Proxmox when no per-Endpoint or per-Node override applies. Operator edits on a specific VM are preserved by the same snapshot lock. |
+
+The lookup order applied during sync is **VM-level (operator pin) → per-Node → per-Endpoint → Plugin Settings default → built-in fallback**. The `proxmox_last_synced_role_id` custom field on `virtualization.VirtualMachine` stores the role that sync last wrote; subsequent runs only update the role when it still matches that snapshot, so manual edits in NetBox are not clobbered.
 
 ---
 
@@ -105,6 +118,53 @@ Tri-state semantics on the per-endpoint tab:
 The `overwrite_vm_tags` toggle controls **merge vs replace** semantics: when enabled, Proxbox-managed tags replace the existing tag set; when disabled, Proxbox tags are merged with whatever tags are already present on the NetBox VM.
 
 See [Sync Overwrite Flags](./sync-overwrite-flags.md) for the full flag matrix.
+
+---
+
+## Tenant Mapping
+
+These fields drive the optional VM-name → Tenant resolver. Existing tenant assignments are never overwritten by this rule set.
+
+| Field | Default | Env override | Description |
+|---|---|---|---|
+| **Enable tenant assignment by VM-name regex** | `false` | _(plugin only)_ | When enabled, sync resolves a NetBox Tenant for each VM by matching its name against the rules below. |
+| **Tenant name regex rules** | `[]` | _(plugin only)_ | Ordered list of `{pattern, tenant_slug, [label]}` dicts. First match wins; specificity-first ordering is recommended (e.g. `^cust-acme-` before `^cust-`). Patterns are compiled and tenant slugs are verified at save time. |
+
+See [Tenant Mapping operations](../operations/tenant-mapping.md) for runbook-level guidance, pattern examples, and the audit-tag emitted on each match.
+
+---
+
+## Branching
+
+These fields configure the optional **branching-enabled sync** mode where every Proxbox job runs against a fresh `netbox-branching` branch and merges on success. Requires the `netbox_branching` plugin installed and listed **last** in `PLUGINS`.
+
+| Field | Default | Env override | Description |
+|---|---|---|---|
+| **Branching-enabled sync (Proxmox → NetBox)** | `false` | _(plugin only)_ | Master toggle. When enabled, every Proxbox sync job creates a branch, runs the sync on it, and merges it back into `main` on success. |
+| **Branch name prefix** | `proxbox-sync` | _(plugin only)_ | Prefix used when auto-creating a NetBox branch per sync job. Final name pattern is `<prefix>-<job_id>-<timestamp>`. |
+| **Branch merge conflict policy** | `fail` | _(plugin only)_ | `fail` leaves the branch open for operator review and marks the job failed. `acknowledge` attempts the merge anyway and delegates conflict handling to the netbox-branching merge strategy. |
+
+---
+
+## NetBox → Proxmox intent direction
+
+These fields gate the optional write-back direction in which merging a branch flagged `apply_to_proxmox=True` dispatches CREATE / UPDATE writes to Proxmox via `proxbox-api`. See the [Safety Model](../../CLAUDE.md#safety-model) for the full five-lock invariant chain.
+
+| Field | Default | Env override | Description |
+|---|---|---|---|
+| **Enable NetBox → Proxmox intent direction** | `false` | _(plugin only)_ | Master flag. Off by default. DELETE still requires the separate `DeletionRequest` authorization chain even when this is on. |
+| **Typed confirmation phrase** | _(empty)_ | _(plugin only)_ | Operators enabling the master flag must type the exact phrase `allow-edit-and-add-actions` here. Toggling the master flag back to `false` clears this phrase, forcing re-confirmation on re-enable. |
+| **Allow apply-destroy authorization workflow** | `false` | _(plugin only)_ | Per-branch destroy master switch. Even when set, every destroy flows through a separate `DeletionRequest` approved by a user holding `netbox_proxbox.authorize_deletion_request`. |
+
+---
+
+## Hardware Discovery
+
+| Field | Default | Env override | Description |
+|---|---|---|---|
+| **Enable SSH-based hardware discovery** | `false` | _(plugin only)_ | Master flag for the SSH-driven hardware-discovery pass. When enabled, proxbox-api opens a pinned-fingerprint SSH session to each `ProxmoxNode` that has a stored `NodeSSHCredential` row, runs `dmidecode + ethtool + ip link` under `sudo -n`, and reflects the parsed chassis / NIC values onto the matching `dcim.Device` and `dcim.Interface` custom fields. Flipping off results in zero SSH sockets opened during sync. |
+
+See [Hardware Discovery](./hardware-discovery.md) for the full configuration, custom-field surface, and SSH-credential model.
 
 ---
 

--- a/docs/models/vm-cloudinit.md
+++ b/docs/models/vm-cloudinit.md
@@ -1,0 +1,41 @@
+# VM Cloud-Init Data Model
+
+`ProxmoxVMCloudInit` mirrors the Proxmox cloud-init configuration of each synced QEMU virtual machine onto NetBox. The row is **read-only on the NetBox side** — Proxmox stays the source of truth. proxbox-api populates and refreshes it from `qm config <vmid>` on every sync that touches the VM.
+
+## Shape
+
+| Field | Type | Notes |
+|---|---|---|
+| `virtual_machine` | One-to-one → `virtualization.VirtualMachine` | Cascade-deletes with the VM. Reverse accessor is `vm.proxmox_cloudinit`. |
+| `ciuser` | CharField (≤64) | Proxmox cloud-init user (`ciuser`). |
+| `sshkeys` | TextField | Decoded SSH-key bundle (one key per line). Proxmox stores this URL-encoded; proxbox-api runs `urllib.parse.unquote` before writing. |
+| `ipconfig0` | CharField (≤255) | First-NIC IP configuration string from Proxmox, e.g. `ip=dhcp` or `ip=10.0.0.5/24,gw=10.0.0.1`. |
+| `sshkeys_truncated` | BooleanField | `True` when proxbox-api truncated the `sshkeys` payload because the decoded blob exceeded **10 KB**. |
+| `last_synced` | DateTimeField | `auto_now` timestamp updated on every reconciliation pass. |
+
+The one-to-one constraint means at most one cloud-init row exists per VM. Deleting the VM removes the cloud-init row via `CASCADE`.
+
+## UI Surface
+
+- A dedicated **Cloud-Init** tab is rendered on the VM detail page **only when the row exists**. VMs with no Proxmox cloud-init record render an explicit empty-state message ("No Proxmox cloud-init record") so the tab does not falsely advertise data.
+- The plugin home does **not** list cloud-init rows; they are accessed through the parent VM.
+
+## REST API
+
+The serializer is exposed at `plugins-api:netbox_proxbox-api:proxmoxvmcloudinit-list`:
+
+- `GET /api/plugins/proxbox/vm-cloudinit/` — list rows; supports `?brief=1` to return only `id`, `url`, `display`, `virtual_machine`, `ciuser`.
+- `POST /api/plugins/proxbox/vm-cloudinit/` — proxbox-api creates one row per QEMU VM during cloud-init reflection.
+- `PATCH /api/plugins/proxbox/vm-cloudinit/<id>/` — proxbox-api refreshes individual fields on subsequent syncs.
+
+The endpoint is the only sanctioned write path. NetBox operators should treat the rows as read-only and use Proxmox to edit cloud-init.
+
+## Operator Visibility
+
+Truncation is surfaced through `sshkeys_truncated`. When that flag is true, the UI banner indicates that the key bundle was clipped — operators should consult Proxmox for the authoritative payload rather than relying on the NetBox-side mirror.
+
+## See Also
+
+- [Virtual Machine](./virtual-machine.md) — parent VM model overview.
+- [Sync Overwrite Flags](../configuration/sync-overwrite-flags.md) — `overwrite_vm_cloudinit` controls whether cloud-init reflection runs at all.
+- Source: [`netbox_proxbox/models/vm_cloudinit.py`](https://github.com/netdevopsbr/netbox-proxbox/blob/main/netbox_proxbox/models/vm_cloudinit.py).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
     - Hardware Discovery: 'configuration/hardware-discovery.md'
   - CLI:
     - Overview: 'cli/index.md'
+    - Sync Command: 'cli/sync.md'
     - Command Reference: 'reference/proxbox-cli/command-catalog/index.md'
     - Command Examples:
       - Overview: 'reference/proxbox-cli/command-examples/index.md'
@@ -112,6 +113,7 @@ nav:
     - Headless Sync: 'operations/headless-sync.md'
     - Single-Exec Compose: 'operations/single-exec.md'
     - Scheduler Container: 'scheduler/README.md'
+    - Tenant Mapping: 'operations/tenant-mapping.md'
   - API Reference:
     - Overview: 'api/index.md'
     - Endpoints: 'api/endpoints.md'
@@ -142,6 +144,7 @@ nav:
     - Endpoint Import / Export: 'features/endpoint-import-export.md'
   - Data Model:
     - Virtual Machine: 'models/virtual-machine.md'
+    - VM Cloud-Init: 'models/vm-cloudinit.md'
     - Containers: 'models/containers.md'
     - Other Models: 'models/others.md'
   - Release Notes:


### PR DESCRIPTION
## Summary

Closes documentation gaps surfaced by the issue [#369](https://github.com/emersonfelipesp/netbox-proxbox/issues/369) audit. All 19 sub-issues in the v0.0.15 epic are implemented and merged into \`develop\` — this PR brings the docs tree and mkdocs nav up to date with what actually ships.

### docs/configuration/plugin-settings.md
- New **Core Behavior** rows: \`ensure_netbox_objects\` (#358), \`parse_description_metadata\` (#366)
- New **Default VM roles** subsection: \`default_role_qemu\` / \`default_role_lxc\` (#364) — documents the per-VM-type role fallback and the \`proxmox_last_synced_role_id\` snapshot lock that preserves operator edits (#367)
- New **Tenant Mapping** section: \`enable_tenant_name_regex\` + \`tenant_name_regex_rules\` (#365)
- New **Branching** section: \`branching_enabled\`, \`branch_name_prefix\`, \`branch_on_conflict\` (#370)
- New **NetBox → Proxmox intent direction** section: master flag, typed confirmation, apply-destroy confirmation
- New **Hardware Discovery** section that links to the existing dedicated page

### mkdocs.yml
Adds nav entries for files that already existed on disk but were orphaned:
- \`cli/sync.md\` under **CLI** (#373)
- \`operations/tenant-mapping.md\` under **Operations** (#365)
- \`models/vm-cloudinit.md\` under **Data Model** (#363, new file)

### docs/models/vm-cloudinit.md (new)
Documents the \`ProxmoxVMCloudInit\` one-to-one model shipped with v0.0.15 (#363): field shape, read-only nature, REST endpoint, UI tab behavior, and the SSH-key truncation flag.

### docs/api/endpoints.md
Adds the \`allow_writes\` row to the \`ProxmoxEndpoint\` data model (#376) — the per-endpoint gate that proxbox-api consults before allowing operational verbs (start / stop / snapshot / migrate).

## Tests / contracts
Existing test infrastructure already covers the items the audit flagged as test-side:
- \`tests/test_sse_schema_mirror.py\` + \`contracts/proxbox_api_sse_schema.json\` pin \`DuplicateNameResolvedPayload\` fields (#368).
- \`tests/test_settings_view_encryption.py\` exercises \`default_role_qemu\` / \`default_role_lxc\` on the settings surface (#364).
- The migration's seed for the two default DeviceRoles is covered by the existing data-callable tests in \`tests/migrations/\`.

## Test plan
- [ ] \`mkdocs build\` succeeds with no orphan-page or broken-link warnings on the new nav entries.
- [ ] \`pytest tests/\` stays green (no code changes; only markdown + yaml).
- [ ] Spot-check the rendered pages on the GitHub Pages preview after merge.