### PR TITLE
refactor: code quality cleanup for v0.0.15.post1

### DIFF
--- a/netbox_proxbox/api/serializers/cloud_image_template.py
+++ b/netbox_proxbox/api/serializers/cloud_image_template.py
@@ -57,20 +57,22 @@ class CloudImageTemplateSerializer(NetBoxModelSerializer):
             "is_active",
         )
 
+    def _apply_allowed_tenants(self, instance, allowed_tenants):
+        if allowed_tenants is not None:
+            instance.allowed_tenants.set(allowed_tenants)
+
     def create(self, validated_data):
         """Create while applying tenant scope after the instance exists."""
         allowed_tenants = validated_data.pop("allowed_tenants", None)
         instance = super().create(validated_data)
-        if allowed_tenants is not None:
-            instance.allowed_tenants.set(allowed_tenants)
+        self._apply_allowed_tenants(instance, allowed_tenants)
         return instance
 
     def update(self, instance, validated_data):
         """Update writable nested fields without DRF's default nested assertion."""
         allowed_tenants = validated_data.pop("allowed_tenants", None)
         instance = super().update(instance, validated_data)
-        if allowed_tenants is not None:
-            instance.allowed_tenants.set(allowed_tenants)
+        self._apply_allowed_tenants(instance, allowed_tenants)
         return instance
 
 

--- a/netbox_proxbox/api/views.py
+++ b/netbox_proxbox/api/views.py
@@ -741,22 +741,20 @@ class _ProxboxVMListAPIView(APIView):
             vm_type_slug=self.vm_type_slug,
         ).order_by("name")
 
-        paginator = LimitOffsetPagination()
-        paginator.default_limit = 1000
-        paginator.max_limit = 5000
-
-        query_params = request.query_params
-        if "limit" not in query_params and "offset" not in query_params:
+        if "limit" not in request.query_params and "offset" not in request.query_params:
             results = [_serialize_vm(vm, request) for vm in qs]
             return Response(
                 {
-                    "count": qs.count(),
+                    "count": len(results),
                     "next": None,
                     "previous": None,
                     "results": results,
                 }
             )
 
+        paginator = LimitOffsetPagination()
+        paginator.default_limit = 1000
+        paginator.max_limit = 5000
         page = paginator.paginate_queryset(qs, request, view=self)
         results = [_serialize_vm(vm, request) for vm in page]
         return paginator.get_paginated_response(results)

--- a/netbox_proxbox/views/endpoints/proxmox.py
+++ b/netbox_proxbox/views/endpoints/proxmox.py
@@ -331,6 +331,7 @@ class ProxmoxEndpointBulkDeleteView(generic.BulkDeleteView):
     """Bulk-delete Proxmox endpoint records."""
 
     queryset = ProxmoxEndpoint.objects.all()
+    filterset = ProxmoxEndpointFilterSet
     table = ProxmoxEndpointTable
 
 

--- a/tests/test_api_source_contracts.py
+++ b/tests/test_api_source_contracts.py
@@ -612,7 +612,7 @@ def test_vm_resource_api_filters_full_queryset_before_limit_offset_pagination():
     assert "paginator = LimitOffsetPagination()" in source
     assert "paginator.default_limit = 1000" in source
     assert "paginator.max_limit = 5000" in source
-    assert '"count": qs.count()' in source
+    assert '"count": len(results)' in source
     assert '"next": None' in source
     assert '"previous": None' in source
     assert "paginator.paginate_queryset(qs, request, view=self)" in source

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -25,7 +25,6 @@ UPGRADING_PATH = REPO_ROOT / "docs" / "installation" / "upgrading.md"
 RELEASE_NOTES_INDEX_PATH = REPO_ROOT / "docs" / "release-notes" / "index.md"
 RELEASE_NOTES_014_PATH = REPO_ROOT / "docs" / "release-notes" / "version-0.0.14.md"
 RELEASE_NOTES_015_PATH = REPO_ROOT / "docs" / "release-notes" / "version-0.0.15.md"
-RELEASE_NOTES_016_PATH = REPO_ROOT / "docs" / "release-notes" / "version-0.0.16.md"
 E2E_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "e2e-docker.yml"
 PUBLISH_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "publish-testpypi.yml"
 NIGHTLY_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "nightly-contracts.yml"
@@ -33,12 +32,12 @@ DOCS_SCREENSHOTS_WORKFLOW_PATH = (
     REPO_ROOT / ".github" / "workflows" / "docs-screenshots.yml"
 )
 
-CURRENT_PLUGIN_VERSION = "0.0.16"
+CURRENT_PLUGIN_VERSION = "0.0.15"
 CURRENT_PROXBOX_API_VERSION = "0.0.11"
 CURRENT_NETBOX_MIN_VERSION = "4.5.8"
 CURRENT_NETBOX_MAX_VERSION = "4.6.99"
-PREVIOUS_PLUGIN_VERSION = "0.0.15"
-PREVIOUS_PROXBOX_API_VERSION = "0.0.11"
+PREVIOUS_PLUGIN_VERSION = "0.0.14"
+PREVIOUS_PROXBOX_API_VERSION = "0.0.10.post2"
 
 
 def _class_constants(class_name: str) -> dict[str, str]:
@@ -97,7 +96,7 @@ def test_certified_netbox_versions_are_documented():
         DOCS_INDEX_PATH,
         INSTALL_GIT_PATH,
         UPGRADING_PATH,
-        RELEASE_NOTES_016_PATH,
+        RELEASE_NOTES_015_PATH,
     )
     for path in docs_with_explicit_range:
         text = _read(path)
@@ -182,7 +181,7 @@ def test_current_release_pairing_is_documented_in_primary_docs():
         "v0.0.8.post1",
         "v0.0.3.post1",
     )
-    for path in (README_PATH, DOCS_INDEX_PATH, RELEASE_NOTES_016_PATH):
+    for path in (README_PATH, DOCS_INDEX_PATH, RELEASE_NOTES_015_PATH):
         text = _read(path)
         _assert_markdown_table_row(text, current_row)
 
@@ -191,7 +190,7 @@ def test_current_release_pairing_is_documented_in_primary_docs():
         DOCS_INDEX_PATH,
         UPGRADING_PATH,
         RELEASE_NOTES_INDEX_PATH,
-        RELEASE_NOTES_016_PATH,
+        RELEASE_NOTES_015_PATH,
     ):
         text = _read(path)
         assert CURRENT_PLUGIN_VERSION in text, f"{path} missing plugin version"
@@ -209,7 +208,7 @@ def test_previous_release_compatibility_row_matches_release_notes():
     for path in (
         README_PATH,
         DOCS_INDEX_PATH,
+        RELEASE_NOTES_014_PATH,
         RELEASE_NOTES_015_PATH,
-        RELEASE_NOTES_016_PATH,
     ):
         _assert_markdown_table_row(_read(path), previous_row)


### PR DESCRIPTION
## Summary

- Defer `LimitOffsetPagination` instantiation to the paginated branch — no-pagination requests (the dominant path) pay zero allocation cost
- Replace `qs.count()` with `len(results)` in `_ProxboxVMListAPIView.get()`, eliminating a redundant `SELECT COUNT(*)` on every unpaginated response
- Remove one-use `query_params` alias in the same method
- Extract `_apply_allowed_tenants()` helper on `CloudImageTemplateSerializer`, collapsing near-identical `create`/`update` bodies into 3 lines each
- Add missing `filterset = ProxmoxEndpointFilterSet` to `ProxmoxEndpointBulkDeleteView` — every other `BulkDeleteView` in the plugin sets this; without it the bulk confirmation step has no queryset scope
- Align `test_version.py` with the actual version (`0.0.15.post1`): reverts the pre-emptive `CURRENT_PLUGIN_VERSION="0.0.16"` bump, restores `PREVIOUS_PLUGIN_VERSION="0.0.14"`, and fixes `RELEASE_NOTES` path references accordingly

## Test plan

- [x] `uv run pytest tests/` — 798 passed, 4 skipped, 0 failed
- [x] `rtk ruff check .` — no issues
- [x] `uv run python -m compileall netbox_proxbox tests -q` — clean