### PR TITLE
feat(cloud-init): add CloudImageTemplate catalog model

### DIFF
--- a/netbox_proxbox/api/serializers/__init__.py
+++ b/netbox_proxbox/api/serializers/__init__.py
@@ -19,6 +19,10 @@ from netbox_proxbox.api.serializers.cluster import (
     ProxmoxClusterSerializer,
     ProxmoxNodeSerializer,
 )
+from netbox_proxbox.api.serializers.cloud_image_template import (
+    CloudImageTemplateSerializer,
+    NestedCloudImageTemplateSerializer,
+)
 from netbox_proxbox.api.serializers.endpoints import (
     FastAPIEndpointSerializer,
     NestedTokenSerializer,
@@ -39,11 +43,13 @@ from netbox_proxbox.api.serializers.vm_task_history import VMTaskHistorySerializ
 
 __all__ = (
     "BackupRoutineSerializer",
+    "CloudImageTemplateSerializer",
     "DeviceResourceSerializer",
     "FastAPIEndpointSerializer",
     "InterfaceResourceSerializer",
     "IPAddressResourceSerializer",
     "NestedBackupRoutineSerializer",
+    "NestedCloudImageTemplateSerializer",
     "NestedProxmoxClusterSerializer",
     "NestedProxmoxEndpointSerializer",
     "NestedTokenSerializer",

--- a/netbox_proxbox/api/serializers/cloud_image_template.py
+++ b/netbox_proxbox/api/serializers/cloud_image_template.py
@@ -1,0 +1,78 @@
+"""API serializer for tenant-scoped cloud image templates."""
+
+from __future__ import annotations
+
+from netbox.api.fields import ChoiceField
+from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
+from rest_framework import serializers
+from tenancy.api.serializers_.tenants import TenantSerializer
+from virtualization.api.serializers_.clusters import ClusterSerializer
+
+from netbox_proxbox.choices import CloudImageOSFamilyChoices
+from netbox_proxbox.models import CloudImageTemplate
+
+
+class CloudImageTemplateSerializer(NetBoxModelSerializer):
+    """Full representation of a Cloud Portal cloud image template."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_proxbox-api:cloudimagetemplate-detail",
+    )
+    cluster = ClusterSerializer(nested=True)
+    os_family = ChoiceField(choices=CloudImageOSFamilyChoices)
+    allowed_tenants = TenantSerializer(nested=True, many=True, required=False)
+
+    class Meta:
+        model = CloudImageTemplate
+        fields = (
+            "id",
+            "url",
+            "display",
+            "name",
+            "slug",
+            "description",
+            "cluster",
+            "source_vmid",
+            "os_family",
+            "os_release",
+            "default_ciuser",
+            "allowed_tenants",
+            "is_active",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+        brief_fields = (
+            "id",
+            "url",
+            "display",
+            "name",
+            "slug",
+            "cluster",
+            "source_vmid",
+            "os_family",
+            "os_release",
+            "default_ciuser",
+            "is_active",
+        )
+
+
+class NestedCloudImageTemplateSerializer(WritableNestedSerializer):
+    """Nested cloud image template representation for related serializers."""
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name="plugins-api:netbox_proxbox-api:cloudimagetemplate-detail",
+    )
+
+    class Meta:
+        model = CloudImageTemplate
+        fields = (
+            "id",
+            "url",
+            "display",
+            "name",
+            "slug",
+            "source_vmid",
+        )
+        brief_fields = ("id", "url", "display", "name", "slug")

--- a/netbox_proxbox/api/urls.py
+++ b/netbox_proxbox/api/urls.py
@@ -45,6 +45,11 @@ router.register(
     "proxmox-clusters", views.ProxmoxClusterViewSet, basename="proxmoxcluster"
 )
 router.register("proxmox-nodes", views.ProxmoxNodeViewSet, basename="proxmoxnode")
+router.register(
+    "cloud-image-templates",
+    views.CloudImageTemplateViewSet,
+    basename="cloudimagetemplate",
+)
 router.register("storage", views.ProxmoxStorageViewSet, basename="storage")
 router.register("backups", views.VMBackupViewSet)
 router.register("backup-routines", views.BackupRoutineViewSet, basename="backuproutine")

--- a/netbox_proxbox/api/views.py
+++ b/netbox_proxbox/api/views.py
@@ -19,6 +19,7 @@ from netbox_proxbox.choices import ProxmoxVMTypeChoices
 from .. import filtersets, models
 from .serializers import (
     BackupRoutineSerializer,
+    CloudImageTemplateSerializer,
     FastAPIEndpointSerializer,
     NetBoxEndpointSerializer,
     NodeSSHCredentialSerializer,
@@ -62,6 +63,7 @@ class ProxBoxRootView(APIRootView):
         }
         response.data["schedule_sync"] = f"{base}/sync/schedule/"
         response.data["logs"] = f"{base}/logs/"
+        response.data["cloud_image_templates"] = f"{base}/cloud-image-templates/"
         response.data["ha"] = {
             "summary": f"{base}/ha/summary/",
             "vm": f"{base}/ha/vm/",
@@ -121,6 +123,16 @@ class VMBackupViewSet(NetBoxModelViewSet):
     )
     serializer_class = VMBackupSerializer
     filterset_class = filtersets.VMBackupFilterSet
+
+
+class CloudImageTemplateViewSet(NetBoxModelViewSet):
+    """REST API for tenant-scoped Cloud Portal cloud image templates."""
+
+    queryset = models.CloudImageTemplate.objects.select_related(
+        "cluster",
+    ).prefetch_related("allowed_tenants", "tags")
+    serializer_class = CloudImageTemplateSerializer
+    filterset_class = filtersets.CloudImageTemplateFilterSet
 
 
 class VMSnapshotViewSet(NetBoxModelViewSet):

--- a/netbox_proxbox/choices.py
+++ b/netbox_proxbox/choices.py
@@ -246,6 +246,26 @@ class ReplicationStatusChoices(ChoiceSet):
     ]
 
 
+class CloudImageOSFamilyChoices(ChoiceSet):
+    """Operating-system families exposed through the cloud image catalog."""
+
+    key = "CloudImageTemplate.os_family"
+
+    UBUNTU = "ubuntu"
+    DEBIAN = "debian"
+    ROCKY = "rocky"
+    ALPINE = "alpine"
+    GENERIC = "generic"
+
+    CHOICES = [
+        (UBUNTU, _("Ubuntu"), "orange"),
+        (DEBIAN, _("Debian"), "red"),
+        (ROCKY, _("Rocky Linux"), "green"),
+        (ALPINE, _("Alpine Linux"), "blue"),
+        (GENERIC, _("Generic Linux"), "gray"),
+    ]
+
+
 class ProxmoxVMTypeChoices(ChoiceSet):
     """Proxmox hypervisor VM type (QEMU vs LXC) as stored in the proxmox_vm_type custom field."""
 

--- a/netbox_proxbox/filtersets.py
+++ b/netbox_proxbox/filtersets.py
@@ -1,13 +1,19 @@
 """Define NetBox filtersets for the plugin's list views and API queries."""
 
+import django_filters
 from django.db.models import Q, QuerySet
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from netbox.filtersets import NetBoxModelFilterSet
+from tenancy.models import Tenant
 from utilities.filtersets import register_filterset
+from utilities.filters import MultiValueNumberFilter
+from virtualization.models import Cluster
 
+from .choices import CloudImageOSFamilyChoices
 from .models import (
     BackupRoutine,
+    CloudImageTemplate,
     FastAPIEndpoint,
     NetBoxEndpoint,
     NodeSSHCredential,
@@ -45,6 +51,74 @@ class ProxboxModelFilterSet(NetBoxModelFilterSet):
             if name in filters:
                 extend_schema_field(openapi_type)(filters[name])
         return filters
+
+
+@register_filterset
+class CloudImageTemplateFilterSet(ProxboxModelFilterSet):
+    """Filter cloud image templates exposed through the Cloud Portal."""
+
+    cluster_id = django_filters.ModelMultipleChoiceFilter(
+        field_name="cluster",
+        queryset=Cluster.objects.all(),
+    )
+    cluster = django_filters.ModelMultipleChoiceFilter(
+        field_name="cluster__name",
+        to_field_name="name",
+        queryset=Cluster.objects.all(),
+    )
+    os_family = django_filters.MultipleChoiceFilter(
+        choices=CloudImageOSFamilyChoices,
+    )
+    allowed_tenants_id = django_filters.ModelMultipleChoiceFilter(
+        field_name="allowed_tenants",
+        queryset=Tenant.objects.all(),
+    )
+    allowed_tenants = django_filters.ModelMultipleChoiceFilter(
+        field_name="allowed_tenants__slug",
+        to_field_name="slug",
+        queryset=Tenant.objects.all(),
+    )
+    allowed_tenants__id__in = MultiValueNumberFilter(
+        field_name="allowed_tenants__id",
+        lookup_expr="in",
+    )
+    allowed_tenants__isnull = django_filters.BooleanFilter(
+        field_name="allowed_tenants",
+        lookup_expr="isnull",
+    )
+
+    class Meta:
+        model = CloudImageTemplate
+        fields = (
+            "id",
+            "name",
+            "slug",
+            "cluster",
+            "cluster_id",
+            "source_vmid",
+            "os_family",
+            "os_release",
+            "default_ciuser",
+            "allowed_tenants",
+            "allowed_tenants_id",
+            "allowed_tenants__id__in",
+            "allowed_tenants__isnull",
+            "is_active",
+        )
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        """Match cloud image name, slug, cluster, release, or source VMID."""
+        if not value.strip():
+            return queryset
+        query = (
+            Q(name__icontains=value)
+            | Q(slug__icontains=value)
+            | Q(cluster__name__icontains=value)
+            | Q(os_release__icontains=value)
+        )
+        if value.isdigit():
+            query |= Q(source_vmid=int(value))
+        return queryset.filter(query)
 
 
 @register_filterset

--- a/netbox_proxbox/forms/__init__.py
+++ b/netbox_proxbox/forms/__init__.py
@@ -1,6 +1,7 @@
 """Re-export the plugin's model and filter form classes."""
 
 from .backup_routine import *
+from .cloud_image_template import *
 from .deletion_request_approve import *
 from .deletion_request_reject import *
 from .fastapi import *

--- a/netbox_proxbox/forms/cloud_image_template.py
+++ b/netbox_proxbox/forms/cloud_image_template.py
@@ -1,0 +1,88 @@
+"""Define NetBox forms for tenant-scoped cloud image templates."""
+
+from django import forms
+from django.utils.translation import gettext as _
+from netbox.forms import NetBoxModelFilterSetForm, NetBoxModelForm
+from tenancy.models import Tenant
+from utilities.forms.fields import (
+    CommentField,
+    DynamicModelChoiceField,
+    DynamicModelMultipleChoiceField,
+)
+from virtualization.models import Cluster
+
+from netbox_proxbox.choices import CloudImageOSFamilyChoices
+from netbox_proxbox.models import CloudImageTemplate
+
+
+class CloudImageTemplateForm(NetBoxModelForm):
+    """Form for creating and editing CloudImageTemplate catalog entries."""
+
+    cluster = DynamicModelChoiceField(
+        queryset=Cluster.objects.all(),
+        required=True,
+        label=_("Cluster"),
+        help_text=_("Cluster that contains the Proxmox source template VMID."),
+    )
+    allowed_tenants = DynamicModelMultipleChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Allowed tenants"),
+        help_text=_("Leave empty to make this template available to all tenants."),
+    )
+    comments = CommentField()
+
+    class Meta:
+        model = CloudImageTemplate
+        fields = (
+            "name",
+            "slug",
+            "description",
+            "cluster",
+            "source_vmid",
+            "os_family",
+            "os_release",
+            "default_ciuser",
+            "allowed_tenants",
+            "is_active",
+            "tags",
+            "comments",
+        )
+
+    def clean_default_ciuser(self) -> str:
+        """Keep ciuser values compatible with Proxmox cloud-init user fields."""
+        value = (self.cleaned_data.get("default_ciuser") or "").strip()
+        if not value:
+            raise forms.ValidationError(_("Default cloud-init user is required."))
+        if any(char.isspace() for char in value):
+            raise forms.ValidationError(_("Cloud-init user cannot contain whitespace."))
+        return value
+
+
+class CloudImageTemplateFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for CloudImageTemplate list views."""
+
+    model = CloudImageTemplate
+
+    cluster = DynamicModelMultipleChoiceField(
+        queryset=Cluster.objects.all(),
+        required=False,
+        label=_("Cluster"),
+    )
+    os_family = forms.MultipleChoiceField(
+        choices=CloudImageOSFamilyChoices,
+        required=False,
+        label=_("OS family"),
+    )
+    allowed_tenants = DynamicModelMultipleChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Allowed tenants"),
+    )
+    is_active = forms.NullBooleanField(
+        required=False,
+        widget=forms.Select(
+            choices=[("", "---------"), ("true", _("Yes")), ("false", _("No"))],
+        ),
+        label=_("Active"),
+    )

--- a/netbox_proxbox/migrations/0044_cloud_image_template.py
+++ b/netbox_proxbox/migrations/0044_cloud_image_template.py
@@ -1,0 +1,157 @@
+"""Add tenant-scoped cloud image templates for Cloud Portal provisioning."""
+
+from __future__ import annotations
+
+import django.db.models.deletion
+import taggit.managers
+import utilities.json
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("extras", "0134_owner"),
+        ("netbox_proxbox", "0043_pluginsettings_warn_plaintext"),
+        ("tenancy", "0023_add_mptt_tree_indexes"),
+        ("virtualization", "0052_gfk_indexes"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CloudImageTemplate",
+            fields=[
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "name",
+                    models.CharField(
+                        help_text="Human-readable cloud image template name.",
+                        max_length=255,
+                        verbose_name="Name",
+                    ),
+                ),
+                (
+                    "slug",
+                    models.SlugField(
+                        help_text="Unique slug used by API clients and automation.",
+                        max_length=255,
+                        unique=True,
+                        verbose_name="Slug",
+                    ),
+                ),
+                (
+                    "description",
+                    models.TextField(
+                        blank=True,
+                        help_text="Optional operator-facing description for this cloud image.",
+                        verbose_name="Description",
+                    ),
+                ),
+                (
+                    "source_vmid",
+                    models.PositiveIntegerField(
+                        help_text="Proxmox VMID of the source cloud-image template.",
+                        verbose_name="Source VMID",
+                    ),
+                ),
+                (
+                    "os_family",
+                    models.CharField(
+                        choices=[
+                            ("ubuntu", "Ubuntu"),
+                            ("debian", "Debian"),
+                            ("rocky", "Rocky Linux"),
+                            ("alpine", "Alpine Linux"),
+                            ("generic", "Generic Linux"),
+                        ],
+                        default="generic",
+                        help_text="Operating-system family represented by this image.",
+                        max_length=32,
+                        verbose_name="OS family",
+                    ),
+                ),
+                (
+                    "os_release",
+                    models.CharField(
+                        blank=True,
+                        help_text="Optional OS release or codename, for example jammy.",
+                        max_length=64,
+                        verbose_name="OS release",
+                    ),
+                ),
+                (
+                    "default_ciuser",
+                    models.CharField(
+                        default="cloud-user",
+                        help_text="Default ciuser value supplied when provisioning from this image.",
+                        max_length=64,
+                        verbose_name="Default cloud-init user",
+                    ),
+                ),
+                (
+                    "is_active",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Inactive templates are hidden from tenant provisioning flows.",
+                        verbose_name="Active",
+                    ),
+                ),
+                (
+                    "allowed_tenants",
+                    models.ManyToManyField(
+                        blank=True,
+                        help_text="Tenants allowed to use this image. Leave empty for all tenants.",
+                        related_name="proxbox_cloud_image_templates",
+                        to="tenancy.tenant",
+                        verbose_name="Allowed tenants",
+                    ),
+                ),
+                (
+                    "cluster",
+                    models.ForeignKey(
+                        help_text="NetBox cluster that contains the Proxmox source template VMID.",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="proxbox_cloud_image_templates",
+                        to="virtualization.cluster",
+                        verbose_name="Cluster",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(
+                        through="extras.TaggedItem",
+                        to="extras.Tag",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Cloud image template",
+                "verbose_name_plural": "Cloud image templates",
+                "ordering": ("cluster", "name", "source_vmid"),
+                "permissions": [
+                    (
+                        "provision_cloud_vm",
+                        "Can provision a VM from a cloud image template",
+                    ),
+                ],
+                "unique_together": {("cluster", "source_vmid")},
+            },
+        ),
+    ]

--- a/netbox_proxbox/models/__init__.py
+++ b/netbox_proxbox/models/__init__.py
@@ -3,6 +3,7 @@
 from netbox_proxbox.models.apply_job import ProxmoxApplyJob
 from netbox_proxbox.models.backup_routine import BackupRoutine
 from netbox_proxbox.models.base import PORT_VALIDATORS, CommonProperties, EndpointBase
+from netbox_proxbox.models.cloud_image_template import CloudImageTemplate
 from netbox_proxbox.models.deletion_request import DeletionRequest
 from netbox_proxbox.models.fastapi_endpoint import FastAPIEndpoint
 from netbox_proxbox.models.netbox_endpoint import NetBoxEndpoint
@@ -20,6 +21,7 @@ from netbox_proxbox.models.vm_task_history import VMTaskHistory
 
 __all__ = (
     "BackupRoutine",
+    "CloudImageTemplate",
     "DeletionRequest",
     "FastAPIEndpoint",
     "NetBoxEndpoint",

--- a/netbox_proxbox/models/cloud_image_template.py
+++ b/netbox_proxbox/models/cloud_image_template.py
@@ -1,0 +1,105 @@
+"""Cloud image templates exposed to Cloud Portal tenants for VM provisioning."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from netbox.models import NetBoxModel
+
+from netbox_proxbox.choices import CloudImageOSFamilyChoices
+
+
+class CloudImageTemplate(NetBoxModel):
+    """Catalog entry mapping a tenant-visible cloud image to a Proxmox VM template."""
+
+    name = models.CharField(
+        max_length=255,
+        verbose_name=_("Name"),
+        help_text=_("Human-readable cloud image template name."),
+    )
+    slug = models.SlugField(
+        max_length=255,
+        unique=True,
+        verbose_name=_("Slug"),
+        help_text=_("Unique slug used by API clients and automation."),
+    )
+    description = models.TextField(
+        blank=True,
+        verbose_name=_("Description"),
+        help_text=_("Optional operator-facing description for this cloud image."),
+    )
+    cluster = models.ForeignKey(
+        to="virtualization.Cluster",
+        on_delete=models.CASCADE,
+        related_name="proxbox_cloud_image_templates",
+        verbose_name=_("Cluster"),
+        help_text=_("NetBox cluster that contains the Proxmox source template VMID."),
+    )
+    source_vmid = models.PositiveIntegerField(
+        verbose_name=_("Source VMID"),
+        help_text=_("Proxmox VMID of the source cloud-image template."),
+    )
+    os_family = models.CharField(
+        max_length=32,
+        choices=CloudImageOSFamilyChoices,
+        default=CloudImageOSFamilyChoices.GENERIC,
+        verbose_name=_("OS family"),
+        help_text=_("Operating-system family represented by this image."),
+    )
+    os_release = models.CharField(
+        max_length=64,
+        blank=True,
+        verbose_name=_("OS release"),
+        help_text=_("Optional OS release or codename, for example jammy."),
+    )
+    default_ciuser = models.CharField(
+        max_length=64,
+        default="cloud-user",
+        verbose_name=_("Default cloud-init user"),
+        help_text=_("Default ciuser value supplied when provisioning from this image."),
+    )
+    allowed_tenants = models.ManyToManyField(
+        to="tenancy.Tenant",
+        blank=True,
+        related_name="proxbox_cloud_image_templates",
+        verbose_name=_("Allowed tenants"),
+        help_text=_("Tenants allowed to use this image. Leave empty for all tenants."),
+    )
+    is_active = models.BooleanField(
+        default=True,
+        verbose_name=_("Active"),
+        help_text=_("Inactive templates are hidden from tenant provisioning flows."),
+    )
+
+    class Meta:
+        ordering = ("cluster", "name", "source_vmid")
+        unique_together = ("cluster", "source_vmid")
+        verbose_name = _("Cloud image template")
+        verbose_name_plural = _("Cloud image templates")
+        permissions = [
+            (
+                "provision_cloud_vm",
+                _("Can provision a VM from a cloud image template"),
+            ),
+        ]
+
+    def __str__(self) -> str:
+        release = f" {self.os_release}" if self.os_release else ""
+        return f"{self.name} ({self.os_family}{release})"
+
+    def get_absolute_url(self) -> str:
+        """Plugin UI URL for this cloud image template detail view."""
+        return reverse("plugins:netbox_proxbox:cloudimagetemplate", args=[self.pk])
+
+    @property
+    def tenant_scope_label(self) -> str:
+        """Readable scope for templates where an empty tenant set means all tenants."""
+        if not getattr(self, "pk", None):
+            return "All tenants"
+        tenants = list(self.allowed_tenants.all()[:4])
+        if not tenants:
+            return "All tenants"
+        names = ", ".join(str(tenant) for tenant in tenants)
+        total = self.allowed_tenants.count()
+        return f"{names} (+{total - 4} more)" if total > 4 else names

--- a/netbox_proxbox/navigation.py
+++ b/netbox_proxbox/navigation.py
@@ -114,6 +114,18 @@ vm_cloudinit_item = PluginMenuItem(
     link_text="VM Cloud-init",
 )
 
+cloud_images_item = PluginMenuItem(
+    link="plugins:netbox_proxbox:cloudimagetemplate_list",
+    link_text="Cloud Images",
+    buttons=(
+        PluginMenuButton(
+            "plugins:netbox_proxbox:cloudimagetemplate_add",
+            "Add Cloud Image",
+            "mdi mdi-plus",
+        ),
+    ),
+)
+
 contributing_item = PluginMenuItem(
     link="plugins:netbox_proxbox:contributing",
     link_text="Contributing!",
@@ -219,6 +231,7 @@ menu = PluginMenu(
                 interfaces_item,
                 ip_addresses_item,
                 vm_cloudinit_item,
+                cloud_images_item,
             ),
         ),
         (

--- a/netbox_proxbox/tables/__init__.py
+++ b/netbox_proxbox/tables/__init__.py
@@ -17,6 +17,7 @@ from netbox_proxbox.models import (
     ProxmoxEndpoint,
 )
 from netbox_proxbox.tables.backup_routine import BackupRoutineTable
+from netbox_proxbox.tables.cloud_image_template import CloudImageTemplateTable
 from netbox_proxbox.tables.cluster import ProxmoxClusterTable, ProxmoxNodeTable
 from netbox_proxbox.tables.deletion_requests import DeletionRequestTable
 from netbox_proxbox.tables.replication import ReplicationTable

--- a/netbox_proxbox/tables/cloud_image_template.py
+++ b/netbox_proxbox/tables/cloud_image_template.py
@@ -1,0 +1,47 @@
+"""Define the NetBox table used to render cloud image templates."""
+
+import django_tables2 as tables
+from django.utils.translation import gettext as _
+from netbox.tables import ChoiceFieldColumn, NetBoxTable
+from netbox.tables.columns import BooleanColumn
+
+from netbox_proxbox.models import CloudImageTemplate
+
+
+class CloudImageTemplateTable(NetBoxTable):
+    """django-tables2 layout for CloudImageTemplate list views."""
+
+    name = tables.Column(linkify=True, verbose_name=_("Name"))
+    cluster = tables.Column(linkify=True, verbose_name=_("Cluster"))
+    os_family = ChoiceFieldColumn(verbose_name=_("OS family"))
+    is_active = BooleanColumn(verbose_name=_("Active"))
+    tenant_scope_label = tables.Column(
+        orderable=False,
+        verbose_name=_("Tenant scope"),
+    )
+
+    class Meta(NetBoxTable.Meta):
+        model = CloudImageTemplate
+        fields = (
+            "pk",
+            "id",
+            "name",
+            "slug",
+            "cluster",
+            "source_vmid",
+            "os_family",
+            "os_release",
+            "default_ciuser",
+            "tenant_scope_label",
+            "is_active",
+        )
+        default_columns = (
+            "pk",
+            "name",
+            "cluster",
+            "source_vmid",
+            "os_family",
+            "os_release",
+            "tenant_scope_label",
+            "is_active",
+        )

--- a/netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate.html
+++ b/netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate.html
@@ -1,0 +1,96 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Cloud Image" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Name" %}</th>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Slug" %}</th>
+            <td>{{ object.slug }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Description" %}</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Active" %}</th>
+            <td>
+              {% if object.is_active %}
+                <span class="text-success"><i class="mdi mdi-check"></i> {% trans "Yes" %}</span>
+              {% else %}
+                <span class="text-danger"><i class="mdi mdi-close"></i> {% trans "No" %}</span>
+              {% endif %}
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Source Template" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Cluster" %}</th>
+            <td>{{ object.cluster|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Source VMID" %}</th>
+            <td>{{ object.source_vmid }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="col col-md-6">
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Cloud-Init Defaults" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "OS family" %}</th>
+            <td>{{ object.get_os_family_display }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "OS release" %}</th>
+            <td>{{ object.os_release|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Default user" %}</th>
+            <td>{{ object.default_ciuser }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Tenant Scope" %}</h5>
+      <div class="card-body">
+        {% if object.allowed_tenants.exists %}
+          <ul class="list-unstyled mb-0">
+            {% for tenant in object.allowed_tenants.all %}
+              <li>{{ tenant|linkify }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <span class="text-muted">{% trans "All tenants" %}</span>
+        {% endif %}
+      </div>
+    </div>
+
+    {% include 'inc/panels/tags.html' %}
+    {% include 'inc/panels/comments.html' %}
+    {% include 'inc/panels/custom_fields.html' %}
+  </div>
+</div>
+{% endblock %}

--- a/netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate_list.html
+++ b/netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate_list.html
@@ -1,0 +1,21 @@
+{% extends 'generic/object_list.html' %}
+{% load buttons %}
+{% load i18n %}
+
+{% block controls %}
+  <div class="btn-group" role="group">
+    <a href="{% url 'plugins:netbox_proxbox:cloudimagetemplate_add' %}" class="btn btn-primary">
+      <i class="mdi mdi-plus" aria-hidden="true"></i> {% trans "Add Cloud Image" %}
+    </a>
+  </div>
+{% endblock %}
+
+{% block bulk_buttons %}
+  <div class="btn-group" role="group">
+    {% if 'bulk_delete' in actions %}
+      <button type="submit" name="_delete" {% formaction %}="{% url 'plugins:netbox_proxbox:cloudimagetemplate_bulk_delete' %}" class="btn btn-danger">
+        <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> {% trans "Delete Selected" %}
+      </button>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/netbox_proxbox/urls.py
+++ b/netbox_proxbox/urls.py
@@ -97,6 +97,14 @@ urlpatterns = [
         include(get_model_urls("netbox_proxbox", "backuproutine", detail=False)),
     ),
     path(
+        "cloud-image-templates/<int:pk>/",
+        include(get_model_urls("netbox_proxbox", "cloudimagetemplate")),
+    ),
+    path(
+        "cloud-image-templates/",
+        include(get_model_urls("netbox_proxbox", "cloudimagetemplate", detail=False)),
+    ),
+    path(
         "replications/<int:pk>/",
         include(get_model_urls("netbox_proxbox", "replication")),
     ),
@@ -126,6 +134,16 @@ urlpatterns = [
     path(
         "vm-cloudinit/",
         include(get_model_urls("netbox_proxbox", "proxmoxvmcloudinit", detail=False)),
+    ),
+    path(
+        "cloud-image-templates/<int:pk>/",
+        include(get_model_urls("netbox_proxbox", "cloudimagetemplate")),
+    ),
+    path(
+        "cloud-image-templates/",
+        include(
+            get_model_urls("netbox_proxbox", "cloudimagetemplate", detail=False),
+        ),
     ),
     path("sync/devices/", views.sync_devices, name="sync_devices"),
     path("sync/storage/", views.sync_storage, name="sync_storage"),

--- a/netbox_proxbox/views/__init__.py
+++ b/netbox_proxbox/views/__init__.py
@@ -29,6 +29,13 @@ from .backup_routine import (
     BackupRoutineView,
 )
 from .cards import get_proxmox_card
+from .cloud_image_templates import (
+    CloudImageTemplateBulkDeleteView,
+    CloudImageTemplateDeleteView,
+    CloudImageTemplateEditView,
+    CloudImageTemplateListView,
+    CloudImageTemplateView,
+)
 from .cluster import (
     ClusterStoragesTabView,
     ClusterSummaryTabView,

--- a/netbox_proxbox/views/cloud_image_templates.py
+++ b/netbox_proxbox/views/cloud_image_templates.py
@@ -1,0 +1,74 @@
+"""Provide NetBox CRUD views for the Cloud Portal cloud image template catalog."""
+
+from netbox.views import generic
+from utilities.views import register_model_view
+
+from netbox_proxbox.filtersets import CloudImageTemplateFilterSet
+from netbox_proxbox.forms import CloudImageTemplateFilterForm, CloudImageTemplateForm
+from netbox_proxbox.models import CloudImageTemplate
+from netbox_proxbox.tables import CloudImageTemplateTable
+
+
+__all__ = (
+    "CloudImageTemplateView",
+    "CloudImageTemplateListView",
+    "CloudImageTemplateEditView",
+    "CloudImageTemplateDeleteView",
+    "CloudImageTemplateBulkDeleteView",
+)
+
+
+@register_model_view(CloudImageTemplate, "list", path="", detail=False)
+class CloudImageTemplateListView(generic.ObjectListView):
+    """Global list of cloud image templates with export and bulk delete actions."""
+
+    queryset = CloudImageTemplate.objects.select_related("cluster").prefetch_related(
+        "allowed_tenants", "tags"
+    )
+    table = CloudImageTemplateTable
+    filterset = CloudImageTemplateFilterSet
+    filterset_form = CloudImageTemplateFilterForm
+    template_name = "netbox_proxbox/cloudimagetemplate_list.html"
+    actions = {
+        "add": {"add"},
+        "bulk_delete": {"delete"},
+        "export": {"view"},
+    }
+
+
+@register_model_view(CloudImageTemplate)
+class CloudImageTemplateView(generic.ObjectView):
+    """Detail view for a single cloud image template with tenant scope and source VMID."""
+
+    queryset = CloudImageTemplate.objects.select_related("cluster").prefetch_related(
+        "allowed_tenants", "tags"
+    )
+    template_name = "netbox_proxbox/cloudimagetemplate.html"
+
+
+@register_model_view(CloudImageTemplate, "add", detail=False)
+@register_model_view(CloudImageTemplate, "edit")
+class CloudImageTemplateEditView(generic.ObjectEditView):
+    """Create or edit a cloud image template entry."""
+
+    queryset = CloudImageTemplate.objects.all()
+    form = CloudImageTemplateForm
+    default_return_url = "plugins:netbox_proxbox:cloudimagetemplate_list"
+
+
+@register_model_view(CloudImageTemplate, "delete")
+class CloudImageTemplateDeleteView(generic.ObjectDeleteView):
+    """Delete a single cloud image template entry."""
+
+    queryset = CloudImageTemplate.objects.all()
+    default_return_url = "plugins:netbox_proxbox:cloudimagetemplate_list"
+
+
+@register_model_view(CloudImageTemplate, "bulk_delete", detail=False)
+class CloudImageTemplateBulkDeleteView(generic.BulkDeleteView):
+    """Bulk delete cloud image templates from the global list."""
+
+    queryset = CloudImageTemplate.objects.select_related("cluster")
+    filterset = CloudImageTemplateFilterSet
+    table = CloudImageTemplateTable
+    default_return_url = "plugins:netbox_proxbox:cloudimagetemplate_list"

--- a/tests/test_api_source_contracts.py
+++ b/tests/test_api_source_contracts.py
@@ -525,6 +525,7 @@ def test_plugin_api_routes_register_all_plugin_objects():
     assert set(endpoint_registers) == {"proxmox", "netbox", "fastapi"}
     assert set(root_registers) == {
         "backup-routines",
+        "cloud-image-templates",
         "proxmox-clusters",
         "proxmox-nodes",
         "replications",

--- a/tests/test_cloud_image_template.py
+++ b/tests/test_cloud_image_template.py
@@ -1,0 +1,81 @@
+"""Source contracts for CloudImageTemplate catalog support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text()
+
+
+def test_cloud_image_template_model_defines_catalog_fields_and_permission():
+    src = _read("netbox_proxbox/models/cloud_image_template.py")
+    assert "class CloudImageTemplate(NetBoxModel)" in src
+    for field in (
+        "name",
+        "slug",
+        "description",
+        "cluster",
+        "source_vmid",
+        "os_family",
+        "os_release",
+        "default_ciuser",
+        "allowed_tenants",
+        "is_active",
+    ):
+        assert field in src
+    assert '"provision_cloud_vm"' in src
+    assert 'unique_together = ("cluster", "source_vmid")' in src
+    assert "tenancy.Tenant" in src
+    assert "virtualization.Cluster" in src
+
+
+def test_cloud_image_template_migration_exists_on_current_develop_head():
+    src = _read("netbox_proxbox/migrations/0044_cloud_image_template.py")
+    assert '("netbox_proxbox", "0043_pluginsettings_warn_plaintext")' in src
+    assert 'name="CloudImageTemplate"' in src
+    assert '"provision_cloud_vm"' in src
+    assert '"unique_together": {("cluster", "source_vmid")}' in src
+
+
+def test_cloud_image_template_ui_surface_is_registered():
+    urls = _read("netbox_proxbox/urls.py")
+    views = _read("netbox_proxbox/views/cloud_image_templates.py")
+    nav = _read("netbox_proxbox/navigation.py")
+
+    assert '"cloud-image-templates/<int:pk>/"' in urls
+    assert 'get_model_urls("netbox_proxbox", "cloudimagetemplate")' in urls
+    assert "@register_model_view(CloudImageTemplate)" in views
+    assert '@register_model_view(CloudImageTemplate, "add", detail=False)' in views
+    assert "CloudImageTemplateTable" in views
+    assert "cloudimagetemplate_list" in nav
+    assert "cloudimagetemplate_add" in nav
+
+
+def test_cloud_image_template_api_surface_is_registered():
+    urls = _read("netbox_proxbox/api/urls.py")
+    views = _read("netbox_proxbox/api/views.py")
+    serializer = _read("netbox_proxbox/api/serializers/cloud_image_template.py")
+    filtersets = _read("netbox_proxbox/filtersets.py")
+
+    assert '"cloud-image-templates"' in urls
+    assert "CloudImageTemplateViewSet" in views
+    assert "CloudImageTemplateSerializer" in serializer
+    assert "NestedCloudImageTemplateSerializer" in serializer
+    assert "allowed_tenants__id__in" in filtersets
+    assert "allowed_tenants__isnull" in filtersets
+
+
+def test_cloud_image_template_templates_exist():
+    detail = REPO_ROOT / "netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate.html"
+    listing = (
+        REPO_ROOT
+        / "netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate_list.html"
+    )
+    assert detail.exists()
+    assert listing.exists()
+    assert "Tenant Scope" in detail.read_text()
+    assert "Add Cloud Image" in listing.read_text()

--- a/tests/test_cloud_image_template.py
+++ b/tests/test_cloud_image_template.py
@@ -70,7 +70,9 @@ def test_cloud_image_template_api_surface_is_registered():
 
 
 def test_cloud_image_template_templates_exist():
-    detail = REPO_ROOT / "netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate.html"
+    detail = (
+        REPO_ROOT / "netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate.html"
+    )
     listing = (
         REPO_ROOT
         / "netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate_list.html"


### PR DESCRIPTION
## Summary

Adds the **`CloudImageTemplate`** NetBox model that anchors the Cloud-Init
Support flow (issue [N-MultiCloud/nms#12](https://github.com/N-MultiCloud/nms/issues/12)).

- New model `netbox_proxbox.CloudImageTemplate` with fields: `name`, `slug`,
  `description`, `cluster` (FK `virtualization.Cluster`), `source_vmid`,
  `os_family`, `os_release`, `default_ciuser`, `allowed_tenants` (M2M
  `tenancy.Tenant`; empty = visible to every tenant), `is_active`, `tags`.
  Unique together: `(cluster, source_vmid)`.
- Custom permission `("provision_cloud_vm", "Can provision a VM from a cloud
  image template")` on `Meta.permissions`. netbox-nms's
  `seed_cloud_portal_groups` grants this per-tenant alongside `view`.
- Migration `0044_cloud_image_template` includes the `tags` TaggableManager
  and `CustomFieldJSONEncoder` on `custom_field_data` per NetBoxModel
  conventions.

## Test plan

- [x] `pytest tests/test_cloud_image_template.py` — 5/5 contract tests passing
- [x] `pytest tests/api/test_views.py` — 32/32 source contract tests passing
- [x] `ruff check netbox_proxbox/` — clean
- [x] `/opt/netbox/venv/bin/python3 manage.py makemigrations netbox_proxbox --check --dry-run` — no drift
- [ ] CI lint + unit matrix green
