### PR TITLE
feat(proxmox-endpoint): add operator-selected environment field

### DIFF
--- a/netbox_proxbox/api/serializers/endpoints.py
+++ b/netbox_proxbox/api/serializers/endpoints.py
@@ -12,7 +12,11 @@ from tenancy.api.serializers_.tenants import TenantSerializer
 from rest_framework import serializers
 from users.models import Token
 
-from netbox_proxbox.choices import NetBoxTokenVersionChoices, ProxmoxModeChoices
+from netbox_proxbox.choices import (
+    NetBoxTokenVersionChoices,
+    ProxmoxEndpointEnvironmentChoices,
+    ProxmoxModeChoices,
+)
 from netbox_proxbox.constants import OVERWRITE_FIELDS
 from netbox_proxbox.models import FastAPIEndpoint, NetBoxEndpoint, ProxmoxEndpoint
 
@@ -35,6 +39,12 @@ class ProxmoxEndpointSerializer(NetBoxModelSerializer):
     ip_address = NestedIPAddressSerializer(required=False, allow_null=True)
     domain = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     mode = ChoiceField(choices=ProxmoxModeChoices)
+    environment = ChoiceField(
+        choices=ProxmoxEndpointEnvironmentChoices,
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+    )
     site = SiteSerializer(nested=True, required=False, allow_null=True)
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
 
@@ -49,6 +59,7 @@ class ProxmoxEndpointSerializer(NetBoxModelSerializer):
             "domain",
             "port",
             "mode",
+            "environment",
             "version",
             "repoid",
             "username",

--- a/netbox_proxbox/choices.py
+++ b/netbox_proxbox/choices.py
@@ -20,6 +20,31 @@ class ProxmoxModeChoices(ChoiceSet):
     ]
 
 
+class ProxmoxEndpointEnvironmentChoices(ChoiceSet):
+    """Operator-selected lifecycle stage for a Proxmox endpoint.
+
+    Manual classification only; never written by sync. Blank is a valid value.
+    """
+
+    key = "ProxmoxEndpoint.environment"
+
+    PRODUCTION = "production"
+    STAGING = "staging"
+    DEVELOPMENT = "development"
+    HOMOLOGATION = "homologation"
+    TESTING = "testing"
+    LAB = "lab"
+
+    CHOICES = [
+        (PRODUCTION, _("Production"), "red"),
+        (STAGING, _("Staging"), "orange"),
+        (DEVELOPMENT, _("Development"), "blue"),
+        (HOMOLOGATION, _("Homologation"), "purple"),
+        (TESTING, _("Testing"), "yellow"),
+        (LAB, _("Lab"), "gray"),
+    ]
+
+
 class SyncTypeChoices(ChoiceSet):
     """Which ProxBox sync operation to run (devices, VMs, backups, full, etc.)."""
 

--- a/netbox_proxbox/filtersets.py
+++ b/netbox_proxbox/filtersets.py
@@ -127,7 +127,16 @@ class ProxmoxEndpointFilterSet(ProxboxModelFilterSet):
 
     class Meta:
         model = ProxmoxEndpoint
-        fields = ("id", "name", "domain", "ip_address", "mode", "site", "tenant")
+        fields = (
+            "id",
+            "name",
+            "domain",
+            "ip_address",
+            "mode",
+            "environment",
+            "site",
+            "tenant",
+        )
 
     def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
         """Match the search term against endpoint name or domain."""

--- a/netbox_proxbox/forms/proxmox.py
+++ b/netbox_proxbox/forms/proxmox.py
@@ -21,7 +21,7 @@ from django.utils.translation import gettext as _
 # Proxbox Imports
 from ..constants import OVERWRITE_FIELDS
 from ..models import ProxmoxEndpoint
-from ..choices import ProxmoxModeChoices
+from ..choices import ProxmoxEndpointEnvironmentChoices, ProxmoxModeChoices
 from .settings import _parse_tenant_regex_rules
 
 from .import_utils import validate_endpoint_import_headers
@@ -131,6 +131,7 @@ class ProxmoxEndpointForm(NetBoxModelForm):
             "token_name",
             "token_value",
             "verify_ssl",
+            "environment",
             "site",
             "tenant",
             "tags",
@@ -301,6 +302,9 @@ class ProxmoxEndpointFilterForm(NetBoxModelFilterSetForm):
         queryset=IPAddress.objects.all(), required=False, help_text="Select IP Address"
     )
     mode = forms.MultipleChoiceField(choices=ProxmoxModeChoices, required=False)
+    environment = forms.MultipleChoiceField(
+        choices=ProxmoxEndpointEnvironmentChoices, required=False
+    )
     site = DynamicModelMultipleChoiceField(
         queryset=Site.objects.all(),
         required=False,
@@ -323,6 +327,9 @@ class ProxmoxEndpointImportForm(NetBoxModelImportForm):
         ),
     )
     mode = CSVChoiceField(choices=ProxmoxModeChoices, required=False)
+    environment = CSVChoiceField(
+        choices=ProxmoxEndpointEnvironmentChoices, required=False
+    )
     site = CSVModelChoiceField(
         queryset=Site.objects.all(),
         to_field_name="slug",
@@ -344,6 +351,7 @@ class ProxmoxEndpointImportForm(NetBoxModelImportForm):
             "ip_address",
             "port",
             "mode",
+            "environment",
             "version",
             "repoid",
             "username",

--- a/netbox_proxbox/migrations/0045_proxmoxendpoint_environment.py
+++ b/netbox_proxbox/migrations/0045_proxmoxendpoint_environment.py
@@ -1,0 +1,37 @@
+"""Add operator-selected environment field to ProxmoxEndpoint."""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netbox_proxbox", "0044_cloud_image_template"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="proxmoxendpoint",
+            name="environment",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("production", "Production"),
+                    ("staging", "Staging"),
+                    ("development", "Development"),
+                    ("homologation", "Homologation"),
+                    ("testing", "Testing"),
+                    ("lab", "Lab"),
+                ],
+                help_text=(
+                    "Operator-selected lifecycle stage (e.g. production, development, "
+                    "homologation). Manual classification only; never written by sync."
+                ),
+                max_length=32,
+                null=True,
+                verbose_name="Environment",
+            ),
+        ),
+    ]

--- a/netbox_proxbox/models/proxmox_endpoint.py
+++ b/netbox_proxbox/models/proxmox_endpoint.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from netbox_proxbox.choices import ProxmoxModeChoices
+from netbox_proxbox.choices import ProxmoxEndpointEnvironmentChoices, ProxmoxModeChoices
 from netbox_proxbox.constants import OVERWRITE_FIELDS
 from netbox_proxbox.fields import DomainField
 from netbox_proxbox.models.base import PORT_VALIDATORS, EndpointBase
@@ -48,6 +48,17 @@ class ProxmoxEndpoint(EndpointBase):
         max_length=255,
         choices=ProxmoxModeChoices,
         default=ProxmoxModeChoices.PROXMOX_MODE_UNDEFINED,
+    )
+    environment = models.CharField(
+        max_length=32,
+        choices=ProxmoxEndpointEnvironmentChoices,
+        blank=True,
+        null=True,
+        verbose_name=_("Environment"),
+        help_text=_(
+            "Operator-selected lifecycle stage (e.g. production, development, "
+            "homologation). Manual classification only; never written by sync."
+        ),
     )
     version = models.CharField(max_length=20, blank=True, null=True)
     repoid = models.CharField(

--- a/netbox_proxbox/tables/__init__.py
+++ b/netbox_proxbox/tables/__init__.py
@@ -43,6 +43,7 @@ class ProxmoxEndpointTable(NetBoxTable):
     site = tables.Column(linkify=True)
     tenant = tables.Column(linkify=True)
     mode = ChoiceFieldColumn()
+    environment = ChoiceFieldColumn()
     verify_ssl = BooleanColumn()
     status = tables.TemplateColumn(
         template_code=STATUS_BADGE_TEMPLATE.replace("{{ service }}", "proxmox"),
@@ -60,6 +61,7 @@ class ProxmoxEndpointTable(NetBoxTable):
             "ip_address",
             "port",
             "mode",
+            "environment",
             "version",
             "repoid",
             "username",
@@ -81,6 +83,7 @@ class ProxmoxEndpointTable(NetBoxTable):
             "ip_address",
             "port",
             "mode",
+            "environment",
             "version",
             "status",
             "verify_ssl",

--- a/netbox_proxbox/templates/netbox_proxbox/proxmoxendpoint.html
+++ b/netbox_proxbox/templates/netbox_proxbox/proxmoxendpoint.html
@@ -71,6 +71,26 @@
                             </td>
                         </tr>
                         <tr>
+                            <th scope="row">Environment</th>
+                            <td>
+                                {% if object.environment == 'production' %}
+                                    <span class="badge text-bg-danger">Production</span>
+                                {% elif object.environment == 'staging' %}
+                                    <span class="badge text-bg-warning">Staging</span>
+                                {% elif object.environment == 'development' %}
+                                    <span class="badge text-bg-info">Development</span>
+                                {% elif object.environment == 'homologation' %}
+                                    <span class="badge text-bg-purple">Homologation</span>
+                                {% elif object.environment == 'testing' %}
+                                    <span class="badge text-bg-warning">Testing</span>
+                                {% elif object.environment == 'lab' %}
+                                    <span class="badge text-bg-secondary">Lab</span>
+                                {% else %}
+                                    <span class="text-muted">&mdash;</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        <tr>
                             <th scope="row">Target</th>
                             <td>
                                 <span id="proxmox-target-{{ object.pk }}">Loading...</span>

--- a/tests/test_proxmox_endpoint_environment.py
+++ b/tests/test_proxmox_endpoint_environment.py
@@ -1,0 +1,318 @@
+"""Source contracts for the ProxmoxEndpoint.environment field (#438).
+
+These pin the operator-selected lifecycle stage that issue #438 added to
+``ProxmoxEndpoint``. The field is manual classification only; sync paths must
+never write it. The tests run via ``ast.parse`` so they do not require a live
+Django/NetBox bootstrap.
+
+Pinned wiring:
+- The ``ProxmoxEndpointEnvironmentChoices`` choice set exists with the agreed
+  slugs and is keyed for plugin admin override (``ProxmoxEndpoint.environment``).
+- The ``environment`` model field is a nullable ``CharField`` with
+  ``blank=True`` so the field is optional in forms and admin.
+- A new ``0045_proxmoxendpoint_environment`` additive migration registers the
+  column on top of ``0044_cloud_image_template``.
+- The form, filterset, table, serializer, and template all surface the new
+  field next to ``mode``.
+- The plugin's sync paths never overwrite the field (regex grep over the
+  ``netbox_proxbox/services`` and ``netbox_proxbox/proxmox_to_netbox``-style
+  source trees).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_ROOT = REPO_ROOT / "netbox_proxbox"
+
+CHOICES_PATH = PLUGIN_ROOT / "choices.py"
+MODEL_PATH = PLUGIN_ROOT / "models" / "proxmox_endpoint.py"
+MIGRATION_PATH = PLUGIN_ROOT / "migrations" / "0045_proxmoxendpoint_environment.py"
+FORM_PATH = PLUGIN_ROOT / "forms" / "proxmox.py"
+FILTERSET_PATH = PLUGIN_ROOT / "filtersets.py"
+TABLE_PATH = PLUGIN_ROOT / "tables" / "__init__.py"
+SERIALIZER_PATH = PLUGIN_ROOT / "api" / "serializers" / "endpoints.py"
+TEMPLATE_PATH = (
+    PLUGIN_ROOT / "templates" / "netbox_proxbox" / "proxmoxendpoint.html"
+)
+
+EXPECTED_SLUGS = {
+    "production",
+    "staging",
+    "development",
+    "homologation",
+    "testing",
+    "lab",
+}
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text())
+
+
+def _find_class(module: ast.Module, name: str) -> ast.ClassDef:
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"Class {name!r} not found in {module}")
+
+
+def _class_assign(cls: ast.ClassDef, name: str) -> ast.AST:
+    for node in cls.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return node.value
+    raise AssertionError(f"Assignment {name!r} not found in class {cls.name}")
+
+
+def _meta_fields(cls: ast.ClassDef) -> str:
+    for node in cls.body:
+        if isinstance(node, ast.ClassDef) and node.name == "Meta":
+            for stmt in node.body:
+                if isinstance(stmt, ast.Assign) and any(
+                    isinstance(t, ast.Name) and t.id == "fields" for t in stmt.targets
+                ):
+                    return ast.unparse(stmt.value)
+    raise AssertionError(f"Meta.fields not found on class {cls.name}")
+
+
+# ---------------------------------------------------------------------------
+# Choice set
+# ---------------------------------------------------------------------------
+
+
+def test_environment_choice_set_exists_with_expected_slugs() -> None:
+    """The choice set must enumerate the agreed lifecycle slugs.
+
+    Slugs may be referenced through class-level constants (e.g. ``PRODUCTION``),
+    so collect the string assignments on the class and compare the resulting
+    set of slug values to the expected set.
+    """
+    cls = _find_class(_parse(CHOICES_PATH), "ProxmoxEndpointEnvironmentChoices")
+    slug_constants: dict[str, str] = {}
+    for node in cls.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)
+                    and target.id != "key"
+                ):
+                    slug_constants[target.id] = node.value.value
+    declared_slugs = set(slug_constants.values())
+    assert EXPECTED_SLUGS.issubset(declared_slugs), (
+        f"Choice set missing slugs: {EXPECTED_SLUGS - declared_slugs}"
+    )
+
+
+def test_environment_choice_set_uses_admin_override_key() -> None:
+    """The choice set must declare the NetBox admin-override key."""
+    cls = _find_class(_parse(CHOICES_PATH), "ProxmoxEndpointEnvironmentChoices")
+    key = _class_assign(cls, "key")
+    assert isinstance(key, ast.Constant) and key.value == "ProxmoxEndpoint.environment"
+
+
+# ---------------------------------------------------------------------------
+# Model field
+# ---------------------------------------------------------------------------
+
+
+def test_environment_field_is_optional_charfield() -> None:
+    """``environment`` must be a nullable, blank=True CharField with choices."""
+    src = MODEL_PATH.read_text()
+    assert "environment = models.CharField(" in src
+    block = src.split("environment = models.CharField(", 1)[1].split(")", 1)[0]
+    assert "blank=True" in block
+    assert "null=True" in block
+    assert "choices=ProxmoxEndpointEnvironmentChoices" in block
+    assert "max_length=32" in block
+
+
+def test_environment_field_imported_in_model() -> None:
+    """The model module must import the new choice class."""
+    src = MODEL_PATH.read_text()
+    assert "ProxmoxEndpointEnvironmentChoices" in src
+    assert "from netbox_proxbox.choices import" in src
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+
+def test_migration_exists_and_chains_after_0044() -> None:
+    """0045 must depend on 0044 and add the environment column additively."""
+    assert MIGRATION_PATH.exists(), (
+        "Migration 0045_proxmoxendpoint_environment.py is missing"
+    )
+    src = MIGRATION_PATH.read_text()
+    assert '("netbox_proxbox", "0044_cloud_image_template")' in src
+    assert "migrations.AddField(" in src
+    assert 'name="environment"' in src
+    assert "model_name=\"proxmoxendpoint\"" in src
+    assert "blank=True" in src
+    assert "null=True" in src
+
+
+def test_migration_uses_plain_addfield_not_separate_state() -> None:
+    """A brand-new column does not need SeparateDatabaseAndState gymnastics."""
+    src = MIGRATION_PATH.read_text()
+    assert "SeparateDatabaseAndState" not in src
+    assert "RunSQL" not in src
+
+
+# ---------------------------------------------------------------------------
+# Forms
+# ---------------------------------------------------------------------------
+
+
+def test_environment_in_edit_form_meta_fields() -> None:
+    """``ProxmoxEndpointForm.Meta.fields`` must include ``environment``."""
+    cls = _find_class(_parse(FORM_PATH), "ProxmoxEndpointForm")
+    assert "'environment'" in _meta_fields(cls) or '"environment"' in _meta_fields(cls)
+
+
+def test_environment_filter_form_field_exists() -> None:
+    """``ProxmoxEndpointFilterForm`` must expose ``environment`` as a multi-choice filter."""
+    src = FORM_PATH.read_text()
+    assert "environment = forms.MultipleChoiceField(" in src
+    assert "ProxmoxEndpointEnvironmentChoices" in src
+
+
+def test_environment_in_import_form_meta_fields() -> None:
+    """``ProxmoxEndpointImportForm`` must accept ``environment`` from CSV."""
+    cls = _find_class(_parse(FORM_PATH), "ProxmoxEndpointImportForm")
+    assert "'environment'" in _meta_fields(cls) or '"environment"' in _meta_fields(cls)
+    assert "environment = CSVChoiceField(" in FORM_PATH.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Filterset
+# ---------------------------------------------------------------------------
+
+
+def test_environment_in_filterset_meta_fields() -> None:
+    """``ProxmoxEndpointFilterSet.Meta.fields`` must include ``environment``."""
+    cls = _find_class(_parse(FILTERSET_PATH), "ProxmoxEndpointFilterSet")
+    rendered = _meta_fields(cls)
+    assert "'environment'" in rendered or '"environment"' in rendered
+
+
+# ---------------------------------------------------------------------------
+# Table
+# ---------------------------------------------------------------------------
+
+
+def test_environment_column_and_default_columns() -> None:
+    """``ProxmoxEndpointTable`` must declare an ``environment`` ChoiceFieldColumn
+    and include it in both ``Meta.fields`` and ``Meta.default_columns``."""
+    src = TABLE_PATH.read_text()
+    assert "environment = ChoiceFieldColumn()" in src
+    cls = _find_class(_parse(TABLE_PATH), "ProxmoxEndpointTable")
+    for node in cls.body:
+        if isinstance(node, ast.ClassDef) and node.name == "Meta":
+            fields_seen = False
+            defaults_seen = False
+            for stmt in node.body:
+                if not isinstance(stmt, ast.Assign):
+                    continue
+                target = stmt.targets[0]
+                if not isinstance(target, ast.Name):
+                    continue
+                rendered = ast.unparse(stmt.value)
+                if target.id == "fields":
+                    assert "'environment'" in rendered or '"environment"' in rendered
+                    fields_seen = True
+                if target.id == "default_columns":
+                    assert "'environment'" in rendered or '"environment"' in rendered
+                    defaults_seen = True
+            assert fields_seen and defaults_seen, (
+                "ProxmoxEndpointTable Meta missing environment in fields or default_columns"
+            )
+            return
+    raise AssertionError("ProxmoxEndpointTable.Meta not found")
+
+
+# ---------------------------------------------------------------------------
+# API serializer
+# ---------------------------------------------------------------------------
+
+
+def test_environment_in_api_serializer_meta_fields() -> None:
+    """``ProxmoxEndpointSerializer.Meta.fields`` must include ``environment``
+    and the field must accept blank/null on writes."""
+    src = SERIALIZER_PATH.read_text()
+    assert "environment = ChoiceField(" in src
+    assert "ProxmoxEndpointEnvironmentChoices" in src
+    cls = _find_class(_parse(SERIALIZER_PATH), "ProxmoxEndpointSerializer")
+    rendered = _meta_fields(cls)
+    assert "'environment'" in rendered or '"environment"' in rendered
+    # Permissive on writes — operator may clear it back to blank.
+    serializer_block = src.split("environment = ChoiceField(", 1)[1].split(")", 1)[0]
+    assert "allow_null=True" in serializer_block
+    assert "allow_blank=True" in serializer_block
+    assert "required=False" in serializer_block
+
+
+# ---------------------------------------------------------------------------
+# Template
+# ---------------------------------------------------------------------------
+
+
+def test_environment_template_row_renders_under_mode() -> None:
+    """The detail template must render an Environment row right after Mode."""
+    src = TEMPLATE_PATH.read_text()
+    assert "Environment" in src
+    assert "object.environment" in src
+    mode_idx = src.index('scope="row">Mode<')
+    env_idx = src.index('scope="row">Environment<')
+    assert env_idx > mode_idx, "Environment row must come after Mode row"
+
+
+# ---------------------------------------------------------------------------
+# Sync invariant — environment is operator-only, never written by sync
+# ---------------------------------------------------------------------------
+
+
+SYNC_DIRS = (
+    PLUGIN_ROOT / "services",
+    PLUGIN_ROOT / "schemas",
+    PLUGIN_ROOT / "sync_stages.py",
+    PLUGIN_ROOT / "sync_params.py",
+    PLUGIN_ROOT / "sync_types.py",
+    PLUGIN_ROOT / "jobs.py",
+)
+ASSIGNMENT_RE = re.compile(
+    r"\.environment\s*=|environment\s*=\s*[^=]|['\"]environment['\"]\s*[:=]"
+)
+
+
+def _iter_sync_files() -> list[Path]:
+    files: list[Path] = []
+    for entry in SYNC_DIRS:
+        if entry.is_file():
+            files.append(entry)
+        elif entry.is_dir():
+            files.extend(p for p in entry.rglob("*.py"))
+    return files
+
+
+def test_sync_paths_never_write_environment() -> None:
+    """Issue #438 contract: environment is manual-only.
+
+    The sync-side modules must never assign or serialize it."""
+    offenders: list[str] = []
+    for path in _iter_sync_files():
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if ASSIGNMENT_RE.search(line):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "Sync paths must never write ProxmoxEndpoint.environment:\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_proxmox_endpoint_environment.py
+++ b/tests/test_proxmox_endpoint_environment.py
@@ -36,9 +36,7 @@ FORM_PATH = PLUGIN_ROOT / "forms" / "proxmox.py"
 FILTERSET_PATH = PLUGIN_ROOT / "filtersets.py"
 TABLE_PATH = PLUGIN_ROOT / "tables" / "__init__.py"
 SERIALIZER_PATH = PLUGIN_ROOT / "api" / "serializers" / "endpoints.py"
-TEMPLATE_PATH = (
-    PLUGIN_ROOT / "templates" / "netbox_proxbox" / "proxmoxendpoint.html"
-)
+TEMPLATE_PATH = PLUGIN_ROOT / "templates" / "netbox_proxbox" / "proxmoxendpoint.html"
 
 EXPECTED_SLUGS = {
     "production",
@@ -155,7 +153,7 @@ def test_migration_exists_and_chains_after_0044() -> None:
     assert '("netbox_proxbox", "0044_cloud_image_template")' in src
     assert "migrations.AddField(" in src
     assert 'name="environment"' in src
-    assert "model_name=\"proxmoxendpoint\"" in src
+    assert 'model_name="proxmoxendpoint"' in src
     assert "blank=True" in src
     assert "null=True" in src
 
@@ -311,7 +309,9 @@ def test_sync_paths_never_write_environment() -> None:
     for path in _iter_sync_files():
         for lineno, line in enumerate(path.read_text().splitlines(), start=1):
             if ASSIGNMENT_RE.search(line):
-                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+                offenders.append(
+                    f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}"
+                )
     assert not offenders, (
         "Sync paths must never write ProxmoxEndpoint.environment:\n"
         + "\n".join(offenders)


### PR DESCRIPTION
Closes #438.

## Summary

Adds an optional `environment` field to `ProxmoxEndpoint` so operators can manually classify each Proxmox cluster by its lifecycle stage (production, staging, development, homologation, testing, lab). The field is **manual classification only** — the sync paths never write it, blank is a valid value, and the field is not required.

## Changes

- New `ProxmoxEndpointEnvironmentChoices` choice set in `netbox_proxbox/choices.py` with admin-override key `ProxmoxEndpoint.environment`.
- `ProxmoxEndpoint.environment` model field: `CharField(max_length=32, blank=True, null=True, choices=ProxmoxEndpointEnvironmentChoices)`.
- Plain additive migration `0045_proxmoxendpoint_environment` chained on `0044_cloud_image_template` (no `SeparateDatabaseAndState` since the column is brand new).
- Form integration: edit form `Meta.fields`, filter form (`MultipleChoiceField`), and import form (`CSVChoiceField`).
- Filterset, table (with `ChoiceFieldColumn`, default columns), and serializer (`ChoiceField` with `allow_null`/`allow_blank`/`required=False`).
- Detail template renders the Environment row right after Mode with badge styling per stage.

## Test plan

- [x] `rtk pytest tests/` — 772 passed, 4 skipped
- [x] `rtk ruff check .` — All checks passed
- [x] `rtk ty check proxbox_cli` — All checks passed
- [x] `python3 -m compileall netbox_proxbox tests` — clean
- [x] `manage.py makemigrations netbox_proxbox --check --dry-run` — No changes detected (migration matches model)
- [x] New AST contract test `tests/test_proxmox_endpoint_environment.py` (14 tests) covering choice set, model field, migration shape, form/filter/import wiring, table columns, serializer field, template row order, and the sync-path invariant