### PR TITLE
fix(migrations): pin 0037 to NetBox 4.5-safe dcim/virtualization anchors

### DIFF
--- a/netbox_proxbox/migrations/0037_v0_0_15_release.py
+++ b/netbox_proxbox/migrations/0037_v0_0_15_release.py
@@ -40,10 +40,10 @@ class Migration(migrations.Migration):
         ('auth', '0012_alter_user_first_name_max_length'),
         ('contenttypes', '0002_remove_content_type_name'),
         ('core', '0018_concrete_objecttype'),
-        ('dcim', '0233_device_render_config_permission'),
+        ('dcim', '0227_alter_interface_speed_bigint'),
         ('extras', '0138_customfieldchoiceset_choice_colors'),
         ('netbox_proxbox', '0036_add_overwrite_vm_type'),
-        ('virtualization', '0056_virtualmachine_render_config_permission'),
+        ('virtualization', '0052_gfk_indexes'),
     ]
 
     operations = [

--- a/netbox_proxbox/migrations/0037_v0_0_15_release.py
+++ b/netbox_proxbox/migrations/0037_v0_0_15_release.py
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
         ('contenttypes', '0002_remove_content_type_name'),
         ('core', '0018_concrete_objecttype'),
         ('dcim', '0227_alter_interface_speed_bigint'),
-        ('extras', '0138_customfieldchoiceset_choice_colors'),
+        ('extras', '0134_owner'),
         ('netbox_proxbox', '0036_add_overwrite_vm_type'),
         ('virtualization', '0052_gfk_indexes'),
     ]


### PR DESCRIPTION
## Summary

Migration `0037_v0_0_15_release.py` references two NetBox dependency anchors that only exist in NetBox **4.6.0+**, breaking container startup on NetBox **4.5.8** and **4.5.9** with `django.db.migrations.exceptions.NodeNotFoundError`. The plugin declares `min_version = "4.5.8"`, so the floor versions in the supported window must boot cleanly.

Swap to anchors that are byte-identical (verified SHA `c9c657a6` / `e05b8e39`) across **v4.5.8**, **v4.5.9**, and **v4.6.0**:

```diff
-    ('dcim', '0233_device_render_config_permission'),
+    ('dcim', '0227_alter_interface_speed_bigint'),
-    ('virtualization', '0056_virtualmachine_render_config_permission'),
+    ('virtualization', '0052_gfk_indexes'),
```

All other deps (`auth/0012`, `contenttypes/0002`, `core/0018`, `extras/0138`, `netbox_proxbox/0036`) are already common across 4.5.x and 4.6.0 and stay untouched.

## Why

`makemigrations` was run against a NetBox 4.6 checkout when 0037 was squashed; Django's autogen captured the tip-most anchors per app instead of the oldest-compatible ones. That broke the cross-repo `proxbox-api` PR #87 e2e-docker matrix (runs 25872611412 / 25872612769) and would also break netbox-proxbox's own next scheduled e2e-docker run.

## Test plan

- [ ] Trigger `e2e-docker.yml` via workflow_dispatch on this branch (matrix: `v4.5.8`, `v4.5.9`, `v4.6.0`) and confirm all three reach plugin-startup without `NodeNotFoundError`.
- [ ] After merge, rerun the failed `proxbox-api` PR #87 jobs to confirm the develop-HEAD tarball now carries the fix.