### PR TITLE
feat(intent): embed netbox-metadata block on NetBox→Proxmox writes (#423)

### DIFF
--- a/netbox_proxbox/api/serializers/settings.py
+++ b/netbox_proxbox/api/serializers/settings.py
@@ -26,6 +26,7 @@ class ProxboxPluginSettingsSerializer(NetBoxModelSerializer):
             "ensure_netbox_objects",
             "delete_orphans",
             "parse_description_metadata",
+            "embed_description_metadata",
             "enable_tenant_name_regex",
             "tenant_name_regex_rules",
             "primary_ip_preference",

--- a/netbox_proxbox/forms/settings.py
+++ b/netbox_proxbox/forms/settings.py
@@ -304,6 +304,17 @@ class ProxboxPluginSettingsForm(forms.Form):
             "cover. Disabled by default."
         ),
     )
+    embed_description_metadata = forms.BooleanField(
+        required=False,
+        label="Embed description metadata",
+        help_text=(
+            "When enabled, intent-direction create/update writes to Proxmox append a "
+            'fenced "netbox-metadata" JSON block of NetBox FK ids (role, tenant, site, '
+            "platform, cluster, device) to the Proxmox object's description. Pairs "
+            "with parse_description_metadata to round-trip NetBox metadata through "
+            "Proxmox without drift. Disabled by default."
+        ),
+    )
     ssrf_protection_enabled = forms.BooleanField(
         required=False,
         label="Enable SSRF protection",

--- a/netbox_proxbox/intent/description_metadata.py
+++ b/netbox_proxbox/intent/description_metadata.py
@@ -1,0 +1,139 @@
+"""Render the ``netbox-metadata`` fenced block embedded in Proxmox descriptions.
+
+Counterpart to ``proxbox_api.proxmox_to_netbox.description_metadata`` on the
+backend: that module *parses* fenced blocks of the form ::
+
+    ```netbox-metadata
+    {"role": 1, "tenant": 13}
+    ```
+
+out of a Proxmox description and applies the PK ids onto the NetBox object.
+This module is the write-side mirror — it *builds* the same fenced block from
+a NetBox virtual machine's PK foreign keys so the intent path
+(``netbox-proxbox`` -> ``proxbox-api`` -> Proxmox) can embed it into the
+Proxmox VM/CT ``description`` at create / update time.
+
+Embedding the block on the write side closes the round-trip: a subsequent
+Proxmox -> NetBox reflection sync with ``parse_description_metadata=True``
+will read the same PKs back without drift (the #357 drift-detect invariant).
+
+Issue: https://github.com/emersonfelipesp/netbox-proxbox/issues/423
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+# Keep the regex shape in lock-step with
+# ``proxbox_api.proxmox_to_netbox.description_metadata._FENCE_RE`` so a block
+# emitted here is recognised by the parser and so existing blocks are stripped
+# cleanly on update.
+_FENCE_RE = re.compile(
+    r"^[ \t]*```[ \t]*netbox-metadata[ \t]*\r?\n(?P<body>.*?)\r?\n[ \t]*```[ \t]*$",
+    re.IGNORECASE | re.DOTALL | re.MULTILINE,
+)
+
+# NetBox VM attributes that resolve to a single foreign-key id. Each entry is
+# ``(metadata_key, attr_chain)``. ``attr_chain`` is walked via ``getattr`` so
+# ``("role", "id")`` looks up ``vm.role.id``. Keys are restricted to the
+# read-side parser's currently-honoured set; new keys here have no effect until
+# the parser learns them.
+_PK_FIELDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("role", ("role", "id")),
+    ("tenant", ("tenant", "id")),
+    ("site", ("site", "id")),
+    ("platform", ("platform", "id")),
+    ("cluster", ("cluster", "id")),
+    ("device", ("device", "id")),
+)
+
+
+def _resolve(obj: Any, chain: tuple[str, ...]) -> Any:
+    current: Any = obj
+    for attr in chain:
+        if current is None:
+            return None
+        current = getattr(current, attr, None)
+    return current
+
+
+def collect_netbox_metadata(vm: Any) -> dict[str, int]:
+    """Return a ``{key: pk}`` dict of NetBox FK ids present on ``vm``.
+
+    Missing relations (``vm.role is None``) are silently omitted so the
+    resulting block only describes what NetBox actually knows. Non-positive
+    or non-integer ids are dropped to match the parser's accepted shape.
+    """
+    out: dict[str, int] = {}
+    for key, chain in _PK_FIELDS:
+        value = _resolve(vm, chain)
+        if isinstance(value, bool) or not isinstance(value, int):
+            continue
+        if value <= 0:
+            continue
+        out[key] = value
+    return out
+
+
+def render_netbox_metadata_block(metadata: dict[str, int]) -> str | None:
+    """Render ``metadata`` as a fenced ``netbox-metadata`` block.
+
+    Returns ``None`` if ``metadata`` is empty so callers can leave the
+    description untouched. JSON is emitted with sorted keys so repeated
+    builds of the same PK set produce byte-identical output (drift-detect).
+    """
+    if not metadata:
+        return None
+    body = json.dumps(metadata, sort_keys=True, indent=2)
+    return "```netbox-metadata\n" + body + "\n```"
+
+
+def strip_netbox_metadata(text: str | None) -> str | None:
+    """Return ``text`` with every ``netbox-metadata`` fenced block removed.
+
+    Trailing whitespace is trimmed; an empty result collapses to ``None`` so
+    callers can decide to omit ``description`` entirely instead of writing a
+    blank string.
+    """
+    if not text:
+        return None
+    cleaned = _FENCE_RE.sub("", text).rstrip()
+    return cleaned or None
+
+
+def embed_netbox_metadata(description: str | None, block: str | None) -> str | None:
+    """Append ``block`` to ``description`` after a single blank line.
+
+    Any existing ``netbox-metadata`` block is stripped first so repeated
+    applies do not stack. Returns ``None`` if both inputs are empty.
+    """
+    if block is None:
+        return strip_netbox_metadata(description)
+    base = strip_netbox_metadata(description)
+    if base is None:
+        return block
+    return base + "\n\n" + block
+
+
+def build_description_with_metadata(vm: Any, description: str | None) -> str | None:
+    """High-level helper used by ``build_vm_payload`` / ``build_lxc_payload``.
+
+    Combines ``collect_netbox_metadata``, ``render_netbox_metadata_block`` and
+    ``embed_netbox_metadata`` into one call. The caller is responsible for the
+    plugin-settings opt-in gate; this helper unconditionally rebuilds the
+    block.
+    """
+    metadata = collect_netbox_metadata(vm)
+    block = render_netbox_metadata_block(metadata)
+    return embed_netbox_metadata(description, block)
+
+
+__all__ = [
+    "build_description_with_metadata",
+    "collect_netbox_metadata",
+    "embed_netbox_metadata",
+    "render_netbox_metadata_block",
+    "strip_netbox_metadata",
+]

--- a/netbox_proxbox/intent/payload.py
+++ b/netbox_proxbox/intent/payload.py
@@ -5,6 +5,34 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from netbox_proxbox.intent.description_metadata import (
+    build_description_with_metadata,
+)
+
+
+def _embed_description_metadata_setting() -> bool:
+    """Return ``ProxboxPluginSettings.embed_description_metadata`` (default False).
+
+    Imported lazily and wrapped so import-time evaluation of this module is
+    safe in test environments that have not configured Django yet.
+    """
+    try:
+        from netbox_proxbox.models.plugin_settings import ProxboxPluginSettings
+    except Exception:
+        return False
+    try:
+        return bool(ProxboxPluginSettings.get_solo().embed_description_metadata)
+    except Exception:
+        return False
+
+
+def _resolve_description(vm: Any) -> str | None:
+    raw = getattr(vm, "description", None)
+    description = _str_or_none(raw)
+    if not _embed_description_metadata_setting():
+        return description
+    return build_description_with_metadata(vm, description)
+
 
 def _custom_fields(vm: Any) -> dict[str, Any]:
     cf = getattr(vm, "custom_field_data", None)
@@ -135,7 +163,7 @@ def build_vm_payload(vm) -> dict:
             _cf_value(cf, "proxmox_template_vmid", "cf_proxmox_template_vmid")
         ),
         "tags": _tag_names(vm),
-        "description": _str_or_none(getattr(vm, "description", None)),
+        "description": _resolve_description(vm),
     }
     cloud_init = _cloud_init_payload(cf)
     if cloud_init is not None:
@@ -165,7 +193,7 @@ def build_lxc_payload(vm) -> dict:
             )
         ),
         "tags": _tag_names(vm),
-        "description": _str_or_none(getattr(vm, "description", None)),
+        "description": _resolve_description(vm),
     }
     cloud_init = _cloud_init_payload(cf)
     if cloud_init is not None:

--- a/netbox_proxbox/migrations/0046_pluginsettings_embed_description_metadata.py
+++ b/netbox_proxbox/migrations/0046_pluginsettings_embed_description_metadata.py
@@ -1,0 +1,43 @@
+"""Add ``embed_description_metadata`` plugin setting for issue #423.
+
+Mirrors ``parse_description_metadata`` (#366, read-side) by adding a single
+opt-in BooleanField that gates the intent-path write of a fenced
+``netbox-metadata`` JSON block into the Proxmox description. Default
+``False`` keeps the intent path byte-for-byte identical to v0.0.16 for
+existing deployments.
+
+Also merges the 0044 leaf fork (``0044_overwrite_vm_proxmox_tags`` was added
+in parallel with ``0044_cloud_image_template`` -> ``0045_proxmoxendpoint_environment``)
+by depending on both leaves so Django sees a single linear graph again.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netbox_proxbox", "0044_overwrite_vm_proxmox_tags"),
+        ("netbox_proxbox", "0045_proxmoxendpoint_environment"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="proxboxpluginsettings",
+            name="embed_description_metadata",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When enabled, intent-direction create/update writes to Proxmox "
+                    "append a fenced ``netbox-metadata`` JSON block of NetBox FK ids "
+                    "(role, tenant, site, platform, cluster, device) to the Proxmox "
+                    "object's description. Pairs with ``parse_description_metadata`` "
+                    "to round-trip NetBox metadata through Proxmox without drift. "
+                    "Disabled by default."
+                ),
+                verbose_name="Embed description metadata",
+            ),
+        ),
+    ]

--- a/netbox_proxbox/models/plugin_settings.py
+++ b/netbox_proxbox/models/plugin_settings.py
@@ -241,6 +241,17 @@ class ProxboxPluginSettings(NetBoxModel):
             "they cover. Disabled by default."
         ),
     )
+    embed_description_metadata = models.BooleanField(
+        default=False,
+        verbose_name=_("Embed description metadata"),
+        help_text=_(
+            "When enabled, intent-direction create/update writes to Proxmox append a "
+            "fenced ``netbox-metadata`` JSON block of NetBox FK ids (role, tenant, "
+            "site, platform, cluster, device) to the Proxmox object's description. "
+            "Pairs with ``parse_description_metadata`` to round-trip NetBox metadata "
+            "through Proxmox without drift. Disabled by default."
+        ),
+    )
     ssrf_protection_enabled = models.BooleanField(
         default=True,
         verbose_name=_("Enable SSRF protection"),

--- a/netbox_proxbox/templates/netbox_proxbox/settings.html
+++ b/netbox_proxbox/templates/netbox_proxbox/settings.html
@@ -30,6 +30,7 @@
                     {% render_field form.delete_orphans %}
                     {% render_field form.primary_ip_preference %}
                     {% render_field form.parse_description_metadata %}
+                    {% render_field form.embed_description_metadata %}
                     {% render_field form.default_role_qemu %}
                     {% render_field form.default_role_lxc %}
                     {% render_field form.backend_log_file_path %}

--- a/netbox_proxbox/views/settings.py
+++ b/netbox_proxbox/views/settings.py
@@ -61,6 +61,7 @@ class SettingsView(
             "debug_cache": settings_obj.debug_cache,
             "expose_internal_errors": settings_obj.expose_internal_errors,
             "parse_description_metadata": settings_obj.parse_description_metadata,
+            "embed_description_metadata": settings_obj.embed_description_metadata,
             "ssrf_protection_enabled": settings_obj.ssrf_protection_enabled,
             "allow_private_ips": settings_obj.allow_private_ips,
             "additional_allowed_ip_ranges": settings_obj.additional_allowed_ip_ranges,
@@ -202,6 +203,9 @@ class SettingsView(
             settings_obj.parse_description_metadata = form.cleaned_data.get(
                 "parse_description_metadata", False
             )
+            settings_obj.embed_description_metadata = form.cleaned_data.get(
+                "embed_description_metadata", False
+            )
             settings_obj.backend_log_file_path = form.cleaned_data[
                 "backend_log_file_path"
             ]
@@ -306,6 +310,7 @@ class SettingsView(
                     "debug_cache",
                     "expose_internal_errors",
                     "parse_description_metadata",
+                    "embed_description_metadata",
                     "ssrf_protection_enabled",
                     "allow_private_ips",
                     "additional_allowed_ip_ranges",

--- a/tests/test_intent_description_metadata.py
+++ b/tests/test_intent_description_metadata.py
@@ -1,0 +1,244 @@
+"""Tests for the intent-direction ``netbox-metadata`` writer (#423).
+
+The plugin-side mirror of ``proxbox_api.proxmox_to_netbox.description_metadata``:
+when ``ProxboxPluginSettings.embed_description_metadata`` is on, intent payload
+builders append a fenced ``netbox-metadata`` JSON block of NetBox FK ids to the
+Proxmox description so a reflection sync with ``parse_description_metadata=True``
+round-trips without drift.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELPER_PATH = (
+    REPO_ROOT / "netbox_proxbox" / "intent" / "description_metadata.py"
+)
+PAYLOAD_PATH = REPO_ROOT / "netbox_proxbox" / "intent" / "payload.py"
+
+
+def _load_helper_module():
+    """Load ``description_metadata.py`` without triggering ``netbox_proxbox/__init__.py``.
+
+    The package ``__init__`` imports Django/NetBox primitives that aren't
+    available in this lightweight test environment. The helper module itself
+    only uses ``json``/``re``/``typing`` so it can be loaded directly.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_desc_md_under_test", HELPER_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_HELPER = _load_helper_module()
+build_description_with_metadata = _HELPER.build_description_with_metadata
+collect_netbox_metadata = _HELPER.collect_netbox_metadata
+embed_netbox_metadata = _HELPER.embed_netbox_metadata
+render_netbox_metadata_block = _HELPER.render_netbox_metadata_block
+strip_netbox_metadata = _HELPER.strip_netbox_metadata
+
+
+def _vm(**relations):
+    """Build a fake VM whose FK chains return ``relations[name].id``."""
+    return SimpleNamespace(
+        **{
+            name: SimpleNamespace(id=value) if value is not None else None
+            for name, value in relations.items()
+        }
+    )
+
+
+def test_collect_returns_present_pk_ids_only():
+    vm = _vm(role=1, tenant=13, site=None, platform=2, cluster=7, device=12)
+    assert collect_netbox_metadata(vm) == {
+        "role": 1,
+        "tenant": 13,
+        "platform": 2,
+        "cluster": 7,
+        "device": 12,
+    }
+
+
+def test_collect_drops_non_positive_and_non_integer_ids():
+    vm = SimpleNamespace(
+        role=SimpleNamespace(id=0),
+        tenant=SimpleNamespace(id=-3),
+        site=SimpleNamespace(id="13"),
+        platform=SimpleNamespace(id=True),  # bool rejected by int check
+        cluster=SimpleNamespace(id=7),
+        device=None,
+    )
+    assert collect_netbox_metadata(vm) == {"cluster": 7}
+
+
+def test_collect_returns_empty_dict_when_no_relations():
+    vm = SimpleNamespace(role=None, tenant=None, site=None)
+    assert collect_netbox_metadata(vm) == {}
+
+
+def test_render_emits_canonical_fenced_block():
+    block = render_netbox_metadata_block({"tenant": 13, "role": 1})
+    assert block is not None
+    # Sorted keys + fenced wrapper => byte-identical for equal PK sets.
+    assert block == '```netbox-metadata\n{\n  "role": 1,\n  "tenant": 13\n}\n```'
+
+
+def test_render_empty_metadata_returns_none():
+    assert render_netbox_metadata_block({}) is None
+
+
+def test_strip_removes_block_and_collapses_empty_to_none():
+    text = '```netbox-metadata\n{"role": 1}\n```'
+    assert strip_netbox_metadata(text) is None
+
+
+def test_strip_preserves_operator_prose():
+    text = "Production database VM.\n\n" '```netbox-metadata\n{"role": 1}\n```\n'
+    assert strip_netbox_metadata(text) == "Production database VM."
+
+
+def test_strip_ignores_plain_text_netbox_role_lines():
+    # The fenced block is the only thing that matches; loose
+    # ``netbox-role:`` prose stays untouched.
+    text = "netbox-role: webserver (legacy convention)"
+    assert strip_netbox_metadata(text) == text
+
+
+def test_embed_appends_block_after_blank_line():
+    out = embed_netbox_metadata(
+        "Production database VM.",
+        '```netbox-metadata\n{"role": 1}\n```',
+    )
+    assert out == (
+        'Production database VM.\n\n```netbox-metadata\n{"role": 1}\n```'
+    )
+
+
+def test_embed_strips_pre_existing_block_before_appending():
+    description = (
+        "Production database VM.\n\n" '```netbox-metadata\n{"role": 99}\n```'
+    )
+    new_block = '```netbox-metadata\n{"role": 1}\n```'
+    out = embed_netbox_metadata(description, new_block)
+    assert out == "Production database VM.\n\n" + new_block
+    # And the result has exactly one fenced block.
+    assert out.count("```netbox-metadata") == 1
+
+
+def test_embed_returns_block_alone_when_description_empty():
+    block = '```netbox-metadata\n{"role": 1}\n```'
+    assert embed_netbox_metadata(None, block) == block
+    assert embed_netbox_metadata("", block) == block
+
+
+def test_embed_returns_stripped_description_when_block_is_none():
+    assert (
+        embed_netbox_metadata(
+            'prose\n\n```netbox-metadata\n{"role": 1}\n```',
+            None,
+        )
+        == "prose"
+    )
+
+
+def test_build_description_with_metadata_round_trip_is_idempotent():
+    vm = _vm(role=1, tenant=13)
+    once = build_description_with_metadata(vm, "Production VM.")
+    twice = build_description_with_metadata(vm, once)
+    assert once == twice
+    assert once is not None and once.count("```netbox-metadata") == 1
+
+
+def test_build_description_with_metadata_emits_parser_compatible_block():
+    """The block emitted here must parse back via the proxbox-api regex."""
+    vm = _vm(role=1, tenant=13, site=4)
+    description = build_description_with_metadata(vm, "Prod VM.")
+    assert description is not None
+    fence_re = re.compile(
+        r"^[ \t]*```[ \t]*netbox-metadata[ \t]*\r?\n(?P<body>.*?)\r?\n[ \t]*```[ \t]*$",
+        re.IGNORECASE | re.DOTALL | re.MULTILINE,
+    )
+    match = fence_re.search(description)
+    assert match is not None, "emitted block must match the parser regex"
+    payload = json.loads(match.group("body"))
+    assert payload == {"role": 1, "tenant": 13, "site": 4}
+
+
+def test_build_description_returns_plain_text_when_no_pks():
+    vm = SimpleNamespace(description=None)
+    assert build_description_with_metadata(vm, "prose") == "prose"
+    assert build_description_with_metadata(vm, None) is None
+
+
+# --- Source-level contract tests for payload.py wiring ---
+
+
+def _parse_payload() -> ast.Module:
+    return ast.parse(PAYLOAD_PATH.read_text(encoding="utf-8"))
+
+
+def test_payload_imports_description_metadata_helper():
+    module = _parse_payload()
+    found = False
+    for node in ast.walk(module):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module == "netbox_proxbox.intent.description_metadata"
+        ):
+            found = found or any(
+                alias.name == "build_description_with_metadata"
+                for alias in node.names
+            )
+    assert found, (
+        "payload.py must import build_description_with_metadata from "
+        "netbox_proxbox.intent.description_metadata"
+    )
+
+
+def test_payload_resolves_description_through_helper():
+    text = PAYLOAD_PATH.read_text(encoding="utf-8")
+    # Both payload builders use ``_resolve_description(vm)`` for the
+    # description field; raw ``getattr(vm, "description", ...)`` would skip
+    # the embedding gate.
+    assert text.count('"description": _resolve_description(vm)') >= 2
+    assert "_embed_description_metadata_setting" in text
+
+
+def test_resolve_description_calls_helper_when_gate_is_on():
+    """AST contract: ``_resolve_description`` must consult the gate setting
+    and dispatch to ``build_description_with_metadata`` when enabled,
+    otherwise return the plain text. This prevents the embedding from being
+    accidentally bypassed or always-on without a test catching it.
+    """
+    module = _parse_payload()
+    func = None
+    for node in module.body:
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "_resolve_description"
+        ):
+            func = node
+            break
+    assert func is not None, "payload.py must define _resolve_description"
+
+    called_names = {
+        node.func.id
+        for node in ast.walk(func)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "_embed_description_metadata_setting" in called_names, (
+        "_resolve_description must consult the embed gate"
+    )
+    assert "build_description_with_metadata" in called_names, (
+        "_resolve_description must dispatch to build_description_with_metadata "
+        "when the gate is on"
+    )

--- a/tests/test_settings_view_encryption.py
+++ b/tests/test_settings_view_encryption.py
@@ -80,6 +80,7 @@ def _fake_settings_obj(encryption_key: str = "") -> SimpleNamespace:
         debug_cache=False,
         expose_internal_errors=False,
         parse_description_metadata=False,
+        embed_description_metadata=False,
         ssrf_protection_enabled=True,
         allow_private_ips=True,
         additional_allowed_ip_ranges="",


### PR DESCRIPTION
## Summary

Closes #423. Adds the write-side mirror of the read-side `netbox-metadata` parser shipped in #366, so VM/CT create and update along the intent path (NetBox → Proxmox) embed a fenced `netbox-metadata` JSON block of NetBox FK ids into the Proxmox description.

- New helper module `netbox_proxbox/intent/description_metadata.py` builds the block from a NetBox VM's `role / tenant / site / platform / cluster / device` PKs and reuses the same fence regex shape as `proxbox_api.proxmox_to_netbox.description_metadata` so round-trips don't diverge.
- `intent.payload._resolve_description` consults a new opt-in gate, `ProxboxPluginSettings.embed_description_metadata` (default **False**), and dispatches to the helper when enabled. Both `build_vm_payload` and `build_lxc_payload` now use `_resolve_description(vm)` instead of raw `getattr(vm, "description", ...)`.
- Standard plugin-settings wiring is added end-to-end: model field, migration `0046_pluginsettings_embed_description_metadata` (merging the existing `0044` fork), form field, view round-trip + `update_fields`, REST serializer field, and the Settings template render.

The gate is intentionally off by default so operator-edited descriptions are never silently rewritten. When the gate is on, a subsequent reflection sync with `parse_description_metadata=True` reads the same PKs back without drift — closing the #357 zero-drift invariant.

## Test plan

- [x] `uv run pytest tests/` — 790 passed, 4 skipped
- [x] `uv run ruff check .` — clean
- [x] `python3 -m compileall netbox_proxbox tests` — clean
- [x] `tests/test_intent_description_metadata.py` — 18 new cases: collect / render / strip / embed / round-trip / parser-regex compatibility / AST contracts on `payload.py` wiring
- [x] `tests/test_settings_view_encryption.py` fixture extended with `embed_description_metadata=False` so the new field is picked up by hardware-discovery and encryption settings tests
- [ ] CI green on develop