### PR TITLE
fix(views): add ProxmoxEndpointBulkDeleteView to resolve bulk-delete 404

### DIFF
--- a/netbox_proxbox/views/__init__.py
+++ b/netbox_proxbox/views/__init__.py
@@ -51,6 +51,7 @@ from .endpoints import (
     NetBoxEndpointEditView,
     NetBoxEndpointListView,
     NetBoxEndpointView,
+    ProxmoxEndpointBulkDeleteView,
     ProxmoxEndpointDeleteView,
     ProxmoxEndpointEditView,
     ProxmoxEndpointListView,

--- a/netbox_proxbox/views/endpoints/__init__.py
+++ b/netbox_proxbox/views/endpoints/__init__.py
@@ -20,6 +20,7 @@ from .netbox import (
     NetBoxExportQuickAddTokenView,
 )
 from .proxmox import (
+    ProxmoxEndpointBulkDeleteView,
     ProxmoxEndpointBulkImportView,
     ProxmoxEndpointDeleteView,
     ProxmoxEndpointEditView,

--- a/netbox_proxbox/views/endpoints/proxmox.py
+++ b/netbox_proxbox/views/endpoints/proxmox.py
@@ -30,6 +30,7 @@ __all__ = (
     "ProxmoxEndpointEditView",
     "ProxmoxEndpointSettingsView",
     "ProxmoxEndpointDeleteView",
+    "ProxmoxEndpointBulkDeleteView",
     "ProxmoxEndpointBulkImportView",
     "ProxmoxEndpointExportView",
     "ProxmoxExportQuickAddTokenView",
@@ -323,6 +324,14 @@ class ProxmoxEndpointDeleteView(generic.ObjectDeleteView):
     """
 
     queryset = ProxmoxEndpoint.objects.all()
+
+
+@register_model_view(ProxmoxEndpoint, "bulk_delete", detail=False)
+class ProxmoxEndpointBulkDeleteView(generic.BulkDeleteView):
+    """Bulk-delete Proxmox endpoint records."""
+
+    queryset = ProxmoxEndpoint.objects.all()
+    table = ProxmoxEndpointTable
 
 
 @register_model_view(


### PR DESCRIPTION
## Summary

Fixes emersonfelipesp/proxbox-api#112 — **"Can't delete Proxmox Endpoints — Error page not found"**

- The `ProxmoxEndpointBulkDeleteView` was missing from the plugin. When a user selected one or more rows on the Proxmox Endpoint list and clicked the bulk **Delete** action, NetBox tried to resolve the URL `plugins:netbox_proxbox:proxmoxendpoint_bulk_delete`, which had no registered view, producing a 404 "page not found".
- The single-object `ProxmoxEndpointDeleteView` (detail page → delete button) was unaffected and worked correctly.
- Every other model in the plugin (VMBackup, VMSnapshot, Replication, ProxmoxStorage, NodeSSHCredential, CloudImageTemplate) already had a `BulkDeleteView`; `ProxmoxEndpoint` was the only exception.

## Changes (3 files)

| File | Change |
|---|---|
| `netbox_proxbox/views/endpoints/proxmox.py` | Add `ProxmoxEndpointBulkDeleteView` class + add to `__all__` |
| `netbox_proxbox/views/endpoints/__init__.py` | Re-export `ProxmoxEndpointBulkDeleteView` |
| `netbox_proxbox/views/__init__.py` | Re-export `ProxmoxEndpointBulkDeleteView` |

## Test plan

- [ ] Navigate to **Plugins → Proxbox → Proxmox Endpoints** list
- [ ] Check the checkbox next to one or more endpoints
- [ ] Click the **Delete Selected** bulk action
- [ ] Confirm the standard NetBox bulk-delete confirmation page appears (not a 404)
- [ ] Confirm the endpoints are deleted after confirming
- [ ] Verify the single-object delete (from the detail page) still works correctly
- [ ] `python3 -m compileall netbox_proxbox tests` — no errors
- [ ] `ruff check .` — no issues