### PR TITLE
feat(api): build-pve-template action on ProxmoxEndpointViewSet

### DIFF
--- a/netbox_proxbox/api/build_pve_template.py
+++ b/netbox_proxbox/api/build_pve_template.py
@@ -1,0 +1,75 @@
+"""HTTP client helper that proxies Build-PVE-Template to proxbox-api.
+
+The single ``FastAPIEndpoint`` row is the source of truth for the backend
+URL and API key. The plugin posts the request body verbatim to
+``POST /cloud/templates/pve`` on proxbox-api and returns the upstream
+JSON / status pair to the caller.
+
+Error handling mirrors ``services/backend_proxy.request_backend_resource``:
+network errors and non-JSON responses surface as ``503`` with a ``detail``
+field; upstream HTTP errors are propagated 1:1 so the NMS UI can render
+the proxbox-api ``detail`` text directly.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+from netbox_proxbox.services.backend_proxy import get_fastapi_request_context
+
+logger = logging.getLogger("netbox_proxbox.api.build_pve_template")
+
+
+def build_pve_template_via_backend(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], int]:
+    """Proxy a PVE template build request to proxbox-api.
+
+    Returns the body + HTTP status that should be sent back to the caller
+    of the NetBox plugin endpoint. Always returns JSON-serialisable data.
+    """
+    context = get_fastapi_request_context()
+    http_url = getattr(context, "http_url", None)
+    if not http_url:
+        return (
+            {
+                "queued": False,
+                "detail": "No FastAPIEndpoint configured for proxbox-api.",
+            },
+            503,
+        )
+
+    url = http_url.rstrip("/") + "/cloud/templates/pve"
+    headers = dict(getattr(context, "headers", {}) or {})
+    headers.setdefault("Content-Type", "application/json")
+    verify_ssl = bool(getattr(context, "verify_ssl", True))
+
+    try:
+        response = requests.post(
+            url,
+            json=payload,
+            headers=headers,
+            verify=verify_ssl,
+            timeout=(10, 600),
+        )
+    except requests.exceptions.RequestException as exc:
+        logger.error("build-pve-template request to %s failed: %s", url, exc)
+        return (
+            {
+                "queued": False,
+                "detail": f"Could not reach proxbox-api at {url}: {exc}",
+            },
+            503,
+        )
+
+    try:
+        body = response.json() if response.content else {}
+    except ValueError:
+        body = {"detail": response.text[:500]}
+
+    if not isinstance(body, dict):
+        body = {"result": body}
+    return body, response.status_code

--- a/netbox_proxbox/api/serializers/__init__.py
+++ b/netbox_proxbox/api/serializers/__init__.py
@@ -23,6 +23,10 @@ from netbox_proxbox.api.serializers.cloud_image_template import (
     CloudImageTemplateSerializer,
     NestedCloudImageTemplateSerializer,
 )
+from netbox_proxbox.api.serializers.pve_template import (
+    PVETemplateBuildRequestSerializer,
+    PVETemplateBuildResponseSerializer,
+)
 from netbox_proxbox.api.serializers.endpoints import (
     FastAPIEndpointSerializer,
     NestedTokenSerializer,
@@ -61,6 +65,8 @@ __all__ = (
     "ProxmoxEndpointSerializer",
     "ProxmoxNodeSerializer",
     "ProxmoxVMCloudInitSerializer",
+    "PVETemplateBuildRequestSerializer",
+    "PVETemplateBuildResponseSerializer",
     "ReplicationSerializer",
     "ProxmoxStorageSerializer",
     "ScheduledJobSerializer",

--- a/netbox_proxbox/api/serializers/pve_template.py
+++ b/netbox_proxbox/api/serializers/pve_template.py
@@ -1,0 +1,71 @@
+"""Serializer for the Build PVE Template REST action on ProxmoxEndpoint."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class PVETemplateBuildRequestSerializer(serializers.Serializer):
+    """Mirror of proxbox-api's PVETemplateBuildRequest.
+
+    The plugin proxies this body straight through to ``POST
+    /cloud/templates/pve`` on proxbox-api, so the field set is kept in
+    lock-step with ``proxbox_api.schemas.cloud_provision.PVETemplateBuildRequest``.
+    ``endpoint_id`` is injected on the server side from the URL path
+    parameter and must not be supplied by the caller.
+    """
+
+    vmid = serializers.IntegerField(min_value=100)
+    name = serializers.CharField(max_length=128, default="debian12-pve-tmpl")
+    target_node = serializers.CharField(max_length=256)
+    debian_image_url = serializers.URLField(
+        default=(
+            "https://cloud.debian.org/images/cloud/bookworm/latest/"
+            "debian-12-genericcloud-amd64.qcow2"
+        )
+    )
+    image_filename = serializers.CharField(required=False, allow_blank=True, default="")
+    image_storage = serializers.CharField(max_length=64, default="local")
+    vm_storage = serializers.CharField(max_length=64, default="local-lvm")
+    snippets_storage = serializers.CharField(max_length=64, default="local")
+    bridge = serializers.CharField(max_length=64, default="vmbr0")
+    memory_mb = serializers.IntegerField(min_value=512, default=4096)
+    cores = serializers.IntegerField(min_value=1, default=4)
+    nic_name = serializers.CharField(max_length=32, default="ens18")
+    hostname = serializers.CharField(max_length=128, default="pve-node-01")
+    domain = serializers.CharField(max_length=128, default="nmulti.local")
+    node_cidr = serializers.CharField(max_length=64, default="10.0.30.50/24")
+    gateway = serializers.CharField(max_length=64, default="10.0.30.1")
+    nameservers = serializers.ListField(
+        child=serializers.CharField(),
+        default=["1.1.1.1", "8.8.8.8"],
+    )
+    pve_version_pin = serializers.CharField(max_length=32, default="9.1.11")
+    debian_release = serializers.CharField(max_length=32, default="bookworm")
+    ssh_authorized_keys = serializers.ListField(
+        child=serializers.CharField(),
+        default=list,
+    )
+    verify_image_certificates = serializers.BooleanField(default=True)
+    create_vm = serializers.BooleanField(default=True)
+
+
+class PVETemplateBuildResponseSerializer(serializers.Serializer):
+    """OpenAPI-shape mirror of proxbox-api's PVETemplateBuildResponse."""
+
+    endpoint_id = serializers.IntegerField()
+    target_node = serializers.CharField()
+    vmid = serializers.IntegerField()
+    name = serializers.CharField()
+    status = serializers.CharField()
+    image_volid = serializers.CharField()
+    snippet_user_data_path = serializers.CharField()
+    snippet_network_config_path = serializers.CharField()
+    snippet_meta_data_path = serializers.CharField()
+    user_data = serializers.CharField()
+    network_config = serializers.CharField()
+    meta_data = serializers.CharField()
+    qm_cicustom = serializers.CharField()
+    operator_instructions = serializers.CharField()
+    download_upid = serializers.CharField(required=False, allow_null=True)
+    create_upid = serializers.CharField(required=False, allow_null=True)

--- a/netbox_proxbox/api/views.py
+++ b/netbox_proxbox/api/views.py
@@ -30,12 +30,15 @@ from .serializers import (
     ProxmoxNodeSerializer,
     ProxmoxStorageSerializer,
     ProxmoxVMCloudInitSerializer,
+    PVETemplateBuildRequestSerializer,
+    PVETemplateBuildResponseSerializer,
     ReplicationSerializer,
     ScheduleSyncRequestSerializer,
     VMBackupSerializer,
     VMSnapshotSerializer,
     VMTaskHistorySerializer,
 )
+from netbox_proxbox.api.build_pve_template import build_pve_template_via_backend
 
 
 class ProxBoxRootView(APIRootView):
@@ -183,6 +186,40 @@ class ProxmoxEndpointViewSet(NetBoxModelViewSet):
     )
     serializer_class = ProxmoxEndpointSerializer
     filterset_class = filtersets.ProxmoxEndpointFilterSet
+
+    @extend_schema(
+        request=PVETemplateBuildRequestSerializer,
+        responses={
+            201: PVETemplateBuildResponseSerializer,
+            502: OpenApiTypes.OBJECT,
+            503: OpenApiTypes.OBJECT,
+        },
+        operation_id="proxbox_proxmox_endpoint_build_pve_template",
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="build-pve-template",
+        url_name="build-pve-template",
+        permission_classes=[IsAuthenticated],
+    )
+    def build_pve_template(self, request: Request, pk: int | None = None) -> Response:
+        """Trigger a PVE-installer cloud-init template build via proxbox-api.
+
+        Validates the request body against ``PVETemplateBuildRequestSerializer``,
+        injects ``endpoint_id`` from the URL path, then proxies the call to
+        the companion ``POST /cloud/templates/pve`` endpoint on proxbox-api.
+        The response is the upstream body verbatim — including the rendered
+        cloud-init snippets the operator must drop into
+        ``/var/lib/vz/snippets/`` on the target host.
+        """
+        endpoint = self.get_object()
+        serializer = PVETemplateBuildRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        payload = dict(serializer.validated_data)
+        payload["endpoint_id"] = endpoint.pk
+        body, status_code = build_pve_template_via_backend(payload)
+        return Response(body, status=status_code)
 
 
 class NetBoxEndpointViewSet(NetBoxModelViewSet):

--- a/tests/test_build_pve_template.py
+++ b/tests/test_build_pve_template.py
@@ -1,0 +1,46 @@
+"""Static contracts for the build-pve-template REST action on ProxmoxEndpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pve_template_serializer_module_exists() -> None:
+    module = ROOT / "netbox_proxbox/api/serializers/pve_template.py"
+    src = module.read_text()
+    for token in (
+        "PVETemplateBuildRequestSerializer",
+        "PVETemplateBuildResponseSerializer",
+        "vmid",
+        "target_node",
+        "pve_version_pin",
+        "ssh_authorized_keys",
+        "create_vm",
+    ):
+        assert token in src, f"missing token in pve_template.py serializer: {token!r}"
+
+
+def test_pve_template_serializer_exported() -> None:
+    init = (ROOT / "netbox_proxbox/api/serializers/__init__.py").read_text()
+    assert "PVETemplateBuildRequestSerializer" in init
+    assert "PVETemplateBuildResponseSerializer" in init
+
+
+def test_build_pve_template_action_registered_on_viewset() -> None:
+    views = (ROOT / "netbox_proxbox/api/views.py").read_text()
+    for token in (
+        'url_path="build-pve-template"',
+        "PVETemplateBuildRequestSerializer",
+        "build_pve_template_via_backend",
+        '"endpoint_id"',
+    ):
+        assert token in views, f"missing token in api/views.py: {token!r}"
+
+
+def test_build_pve_template_backend_helper_targets_correct_path() -> None:
+    helper = (ROOT / "netbox_proxbox/api/build_pve_template.py").read_text()
+    assert "/cloud/templates/pve" in helper
+    assert "get_fastapi_request_context" in helper
+    assert "requests.post" in helper


### PR DESCRIPTION
Closes #451.

## Summary

Adds a focused REST action on the existing `ProxmoxEndpointViewSet` that proxies a PVE-installer cloud-init template build to the proxbox-api companion endpoint:

`POST /api/plugins/proxbox/endpoints/proxmox/{id}/build-pve-template/`

The body is validated by `PVETemplateBuildRequestSerializer` (mirrors the upstream Pydantic schema field-for-field), `endpoint_id` is injected from the URL path so callers cannot impersonate a different endpoint, and the request is forwarded to proxbox-api via the existing `FastAPIEndpoint` resolver. Errors are surfaced 1:1 so the NMS UI can render the upstream `detail` string verbatim.

## Files

- `netbox_proxbox/api/serializers/pve_template.py` — `PVETemplateBuildRequestSerializer` / `PVETemplateBuildResponseSerializer`.
- `netbox_proxbox/api/build_pve_template.py` — `build_pve_template_via_backend()` helper, uses `get_fastapi_request_context()` to resolve the singleton FastAPI endpoint.
- `netbox_proxbox/api/views.py` — `@action(detail=True, methods=["post"], url_path="build-pve-template")` on `ProxmoxEndpointViewSet`.
- `netbox_proxbox/api/serializers/__init__.py` — re-exports.
- `tests/test_build_pve_template.py` — static contract tests for serializer fields, action registration, and upstream URL target.

## Cross-repo

The matching backend endpoint lives on a sibling branch in `proxbox-api` (`proxmox-cloudinit-image` → `main`). The NMS UI surface lives on a sibling branch in `N-MultiCloud/nms` (`proxmox-cloudinit-image` → `main`).

## Test plan

- [ ] `python -m compileall netbox_proxbox tests`
- [ ] `pytest tests/test_build_pve_template.py`
- [ ] `ruff check .`
- [ ] Smoke against a running NetBox + proxbox-api: POST the action with `create_vm=false` and confirm the rendered cloud-init payloads come through unchanged.