### PR TITLE
fix(sync): skip optional stages on failure instead of aborting full sync (#445)

### DIFF
--- a/netbox_proxbox/sync_stages.py
+++ b/netbox_proxbox/sync_stages.py
@@ -44,6 +44,17 @@ _HEARTBEAT_SECONDS = 20.0
 _STAGE_RETRY_MAX = 2
 _STAGE_RETRY_DELAY = 8.0
 
+# Stages that are supplementary/optional: a failure logs a warning and the sync
+# continues.  Required stages (devices, VMs, storage, interfaces, IPs) are NOT
+# in this set and still abort the run on failure.
+_SKIPPABLE_STAGES: frozenset[str] = frozenset(
+    {
+        SyncTypeChoices.VIRTUAL_MACHINES_BACKUPS,   # "vm-backups"
+        SyncTypeChoices.VIRTUAL_MACHINES_SNAPSHOTS, # "vm-snapshots"
+        SyncTypeChoices.TASK_HISTORY,               # "task-history"
+    }
+)
+
 
 async def _run_batch_selected_sync(
     self: "ProxboxSyncJob",
@@ -410,9 +421,18 @@ def _run_all_stages_sync(
             stage_paths = _sync_stream_paths_for_stage(st, target_vm_ids)
 
             for stream_path in stage_paths:
-                payload, stage_runtime = _execute_stage_sync(
-                    job, st, stream_path, query_params, on_frame, fastapi_endpoint_id
-                )
+                try:
+                    payload, stage_runtime = _execute_stage_sync(
+                        job, st, stream_path, query_params, on_frame, fastapi_endpoint_id
+                    )
+                except RuntimeError as exc:
+                    if st in _SKIPPABLE_STAGES:
+                        job.logger.warning(
+                            "Optional stage '%s' failed and was skipped: %s", st, exc
+                        )
+                        job.job.save(update_fields=["log_entries"])
+                        continue
+                    raise
                 response = payload.get("response") or {}
                 stages_out.append(
                     {


### PR DESCRIPTION
## Summary

Defensive improvement for issue #445: add per-stage error isolation so that failures in optional stages (vm-backups, vm-snapshots, task-history) do not abort the entire full sync job.

### The problem

`_run_all_stages_sync` in `sync_stages.py` had no per-stage error recovery. Any `RuntimeError` raised by `_execute_stage_sync` propagated immediately through the entire stack, aborting all remaining stages. This meant that a single optional stage failure (e.g., "no backups found") would prevent devices, VMs, interfaces, and IP addresses from being synced.

### The fix

Add `_SKIPPABLE_STAGES` — a frozenset of stage type names that are supplementary and should not abort the full sync on failure:

- `"vm-backups"` (`SyncTypeChoices.VIRTUAL_MACHINES_BACKUPS`)
- `"vm-snapshots"` (`SyncTypeChoices.VIRTUAL_MACHINES_SNAPSHOTS`)
- `"task-history"` (`SyncTypeChoices.TASK_HISTORY`)

Wrap `_execute_stage_sync` in a `try/except RuntimeError` block inside the inner stage loop. When a skippable stage fails, a warning is logged and the sync continues to the next stage. Required stages (devices, VMs, storage, network interfaces, IP addresses) still abort on failure.

### Relation to proxbox-api fix

The root cause of issue #445 is in proxbox-api (PR [emersonfelipesp/proxbox-api#114](https://github.com/emersonfelipesp/proxbox-api/pull/114)): the backups sync route incorrectly treated "no backups found" as a fatal `ProxboxException` rather than a valid empty result. This plugin change is defense-in-depth: even after the proxbox-api fix, a future transient backend failure on a supplementary stage will not abort the entire full sync.

## Test plan

- [x] `ruff check .` passes
- [x] `python -m compileall netbox_proxbox` passes
- [ ] Full sync with a cluster that has no backups configured should complete all remaining stages and log a warning for vm-backups
- [ ] Required stage failures (e.g., devices) should still abort the sync as before

Closes #445 (together with proxbox-api PR #114)