### PR TITLE
fix(ha): show PVE 9.x HA rules in dashboard, bump to 0.0.15.post1 (#111)

### DIFF
--- a/netbox_proxbox/__init__.py
+++ b/netbox_proxbox/__init__.py
@@ -146,7 +146,7 @@ class ProxboxConfig(PluginConfig):
     name = "netbox_proxbox"
     verbose_name = "Proxbox"
     description = "Integrates Proxmox and Netbox"
-    version = "0.0.16"
+    version = "0.0.15.post1"
     author = "Emerson Felipe (@emersonfelipesp)"
     author_email = "emersonfelipe.2003@gmail.com"
     min_version = "4.5.8"

--- a/netbox_proxbox/templates/netbox_proxbox/ha.html
+++ b/netbox_proxbox/templates/netbox_proxbox/ha.html
@@ -106,6 +106,48 @@
       </div>
     </div>
 
+    {% if summary.rules %}
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "HA Rules (PVE 9.x)" %}</h5>
+      <div class="card-body p-0">
+        <table class="table table-hover mb-0">
+          <thead>
+            <tr>
+              <th>{% trans "Cluster" %}</th>
+              <th>{% trans "Rule" %}</th>
+              <th>{% trans "Type" %}</th>
+              <th>{% trans "Affinity" %}</th>
+              <th>{% trans "Nodes" %}</th>
+              <th>{% trans "Resources" %}</th>
+              <th>{% trans "Strict" %}</th>
+              <th>{% trans "Comment" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for rule in summary.rules %}
+              <tr>
+                <td>{{ rule.cluster_name|default:"—" }}</td>
+                <td><code>{{ rule.rule }}</code></td>
+                <td>{{ rule.type|default:"—" }}</td>
+                <td>{{ rule.affinity|default:"—" }}</td>
+                <td>{{ rule.nodes|default:"—" }}</td>
+                <td>{{ rule.resources|default:"—" }}</td>
+                <td>
+                  {% if rule.strict is True %}
+                    <span class="badge text-bg-blue">{% trans "Yes" %}</span>
+                  {% else %}—{% endif %}
+                </td>
+                <td>{{ rule.comment|default:"—" }}</td>
+              </tr>
+            {% empty %}
+              <tr><td colspan="8" class="text-muted">{% trans "No HA rules configured." %}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    {% endif %}
+
     <div class="card mb-3">
       <h5 class="card-header">{% trans "HA Resources" %}</h5>
       <div class="card-body p-0">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netbox-proxbox"
-version = "0.0.16"
+version = "0.0.15.post1"
 description = "Netbox Plugin - Integrate Proxmox and Netbox"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary

Companion to `emersonfelipesp/proxbox-api#113` — adapts the HA dashboard template for PVE 9.x clusters where `cluster/ha/groups` has been replaced by `cluster/ha/rules`.

- **`ha.html`**: new "HA Rules (PVE 9.x)" card conditionally rendered when `summary.rules` is non-empty. Shows rule identifier, type (node-affinity / resource-affinity), affinity, nodes, resources, strict, and comment columns. The card is hidden on PVE ≤ 8.x clusters where `summary.rules = []` — fully backward compatible.
- **Version bump**: `0.0.16` → `0.0.15.post1`

## Test plan

- [ ] On PVE 9.x: load `/plugins/proxbox/ha/` and confirm "HA Rules" card appears with rules data; no ERROR logs in backend
- [ ] On PVE ≤ 8.x: load `/plugins/proxbox/ha/` and confirm "HA Groups" card appears as before; no "HA Rules" card
- [ ] Version strings in `pyproject.toml` and `netbox_proxbox/__init__.py` both read `0.0.15.post1`