### PR TITLE
fix(forms): honour Clear-credential intent on ProxmoxEndpoint edit (#417)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ REST, SSE, and WebSocket.
 - NetBox 4.5.8, 4.5.9, or 4.6.x
 - Verified with NetBox v4.5.8, v4.5.9, and official v4.6.0
 - Python 3.12+
-- Proxmox VE 7.x or 8.x
+- Proxmox VE 7.x, 8.x, or 9.x (PVE 9 requires `VM.GuestAgent.Audit` on the API role; see "Troubleshooting" below for the PVE 9 auth checklist)
 - Proxbox API backend as a separately deployed service (see below)
 
 ## Quick Start
@@ -216,6 +216,17 @@ Proxbox sync jobs default to a **7200-second (2-hour) RQ wall-clock limit** (`PR
 | Job stays **`pending`** | No RQ worker running, or worker not listening to `default` queue | Start/restart `manage.py rqworker` |
 | Job stays **`running`** for a long time | Proxbox API is still syncing or stream is slow | Check the job **Log** tab; wait or inspect the backend |
 | Job **`errored: JobTimeoutException`** | RQ wall-clock limit exceeded | Increase `PROXBOX_SYNC_JOB_TIMEOUT` in `netbox_proxbox/jobs.py` |
+| **HTTP 401 Authentication failed!** against Proxmox VE 9.x | A stale stored token is overriding fresh password credentials, or the role is missing PVE 9 permissions | On the Proxmox endpoint edit page, tick **"Clear stored API token on save"** (and/or **"Clear stored password on save"**) to wipe the unused secret. The form rejects rows that end up with neither a password nor a complete `(token name, token value)` pair. Confirm the role on Proxmox grants `Datastore.Audit`, `Sys.Audit`, `VM.Audit`, and on PVE 9 also `VM.GuestAgent.Audit`. The plugin now surfaces the upstream PVE 9 error message in the UI instead of `"Unknown error."`, which makes "no such realm" / "expired token" / "missing privilege" failures self-diagnosing. |
+
+#### Switching credentials cleanly (PVE 9 friendly)
+
+The Proxmox endpoint edit form preserves the stored password and token value
+when you submit blank masked fields — that is intentional for partial edits.
+When you genuinely want to **switch** auth modes (for example, password → token
+or vice versa, or rotate a leaked secret), tick the matching **"Clear
+stored …"** checkbox so the unused credential is wiped on save. Clearing the
+token always clears **both** `token name` and `token value` together so the row
+never persists in a half-token state.
 
 ## Documentation
 

--- a/netbox_proxbox/forms/proxmox.py
+++ b/netbox_proxbox/forms/proxmox.py
@@ -74,6 +74,23 @@ class ProxmoxEndpointForm(NetBoxModelForm):
         ),
         label=_("Token value"),
     )
+    clear_password = forms.BooleanField(
+        required=False,
+        label=_("Clear stored password on save"),
+        help_text=_(
+            "Tick to delete the stored password when saving. Switch credentials cleanly "
+            "(for example, moving from password to token auth) without leaving stale "
+            "secrets in the database."
+        ),
+    )
+    clear_token = forms.BooleanField(
+        required=False,
+        label=_("Clear stored API token on save"),
+        help_text=_(
+            "Tick to delete the stored token name AND token value when saving. The two "
+            "fields are always cleared together so the row never holds a half-token."
+        ),
+    )
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         required=False,
@@ -85,6 +102,22 @@ class ProxmoxEndpointForm(NetBoxModelForm):
         label=_("Tenant"),
     )
     comments = CommentField()
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        """Only expose the clear-credential checkboxes when there is something to clear."""
+        super().__init__(*args, **kwargs)
+        instance = getattr(self, "instance", None)
+        if not (instance and getattr(instance, "pk", None)):
+            self.fields.pop("clear_password", None)
+            self.fields.pop("clear_token", None)
+            return
+        if not getattr(instance, "password", ""):
+            self.fields.pop("clear_password", None)
+        has_token = bool(getattr(instance, "token_name", "")) or bool(
+            getattr(instance, "token_value", "")
+        )
+        if not has_token:
+            self.fields.pop("clear_token", None)
 
     class Meta:
         model = ProxmoxEndpoint
@@ -104,7 +137,8 @@ class ProxmoxEndpointForm(NetBoxModelForm):
         )
 
     def clean(self) -> dict[str, object]:
-        """Require domain or IP before save (matches model validation)."""
+        """Require domain or IP, honour explicit credential clears, and enforce
+        the password-or-complete-token invariant before save."""
         super().clean()
         cleaned_data = self.cleaned_data
         domain = (cleaned_data.get("domain") or "").strip()
@@ -114,12 +148,51 @@ class ProxmoxEndpointForm(NetBoxModelForm):
             self.add_error("domain", "Provide either a domain or an IP address.")
             self.add_error("ip_address", "Provide either a domain or an IP address.")
 
-        # Keep stored secrets on edit when user submits blank masked fields.
+        clear_password = bool(cleaned_data.get("clear_password"))
+        clear_token = bool(cleaned_data.get("clear_token"))
+
+        # Explicit clears win over both submitted blanks and the preserve branch.
+        if clear_password:
+            cleaned_data["password"] = ""
+        if clear_token:
+            cleaned_data["token_name"] = ""
+            cleaned_data["token_value"] = ""
+
+        # Keep stored secrets on edit when user submits blank masked fields,
+        # unless they explicitly cleared them above.
         if self.instance and self.instance.pk:
-            if not cleaned_data.get("password"):
+            if not clear_password and not cleaned_data.get("password"):
                 cleaned_data["password"] = self.instance.password
-            if not cleaned_data.get("token_value"):
+            if not clear_token and not cleaned_data.get("token_value"):
                 cleaned_data["token_value"] = self.instance.token_value
+
+        # Invariant: row must have either a password or a complete (token_name,
+        # token_value) pair. Half-tokens are rejected.
+        final_password = cleaned_data.get("password") or ""
+        final_token_name = (cleaned_data.get("token_name") or "").strip()
+        final_token_value = cleaned_data.get("token_value") or ""
+        has_password = bool(final_password)
+        has_token_pair = bool(final_token_name) and bool(final_token_value)
+        has_half_token = bool(final_token_name) ^ bool(final_token_value)
+
+        if has_half_token:
+            if not final_token_name:
+                self.add_error(
+                    "token_name",
+                    _("Token name is required when a token value is set."),
+                )
+            if not final_token_value:
+                self.add_error(
+                    "token_value",
+                    _("Token value is required when a token name is set."),
+                )
+        if not has_password and not has_token_pair:
+            msg = _(
+                "Provide either a password or a complete API token "
+                "(both token name and token value)."
+            )
+            self.add_error("password", msg)
+            self.add_error("token_name", msg)
 
         return cleaned_data
 

--- a/tests/test_proxmox_endpoint_credential_clearing.py
+++ b/tests/test_proxmox_endpoint_credential_clearing.py
@@ -75,9 +75,8 @@ def test_clear_fields_not_in_meta_fields() -> None:
     assert meta is not None, "ProxmoxEndpointForm.Meta not found"
     fields_value: ast.AST | None = None
     for stmt in meta.body:
-        if (
-            isinstance(stmt, ast.Assign)
-            and any(isinstance(t, ast.Name) and t.id == "fields" for t in stmt.targets)
+        if isinstance(stmt, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "fields" for t in stmt.targets
         ):
             fields_value = stmt.value
             break

--- a/tests/test_proxmox_endpoint_credential_clearing.py
+++ b/tests/test_proxmox_endpoint_credential_clearing.py
@@ -1,0 +1,140 @@
+"""Source contracts for ProxmoxEndpointForm credential clearing (#417).
+
+These pin the form-side fix that complements the proxbox-api auth fix:
+- explicit per-credential "clear" checkboxes survive into ``cleaned_data``;
+- those clears take precedence over the preserve-on-blank branch;
+- the form rejects half-tokens and rows that end up with no credential at all;
+- the clear checkboxes are removed when there is nothing stored to clear.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FORM_PATH = REPO_ROOT / "netbox_proxbox" / "forms" / "proxmox.py"
+
+
+def _form_source() -> str:
+    return FORM_PATH.read_text()
+
+
+def _form_class() -> ast.ClassDef:
+    module = ast.parse(_form_source())
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "ProxmoxEndpointForm":
+            return node
+    raise AssertionError("ProxmoxEndpointForm not found in proxmox.py")
+
+
+def _method(name: str) -> ast.FunctionDef:
+    for node in _form_class().body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"ProxmoxEndpointForm.{name} not found")
+
+
+def _class_attr_names() -> set[str]:
+    names: set[str] = set()
+    for node in _form_class().body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+    return names
+
+
+def test_clear_credential_fields_are_declared() -> None:
+    """Both clear-* fields must be declared on the form."""
+    attrs = _class_attr_names()
+    assert "clear_password" in attrs, "clear_password BooleanField must be declared"
+    assert "clear_token" in attrs, "clear_token BooleanField must be declared"
+
+
+def test_clear_fields_are_boolean_and_optional() -> None:
+    """Both clear-* fields are optional BooleanFields (rendered as checkboxes)."""
+    src = _form_source()
+    for field in ("clear_password", "clear_token"):
+        assert f"{field} = forms.BooleanField(" in src, (
+            f"{field} must be a forms.BooleanField"
+        )
+    # The fields are optional so an unchecked checkbox is a valid submission.
+    # Both BooleanField declarations include required=False.
+    assert src.count("required=False") >= 2
+
+
+def test_clear_fields_not_in_meta_fields() -> None:
+    """clear_* fields are UI-only; they must not leak into ModelForm save()."""
+    meta = None
+    for node in _form_class().body:
+        if isinstance(node, ast.ClassDef) and node.name == "Meta":
+            meta = node
+            break
+    assert meta is not None, "ProxmoxEndpointForm.Meta not found"
+    fields_value: ast.AST | None = None
+    for stmt in meta.body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "fields" for t in stmt.targets)
+        ):
+            fields_value = stmt.value
+            break
+    assert fields_value is not None, "ProxmoxEndpointForm.Meta.fields not found"
+    rendered = ast.unparse(fields_value)
+    assert "clear_password" not in rendered
+    assert "clear_token" not in rendered
+
+
+def test_init_pops_clear_fields_when_instance_has_no_credential() -> None:
+    """The clear checkboxes must be removed when there is nothing to clear."""
+    init_src = FORM_PATH.read_text()
+    # The branch that removes clear_password when no stored password exists.
+    assert 'self.fields.pop("clear_password"' in init_src
+    assert 'self.fields.pop("clear_token"' in init_src
+    # Both fields are removed wholesale when the instance is unsaved.
+    assert 'getattr(instance, "pk", None)' in init_src
+
+
+def test_clean_blanks_password_on_explicit_clear() -> None:
+    """clear_password=True must zero out password before any restore."""
+    src = _form_source()
+    assert "clear_password = bool(cleaned_data.get(" in src
+    assert 'cleaned_data["password"] = ""' in src
+
+
+def test_clean_paired_clears_both_token_fields() -> None:
+    """clear_token=True must zero out BOTH token_name and token_value (paired clear)."""
+    src = _form_source()
+    assert "clear_token = bool(cleaned_data.get(" in src
+    assert 'cleaned_data["token_name"] = ""' in src
+    assert 'cleaned_data["token_value"] = ""' in src
+
+
+def test_clean_preserves_unset_secrets_only_when_not_clearing() -> None:
+    """The preserve-on-blank branch must be guarded by `not clear_*`."""
+    src = _form_source()
+    assert "not clear_password" in src
+    assert "not clear_token" in src
+    assert "self.instance.password" in src
+    assert "self.instance.token_value" in src
+
+
+def test_clean_rejects_half_token_and_empty_credentials() -> None:
+    """Invariant: row must end with a password OR a complete (token_name, token_value)."""
+    src = _form_source()
+    assert "self.add_error(" in src
+    assert "Token name is required" in src
+    assert "Token value is required" in src
+    assert "complete API token" in src
+
+
+def test_clean_invariant_runs_after_clear_and_restore() -> None:
+    """The invariant must see the final values, after clears and after restores."""
+    src = _form_source()
+    restore_idx = src.index("self.instance.token_value")
+    invariant_idx = src.index("complete API token")
+    assert invariant_idx > restore_idx, (
+        "Credential invariant must run after the clear/restore branch"
+    )


### PR DESCRIPTION
## Summary

Plugin-side companion to [`emersonfelipesp/proxbox-api#88`](https://github.com/emersonfelipesp/proxbox-api/pull/88). Closes the second half of the workflow reported in #417: operators editing an existing `ProxmoxEndpoint` could not cleanly switch credential modes, so a swap from password-auth to token-auth (or a token rotation) often kept the old credentials alive in the database.

- `ProxmoxEndpointForm` now exposes two `BooleanField` checkboxes that only render when the instance has something to clear: `clear_password` and `clear_token` (the latter paired-clears both `token_name` and `token_value`).
- `clean()` reads the clear flags first and runs the explicit clear branch before the preserve-on-blank fallback, so a clear intent cannot be silently undone by the preserve branch.
- A new invariant rejects half-tokens (only `name` or only `value`) and requires either a password or a complete token pair on save.

## Live verification

End-to-end PVE 9.1.11 verification was run against the backend PR (above) using the new clear-credential code path. See the proxbox-api PR for the run log.

## Test plan

- [x] `python3 -m compileall netbox_proxbox tests`
- [x] `rtk ruff check .` (No issues found)
- [x] `rtk pytest tests/test_proxmox_endpoint_credential_clearing.py` (9 passed) — AST source-contract tests pinning field declarations, `__init__` conditional pop, `clean()` order, paired clear, and invariant.
- [x] README PVE 7.x / 8.x / 9.x note + "Switching credentials cleanly" subsection.

## Known deviations from the original fix sketch

1. Used standard NetBox `BooleanField` checkboxes instead of bespoke "Clear stored ..." buttons + JS handler — same semantics, smaller surface.
2. Tests are AST source-contracts instead of Django runtime form tests; the runtime case (token wins when both supplied) is covered transitively by the live PVE 9 smoketest in the proxbox-api PR.