### PR TITLE
fix(api): support cloud template updates

### DIFF
--- a/netbox_proxbox/api/serializers/cloud_image_template.py
+++ b/netbox_proxbox/api/serializers/cloud_image_template.py
@@ -57,6 +57,24 @@ class CloudImageTemplateSerializer(NetBoxModelSerializer):
             "is_active",
         )
 
+    def create(self, validated_data):
+        """Create while applying tenant scope after the instance exists."""
+        allowed_tenants = validated_data.pop("allowed_tenants", None)
+        instance = CloudImageTemplate.objects.create(**validated_data)
+        if allowed_tenants is not None:
+            instance.allowed_tenants.set(allowed_tenants)
+        return instance
+
+    def update(self, instance, validated_data):
+        """Update writable nested fields without DRF's default nested assertion."""
+        allowed_tenants = validated_data.pop("allowed_tenants", None)
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+        if allowed_tenants is not None:
+            instance.allowed_tenants.set(allowed_tenants)
+        return instance
+
 
 class NestedCloudImageTemplateSerializer(WritableNestedSerializer):
     """Nested cloud image template representation for related serializers."""

--- a/tests/test_cloud_image_template.py
+++ b/tests/test_cloud_image_template.py
@@ -69,6 +69,15 @@ def test_cloud_image_template_api_surface_is_registered():
     assert "allowed_tenants__isnull" in filtersets
 
 
+def test_cloud_image_template_api_serializer_supports_writable_tenant_scope():
+    serializer = _read("netbox_proxbox/api/serializers/cloud_image_template.py")
+
+    assert "def create(self, validated_data)" in serializer
+    assert "def update(self, instance, validated_data)" in serializer
+    assert 'validated_data.pop("allowed_tenants", None)' in serializer
+    assert "instance.allowed_tenants.set(allowed_tenants)" in serializer
+
+
 def test_cloud_image_template_templates_exist():
     detail = (
         REPO_ROOT / "netbox_proxbox/templates/netbox_proxbox/cloudimagetemplate.html"


### PR DESCRIPTION
## Summary

- Fix CloudImageTemplate API create/update for tenant-scoped templates.
- Handle `allowed_tenants` explicitly so DRF does not reject writable nested fields.
- Add a static contract test for the serializer behavior.

## Validation

- `uv run ruff check netbox_proxbox/api/serializers/cloud_image_template.py tests/test_cloud_image_template.py`
- `uv run pytest tests/test_cloud_image_template.py`
- Live NMS admin template-image publish flow updated NetBox CloudImageTemplate id `1`.
