### PR TITLE
feat(packer): netbox_packer UI surface (#458)

### DIFF
--- a/netbox_packer/netbox_packer/filtersets.py
+++ b/netbox_packer/netbox_packer/filtersets.py
@@ -1,17 +1,50 @@
-"""Minimal filtersets for netbox-packer API queries."""
+"""NetBox filtersets for netbox-packer list views and API queries."""
 
 from __future__ import annotations
 
+import django_filters
+from django.db.models import Q, QuerySet
 from netbox.filtersets import NetBoxModelFilterSet
+from tenancy.models import Tenant
+from virtualization.models import Cluster
 
+from netbox_packer.choices import (
+    PackerBuildStatusChoices,
+    PackerBuilderTypeChoices,
+    PackerOSFamilyChoices,
+    PackerProvisionerRecipeChoices,
+)
 from netbox_packer.models import (
     PackerImageBuild,
     PackerImageDefinition,
     PackerPluginSettings,
 )
+from netbox_proxbox.models import ProxmoxEndpoint
 
 
 class PackerImageDefinitionFilterSet(NetBoxModelFilterSet):
+    """Filter reusable image definitions."""
+
+    proxmox_endpoint = django_filters.ModelMultipleChoiceFilter(
+        queryset=ProxmoxEndpoint.objects.all(),
+    )
+    target_cluster = django_filters.ModelMultipleChoiceFilter(
+        queryset=Cluster.objects.all(),
+    )
+    os_family = django_filters.MultipleChoiceFilter(
+        choices=PackerOSFamilyChoices,
+    )
+    builder_type = django_filters.MultipleChoiceFilter(
+        choices=PackerBuilderTypeChoices,
+    )
+    provisioner_recipe = django_filters.MultipleChoiceFilter(
+        choices=PackerProvisionerRecipeChoices,
+    )
+    tenant = django_filters.ModelMultipleChoiceFilter(
+        field_name="allowed_tenants",
+        queryset=Tenant.objects.all(),
+    )
+
     class Meta:
         model = PackerImageDefinition
         fields = (
@@ -25,10 +58,41 @@ class PackerImageDefinitionFilterSet(NetBoxModelFilterSet):
             "target_node",
             "os_family",
             "provisioner_recipe",
+            "tenant",
+        )
+
+    def search(
+        self,
+        queryset: QuerySet[PackerImageDefinition],
+        name: str,
+        value: str,
+    ) -> QuerySet[PackerImageDefinition]:
+        """Match image definition name or description."""
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(name__icontains=value) | Q(description__icontains=value)
         )
 
 
 class PackerImageBuildFilterSet(NetBoxModelFilterSet):
+    """Filter image build executions."""
+
+    status = django_filters.MultipleChoiceFilter(
+        choices=PackerBuildStatusChoices,
+    )
+    proxmox_endpoint = django_filters.ModelMultipleChoiceFilter(
+        queryset=ProxmoxEndpoint.objects.all(),
+    )
+    os_family = django_filters.MultipleChoiceFilter(
+        field_name="definition__os_family",
+        choices=PackerOSFamilyChoices,
+    )
+    tenant = django_filters.ModelMultipleChoiceFilter(
+        field_name="definition__allowed_tenants",
+        queryset=Tenant.objects.all(),
+    )
+
     class Meta:
         model = PackerImageBuild
         fields = (
@@ -43,6 +107,23 @@ class PackerImageBuildFilterSet(NetBoxModelFilterSet):
             "created_by",
             "netbox_job_id",
             "cloud_image_template",
+            "os_family",
+            "tenant",
+        )
+
+    def search(
+        self,
+        queryset: QuerySet[PackerImageBuild],
+        name: str,
+        value: str,
+    ) -> QuerySet[PackerImageBuild]:
+        """Match build output, backend identifier, or error text."""
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(output_name__icontains=value)
+            | Q(backend_build_id__icontains=value)
+            | Q(error__icontains=value)
         )
 
 

--- a/netbox_packer/netbox_packer/forms.py
+++ b/netbox_packer/netbox_packer/forms.py
@@ -1,32 +1,293 @@
-"""Stub NetBox forms for netbox-packer.
-
-Real edit and filter fields land in PHASE3.
-"""
+"""NetBox forms for netbox-packer image factory views."""
 
 from __future__ import annotations
 
-from netbox.forms import NetBoxModelForm
+from django import forms
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from netbox.forms import NetBoxModelFilterSetForm, NetBoxModelForm
+from tenancy.models import Tenant
+from utilities.forms.fields import (
+    CommentField,
+    DynamicModelChoiceField,
+    DynamicModelMultipleChoiceField,
+    JSONField,
+)
+from utilities.forms.rendering import FieldSet
+from virtualization.models import Cluster
 
+from netbox_packer.choices import (
+    PackerBuildStatusChoices,
+    PackerBuilderTypeChoices,
+    PackerOSFamilyChoices,
+    PackerProvisionerRecipeChoices,
+)
 from netbox_packer.models import (
     PackerImageBuild,
     PackerImageDefinition,
     PackerPluginSettings,
 )
+from netbox_proxbox.models import ProxmoxEndpoint
 
 
 class PackerImageDefinitionForm(NetBoxModelForm):
+    """Create and edit reusable Packer image definitions."""
+
+    proxmox_endpoint = DynamicModelChoiceField(
+        queryset=ProxmoxEndpoint.objects.all(),
+        required=True,
+        label=_("Proxmox endpoint"),
+    )
+    target_cluster = DynamicModelChoiceField(
+        queryset=Cluster.objects.all(),
+        required=False,
+        label=_("Target cluster"),
+    )
+    allowed_tenants = DynamicModelMultipleChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Allowed tenants"),
+        help_text=_("Leave empty to make this definition available to all tenants."),
+    )
+    default_variables = JSONField(
+        required=False,
+        label=_("Default variables"),
+    )
+    comments = CommentField()
+
+    fieldsets = (
+        FieldSet(
+            "name",
+            "slug",
+            "description",
+            "enabled",
+            "tags",
+            name=_("Image definition"),
+        ),
+        FieldSet(
+            "builder_type",
+            "proxmox_endpoint",
+            "target_cluster",
+            "target_node",
+            "source_template_vmid",
+            "default_storage",
+            "default_bridge",
+            name=_("Proxmox target"),
+        ),
+        FieldSet(
+            "os_family",
+            "os_release",
+            "default_ciuser",
+            "provisioner_recipe",
+            "default_variables",
+            name=_("Image defaults"),
+        ),
+        FieldSet("allowed_tenants", name=_("Tenant scope")),
+    )
+
     class Meta:
         model = PackerImageDefinition
-        fields: tuple[str, ...] = ()
+        fields = (
+            "name",
+            "slug",
+            "description",
+            "enabled",
+            "builder_type",
+            "proxmox_endpoint",
+            "target_cluster",
+            "target_node",
+            "source_template_vmid",
+            "default_storage",
+            "default_bridge",
+            "os_family",
+            "os_release",
+            "default_ciuser",
+            "provisioner_recipe",
+            "default_variables",
+            "allowed_tenants",
+            "tags",
+            "comments",
+        )
 
 
-class PackerImageBuildForm(NetBoxModelForm):
-    class Meta:
-        model = PackerImageBuild
-        fields: tuple[str, ...] = ()
+class PackerImageBuildSubmitForm(forms.Form):
+    """Action form for queueing a build in a later phase."""
+
+    output_vmid = forms.IntegerField(
+        min_value=1,
+        required=True,
+        label=_("Output VMID"),
+    )
+    output_name = forms.CharField(
+        max_length=255,
+        required=True,
+        label=_("Output name"),
+    )
+    image_version = forms.CharField(
+        max_length=64,
+        required=True,
+        label=_("Image version"),
+    )
+    dry_run = forms.BooleanField(
+        required=False,
+        label=_("Dry run"),
+    )
+    force = forms.BooleanField(
+        required=False,
+        label=_("Force"),
+    )
+
+    def __init__(
+        self,
+        *args: object,
+        definition: PackerImageDefinition | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        if definition is None:
+            return
+
+        defaults = definition.default_variables or {}
+        today = timezone.localdate()
+        self.fields["output_vmid"].initial = defaults.get("output_vmid")
+        self.fields["output_name"].initial = defaults.get(
+            "output_name",
+            f"{definition.slug}-{today:%Y%m%d}",
+        )
+        self.fields["image_version"].initial = defaults.get(
+            "image_version",
+            today.isoformat(),
+        )
+        self.fields["dry_run"].initial = bool(defaults.get("dry_run", False))
+        self.fields["force"].initial = bool(defaults.get("force", False))
+
+    def clean_output_name(self) -> str:
+        value = (self.cleaned_data.get("output_name") or "").strip()
+        if not value:
+            raise forms.ValidationError(_("Output name is required."))
+        return value
+
+    def clean_image_version(self) -> str:
+        value = (self.cleaned_data.get("image_version") or "").strip()
+        if not value:
+            raise forms.ValidationError(_("Image version is required."))
+        return value
 
 
 class PackerPluginSettingsForm(NetBoxModelForm):
+    """Edit the singleton image factory settings row."""
+
+    fieldsets = (
+        FieldSet(
+            "image_factory_enabled",
+            "image_factory_max_concurrent_builds",
+            "image_factory_default_job_timeout",
+            name=_("Execution"),
+        ),
+        FieldSet(
+            "image_factory_allow_iso_builds",
+            "image_factory_allow_custom_variables",
+            "tags",
+            name=_("Feature gates"),
+        ),
+    )
+
     class Meta:
         model = PackerPluginSettings
-        fields: tuple[str, ...] = ()
+        fields = (
+            "image_factory_enabled",
+            "image_factory_max_concurrent_builds",
+            "image_factory_default_job_timeout",
+            "image_factory_allow_iso_builds",
+            "image_factory_allow_custom_variables",
+            "tags",
+        )
+
+
+class PackerImageDefinitionFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for image definition list views."""
+
+    model = PackerImageDefinition
+
+    q = forms.CharField(required=False, label=_("Search"))
+    enabled = forms.NullBooleanField(
+        required=False,
+        widget=forms.Select(
+            choices=[("", "---------"), ("true", _("Yes")), ("false", _("No"))],
+        ),
+        label=_("Enabled"),
+    )
+    builder_type = forms.MultipleChoiceField(
+        choices=PackerBuilderTypeChoices,
+        required=False,
+        label=_("Builder type"),
+    )
+    os_family = forms.MultipleChoiceField(
+        choices=PackerOSFamilyChoices,
+        required=False,
+        label=_("OS family"),
+    )
+    provisioner_recipe = forms.MultipleChoiceField(
+        choices=PackerProvisionerRecipeChoices,
+        required=False,
+        label=_("Provisioner recipe"),
+    )
+    proxmox_endpoint = DynamicModelMultipleChoiceField(
+        queryset=ProxmoxEndpoint.objects.all(),
+        required=False,
+        label=_("Proxmox endpoint"),
+    )
+    target_cluster = DynamicModelMultipleChoiceField(
+        queryset=Cluster.objects.all(),
+        required=False,
+        label=_("Target cluster"),
+    )
+    tenant = DynamicModelMultipleChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Tenant"),
+    )
+
+    fieldsets = (
+        FieldSet("q", "enabled", "builder_type", "os_family", name=_("Definition")),
+        FieldSet(
+            "proxmox_endpoint",
+            "target_cluster",
+            "tenant",
+            "provisioner_recipe",
+            name=_("Scope"),
+        ),
+    )
+
+
+class PackerImageBuildFilterForm(NetBoxModelFilterSetForm):
+    """Filter controls for image build list views."""
+
+    model = PackerImageBuild
+
+    q = forms.CharField(required=False, label=_("Search"))
+    status = forms.MultipleChoiceField(
+        choices=PackerBuildStatusChoices,
+        required=False,
+        label=_("Status"),
+    )
+    os_family = forms.MultipleChoiceField(
+        choices=PackerOSFamilyChoices,
+        required=False,
+        label=_("OS family"),
+    )
+    proxmox_endpoint = DynamicModelMultipleChoiceField(
+        queryset=ProxmoxEndpoint.objects.all(),
+        required=False,
+        label=_("Proxmox endpoint"),
+    )
+    tenant = DynamicModelMultipleChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label=_("Tenant"),
+    )
+
+    fieldsets = (
+        FieldSet("q", "status", "os_family", name=_("Build")),
+        FieldSet("proxmox_endpoint", "tenant", name=_("Scope")),
+    )

--- a/netbox_packer/netbox_packer/navigation.py
+++ b/netbox_packer/netbox_packer/navigation.py
@@ -1,15 +1,33 @@
-"""Empty NetBox plugin navigation menu for netbox-packer.
-
-Menu items land with the UI views in PHASE3.
-"""
+"""NetBox plugin navigation menu for netbox-packer."""
 
 from __future__ import annotations
 
-from netbox.plugins import PluginMenu
+from netbox.plugins import PluginMenu, PluginMenuItem
 
 
 menu = PluginMenu(
     label="Packer",
-    groups=(),
-    icon_class="mdi mdi-package-variant",
+    groups=(
+        (
+            "Image Factory",
+            (
+                PluginMenuItem(
+                    link="plugins:netbox_packer:packerimagedefinition_list",
+                    link_text="Image Definitions",
+                    permissions=["netbox_packer.view_packerimagedefinition"],
+                ),
+                PluginMenuItem(
+                    link="plugins:netbox_packer:packerimagebuild_list",
+                    link_text="Image Builds",
+                    permissions=["netbox_packer.view_packerimagebuild"],
+                ),
+                PluginMenuItem(
+                    link="plugins:netbox_packer:packerpluginsettings_singleton_edit",
+                    link_text="Plugin Settings",
+                    permissions=["netbox_packer.change_packerpluginsettings"],
+                ),
+            ),
+        ),
+    ),
+    icon_class="mdi mdi-package-variant-closed",
 )

--- a/netbox_packer/netbox_packer/tables.py
+++ b/netbox_packer/netbox_packer/tables.py
@@ -1,24 +1,119 @@
-"""Minimal django-tables2 layouts for future netbox-packer UI views."""
+"""django-tables2 layouts for netbox-packer UI views."""
 
 from __future__ import annotations
 
+import django_tables2 as tables
 from netbox.tables import NetBoxTable
+from netbox.tables.columns import BooleanColumn
 
 from netbox_packer.models import (
     PackerImageBuild,
     PackerImageDefinition,
-    PackerPluginSettings,
 )
 
 
+_BUILD_STATUS_BADGE = """
+{% if value == "completed" %}
+  <span class="badge text-bg-green">{{ record.get_status_display }}</span>
+{% elif value == "running" %}
+  <span class="badge text-bg-blue">{{ record.get_status_display }}</span>
+{% elif value == "failed" %}
+  <span class="badge text-bg-red">{{ record.get_status_display }}</span>
+{% elif value == "cancelled" %}
+  <span class="badge text-bg-yellow">{{ record.get_status_display }}</span>
+{% else %}
+  <span class="badge text-bg-secondary">{{ record.get_status_display }}</span>
+{% endif %}
+"""
+
+_LAST_BUILD_STATUS_BADGE = """
+{% with build=record.builds.first %}
+  {% if build %}
+    {% if build.status == "completed" %}
+      <span class="badge text-bg-green">{{ build.get_status_display }}</span>
+    {% elif build.status == "running" %}
+      <span class="badge text-bg-blue">{{ build.get_status_display }}</span>
+    {% elif build.status == "failed" %}
+      <span class="badge text-bg-red">{{ build.get_status_display }}</span>
+    {% elif build.status == "cancelled" %}
+      <span class="badge text-bg-yellow">{{ build.get_status_display }}</span>
+    {% else %}
+      <span class="badge text-bg-secondary">{{ build.get_status_display }}</span>
+    {% endif %}
+  {% else %}
+    <span class="text-muted">&mdash;</span>
+  {% endif %}
+{% endwith %}
+"""
+
+
 class PackerImageDefinitionTable(NetBoxTable):
+    name = tables.Column(linkify=True)
+    proxmox_endpoint = tables.Column(linkify=True)
+    target_cluster = tables.Column(linkify=True)
+    enabled = BooleanColumn()
+    last_build_at = tables.TemplateColumn(
+        template_code=(
+            "{% load helpers %}"
+            "{% with build=record.builds.first %}"
+            "{% if build %}{{ build.started_at|placeholder }}{% else %}"
+            '<span class="text-muted">&mdash;</span>{% endif %}{% endwith %}'
+        ),
+        verbose_name="Last build",
+        orderable=False,
+    )
+    last_build_status = tables.TemplateColumn(
+        template_code=_LAST_BUILD_STATUS_BADGE,
+        verbose_name="Last status",
+        orderable=False,
+    )
+
     class Meta(NetBoxTable.Meta):
         model = PackerImageDefinition
-        fields = ("pk", "id", "name", "slug", "enabled", "builder_type", "actions")
-        default_columns = ("name", "slug", "enabled", "builder_type")
+        fields = (
+            "pk",
+            "id",
+            "name",
+            "os_family",
+            "os_release",
+            "builder_type",
+            "proxmox_endpoint",
+            "target_cluster",
+            "target_node",
+            "provisioner_recipe",
+            "enabled",
+            "last_build_at",
+            "last_build_status",
+            "tags",
+            "actions",
+        )
+        default_columns = (
+            "name",
+            "os_family",
+            "os_release",
+            "builder_type",
+            "proxmox_endpoint",
+            "target_node",
+            "provisioner_recipe",
+            "enabled",
+            "last_build_at",
+            "last_build_status",
+            "tags",
+        )
 
 
 class PackerImageBuildTable(NetBoxTable):
+    id = tables.Column(linkify=True)
+    definition = tables.Column(linkify=True)
+    status = tables.TemplateColumn(
+        template_code=_BUILD_STATUS_BADGE,
+        verbose_name="Status",
+        order_by=("status",),
+    )
+    proxmox_endpoint = tables.Column(linkify=True)
+    created_by = tables.Column(linkify=True)
+    cloud_image_template = tables.Column(linkify=True)
+
     class Meta(NetBoxTable.Meta):
         model = PackerImageBuild
         fields = (
@@ -27,24 +122,29 @@ class PackerImageBuildTable(NetBoxTable):
             "definition",
             "status",
             "backend_build_id",
+            "proxmox_endpoint",
             "target_node",
             "output_vmid",
+            "output_name",
             "image_version",
             "started_at",
             "completed_at",
+            "created_by",
+            "cloud_image_template",
+            "tags",
             "actions",
         )
         default_columns = (
+            "id",
             "definition",
             "status",
+            "proxmox_endpoint",
             "target_node",
             "output_vmid",
+            "output_name",
             "image_version",
+            "started_at",
+            "completed_at",
+            "created_by",
+            "cloud_image_template",
         )
-
-
-class PackerPluginSettingsTable(NetBoxTable):
-    class Meta(NetBoxTable.Meta):
-        model = PackerPluginSettings
-        fields = ("pk", "singleton_key", "image_factory_enabled", "actions")
-        default_columns = ("singleton_key", "image_factory_enabled")

--- a/netbox_packer/netbox_packer/templates/netbox_packer/packerimagebuild.html
+++ b/netbox_packer/netbox_packer/templates/netbox_packer/packerimagebuild.html
@@ -1,0 +1,145 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+
+{% block extra_controls %}
+  {% if perms.core.delete_job and perms.netbox_packer.change_packerimagebuild %}
+    <form method="post" action="{% url 'plugins:netbox_packer:packerimagebuild_cancel' pk=object.pk %}" class="d-inline">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-outline-danger">
+        <i class="mdi mdi-close-circle-outline" aria-hidden="true"></i>
+        {% trans "Cancel" %}
+      </button>
+    </form>
+  {% endif %}
+{% endblock extra_controls %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Image Build" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Definition" %}</th>
+            <td>{{ object.definition|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Status" %}</th>
+            <td>
+              {% if object.status == "completed" %}
+                <span class="badge text-bg-green">{{ object.get_status_display }}</span>
+              {% elif object.status == "running" %}
+                <span class="badge text-bg-blue">{{ object.get_status_display }}</span>
+              {% elif object.status == "failed" %}
+                <span class="badge text-bg-red">{{ object.get_status_display }}</span>
+              {% elif object.status == "cancelled" %}
+                <span class="badge text-bg-yellow">{{ object.get_status_display }}</span>
+              {% else %}
+                <span class="badge text-bg-secondary">{{ object.get_status_display }}</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Backend build ID" %}</th>
+            <td>{{ object.backend_build_id|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Created by" %}</th>
+            <td>{{ object.created_by|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "NetBox job ID" %}</th>
+            <td>{{ object.netbox_job_id|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Cloud image template" %}</th>
+            <td>{{ object.cloud_image_template|linkify|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Output" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Endpoint" %}</th>
+            <td>{{ object.proxmox_endpoint|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Target node" %}</th>
+            <td>{{ object.target_node }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Output VMID" %}</th>
+            <td>{{ object.output_vmid }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Output name" %}</th>
+            <td>{{ object.output_name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Image version" %}</th>
+            <td>{{ object.image_version }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    {% include 'inc/panels/custom_fields.html' %}
+  </div>
+
+  <div class="col col-md-6">
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Timeline" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Started" %}</th>
+            <td>{{ object.started_at|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Completed" %}</th>
+            <td>{{ object.completed_at|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Created" %}</th>
+            <td>{{ object.created|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Last updated" %}</th>
+            <td>{{ object.last_updated|placeholder }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Logs" %}</h5>
+      <div class="card-body">
+        <p class="text-muted mb-0">{% trans "Logs stream once builds are wired in PHASE4" %}</p>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Backend Response" %}</h5>
+      <div class="card-body">
+        <pre class="mb-0"><code>{{ object.backend_response|default:"{}" }}</code></pre>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Error" %}</h5>
+      <div class="card-body">
+        <pre class="mb-0"><code>{{ object.error|placeholder }}</code></pre>
+      </div>
+    </div>
+
+    {% include 'inc/panels/tags.html' %}
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
+{% endblock content %}

--- a/netbox_packer/netbox_packer/templates/netbox_packer/packerimagebuild_list.html
+++ b/netbox_packer/netbox_packer/templates/netbox_packer/packerimagebuild_list.html
@@ -1,0 +1,6 @@
+{% extends 'generic/object_list.html' %}
+{% load i18n %}
+
+{% block title %}
+  {% trans "Packer Image Builds" %}
+{% endblock %}

--- a/netbox_packer/netbox_packer/templates/netbox_packer/packerimagedefinition.html
+++ b/netbox_packer/netbox_packer/templates/netbox_packer/packerimagedefinition.html
@@ -1,0 +1,171 @@
+{% extends 'generic/object.html' %}
+{% load form_helpers %}
+{% load helpers %}
+{% load i18n %}
+
+{% block extra_controls %}
+  {% if perms.core.add_job and perms.netbox_packer.add_packerimagebuild %}
+    <button class="btn btn-primary" type="button" data-bs-toggle="modal" data-bs-target="#packer-build-modal">
+      <i class="mdi mdi-hammer-wrench" aria-hidden="true"></i>
+      {% trans "Build" %}
+    </button>
+  {% endif %}
+{% endblock extra_controls %}
+
+{% block content %}
+<div class="row mb-3">
+  <div class="col col-md-6">
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Image Definition" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Name" %}</th>
+            <td>{{ object.name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Slug" %}</th>
+            <td>{{ object.slug }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Description" %}</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Enabled" %}</th>
+            <td>
+              {% if object.enabled %}
+                <span class="text-success"><i class="mdi mdi-check"></i> {% trans "Yes" %}</span>
+              {% else %}
+                <span class="text-danger"><i class="mdi mdi-close"></i> {% trans "No" %}</span>
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Builder type" %}</th>
+            <td>{{ object.get_builder_type_display }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Provisioner recipe" %}</th>
+            <td>{{ object.get_provisioner_recipe_display }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Proxmox Target" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "Endpoint" %}</th>
+            <td>{{ object.proxmox_endpoint|linkify }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Target cluster" %}</th>
+            <td>{{ object.target_cluster|linkify|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Target node" %}</th>
+            <td>{{ object.target_node }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Source template VMID" %}</th>
+            <td>{{ object.source_template_vmid }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Default storage" %}</th>
+            <td>{{ object.default_storage }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Default bridge" %}</th>
+            <td>{{ object.default_bridge }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    {% include 'inc/panels/custom_fields.html' %}
+  </div>
+
+  <div class="col col-md-6">
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Image Defaults" %}</h5>
+      <div class="card-body">
+        <table class="table table-hover attr-table">
+          <tr>
+            <th scope="row">{% trans "OS family" %}</th>
+            <td>{{ object.get_os_family_display }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "OS release" %}</th>
+            <td>{{ object.os_release }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "Default cloud-init user" %}</th>
+            <td>{{ object.default_ciuser }}</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Default Variables" %}</h5>
+      <div class="card-body">
+        <pre class="mb-0"><code>{{ object.default_variables|default:"{}" }}</code></pre>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <h5 class="card-header">{% trans "Tenant Scope" %}</h5>
+      <div class="card-body">
+        {% if object.allowed_tenants.exists %}
+          <ul class="list-unstyled mb-0">
+            {% for tenant in object.allowed_tenants.all %}
+              <li>{{ tenant|linkify }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <span class="text-muted">{% trans "All tenants" %}</span>
+        {% endif %}
+      </div>
+    </div>
+
+    {% include 'inc/panels/tags.html' %}
+    {% include 'inc/panels/comments.html' %}
+  </div>
+</div>
+{% endblock content %}
+
+{% block modals %}
+  {{ block.super }}
+  {% if perms.core.add_job and perms.netbox_packer.add_packerimagebuild %}
+    <div class="modal fade" id="packer-build-modal" tabindex="-1" aria-labelledby="packer-build-modal-label" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <form method="post" action="{{ build_url }}">
+            {% csrf_token %}
+            <div class="modal-header">
+              <h5 class="modal-title" id="packer-build-modal-label">{% trans "Build image" %}</h5>
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% trans 'Close' %}"></button>
+            </div>
+            <div class="modal-body">
+              {% render_field build_form.output_vmid %}
+              {% render_field build_form.output_name %}
+              {% render_field build_form.image_version %}
+              {% render_field build_form.dry_run %}
+              {% render_field build_form.force %}
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+              <button type="submit" class="btn btn-primary">
+                <i class="mdi mdi-hammer-wrench" aria-hidden="true"></i>
+                {% trans "Build" %}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock modals %}

--- a/netbox_packer/netbox_packer/templates/netbox_packer/packerimagedefinition_edit.html
+++ b/netbox_packer/netbox_packer/templates/netbox_packer/packerimagedefinition_edit.html
@@ -1,0 +1,10 @@
+{% extends 'generic/object_edit.html' %}
+{% load i18n %}
+
+{% block title %}
+  {% if object.pk %}
+    {% trans "Editing Packer image definition" %} {{ object }}
+  {% else %}
+    {% trans "Add a new Packer image definition" %}
+  {% endif %}
+{% endblock title %}

--- a/netbox_packer/netbox_packer/templates/netbox_packer/packerimagedefinition_list.html
+++ b/netbox_packer/netbox_packer/templates/netbox_packer/packerimagedefinition_list.html
@@ -1,0 +1,6 @@
+{% extends 'generic/object_list.html' %}
+{% load i18n %}
+
+{% block title %}
+  {% trans "Packer Image Definitions" %}
+{% endblock %}

--- a/netbox_packer/netbox_packer/templates/netbox_packer/packerpluginsettings_edit.html
+++ b/netbox_packer/netbox_packer/templates/netbox_packer/packerpluginsettings_edit.html
@@ -1,0 +1,6 @@
+{% extends 'generic/object_edit.html' %}
+{% load i18n %}
+
+{% block title %}
+  {% trans "Packer plugin settings" %}
+{% endblock title %}

--- a/netbox_packer/netbox_packer/urls.py
+++ b/netbox_packer/netbox_packer/urls.py
@@ -1,10 +1,37 @@
-"""URL routes for netbox-packer.
-
-Model UI views land in PHASE3.
-"""
+"""URL routes for netbox-packer."""
 
 from __future__ import annotations
 
+from django.urls import include, path
+from utilities.urls import get_model_urls
+
+from netbox_packer import views
+
 app_name = "netbox_packer"
 
-urlpatterns: list = []
+_MODEL_ROUTES = (
+    ("packerimagedefinition", "image-definitions"),
+    ("packerimagebuild", "image-builds"),
+    ("packerpluginsettings", "settings"),
+)
+
+urlpatterns = [
+    path("", views.PackerHomeView.as_view(), name="home"),
+    path(
+        "settings/edit/",
+        views.settings_singleton_redirect,
+        name="packerpluginsettings_singleton_edit",
+    ),
+]
+
+for _model_name, _slug in _MODEL_ROUTES:
+    urlpatterns += [
+        path(
+            f"{_slug}/<int:pk>/",
+            include(get_model_urls("netbox_packer", _model_name)),
+        ),
+        path(
+            f"{_slug}/",
+            include(get_model_urls("netbox_packer", _model_name, detail=False)),
+        ),
+    ]

--- a/netbox_packer/netbox_packer/views.py
+++ b/netbox_packer/netbox_packer/views.py
@@ -1,6 +1,262 @@
-"""UI view placeholders for netbox-packer.
-
-The PHASE2 plugin exposes only REST API viewsets.
-"""
+"""Views for the netbox-packer UI surface."""
 
 from __future__ import annotations
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
+from django.views import View
+from netbox.views import generic
+from utilities.permissions import get_permission_for_model
+from utilities.views import (
+    ConditionalLoginRequiredMixin,
+    ContentTypePermissionRequiredMixin,
+    ViewTab,
+    register_model_view,
+)
+
+from core.models import Job
+from netbox_packer import filtersets, forms, tables
+from netbox_packer.models import (
+    PackerImageBuild,
+    PackerImageDefinition,
+    PackerPluginSettings,
+)
+
+PHASE4_BUILD_MESSAGE = "Build queueing wired in PHASE4"
+PHASE4_CANCEL_MESSAGE = "Cancel wired in PHASE4"
+
+
+class PackerHomeView(ConditionalLoginRequiredMixin, generic.ObjectListView):
+    """Plugin home landing renders the image definition list."""
+
+    queryset = (
+        PackerImageDefinition.objects.select_related(
+            "proxmox_endpoint",
+            "target_cluster",
+        )
+        .prefetch_related("allowed_tenants", "tags")
+        .all()
+    )
+    table = tables.PackerImageDefinitionTable
+    filterset = filtersets.PackerImageDefinitionFilterSet
+    filterset_form = forms.PackerImageDefinitionFilterForm
+    template_name = "netbox_packer/packerimagedefinition_list.html"
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+@register_model_view(PackerPluginSettings)
+class PackerPluginSettingsView(generic.ObjectView):
+    queryset = PackerPluginSettings.objects.all()
+
+
+@register_model_view(PackerPluginSettings, "edit")
+class PackerPluginSettingsEditView(generic.ObjectEditView):
+    queryset = PackerPluginSettings.objects.all()
+    form = forms.PackerPluginSettingsForm
+    template_name = "netbox_packer/packerpluginsettings_edit.html"
+
+
+class PackerSettingsSingletonRedirectView(
+    ConditionalLoginRequiredMixin,
+    ContentTypePermissionRequiredMixin,
+    View,
+):
+    """Always edit the singleton settings row."""
+
+    def get_required_permission(self) -> str:
+        return "netbox_packer.change_packerpluginsettings"
+
+    def get(self, request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
+        obj = PackerPluginSettings.get_solo()
+        return redirect("plugins:netbox_packer:packerpluginsettings_edit", pk=obj.pk)
+
+
+settings_singleton_redirect = PackerSettingsSingletonRedirectView.as_view()
+
+
+# ---------------------------------------------------------------------------
+# Image definitions
+# ---------------------------------------------------------------------------
+
+
+@register_model_view(PackerImageDefinition)
+class PackerImageDefinitionView(generic.ObjectView):
+    queryset = (
+        PackerImageDefinition.objects.select_related(
+            "proxmox_endpoint",
+            "target_cluster",
+        )
+        .prefetch_related("allowed_tenants", "tags")
+        .all()
+    )
+    template_name = "netbox_packer/packerimagedefinition.html"
+
+    def get_extra_context(
+        self,
+        request: HttpRequest,
+        instance: PackerImageDefinition,
+    ) -> dict[str, object]:
+        return {
+            "build_form": forms.PackerImageBuildSubmitForm(definition=instance),
+            "build_url": reverse(
+                "plugins:netbox_packer:packerimagedefinition_build",
+                args=[instance.pk],
+            ),
+        }
+
+
+@register_model_view(PackerImageDefinition, "list", path="", detail=False)
+class PackerImageDefinitionListView(generic.ObjectListView):
+    queryset = (
+        PackerImageDefinition.objects.select_related(
+            "proxmox_endpoint",
+            "target_cluster",
+        )
+        .prefetch_related("allowed_tenants", "tags")
+        .all()
+    )
+    table = tables.PackerImageDefinitionTable
+    filterset = filtersets.PackerImageDefinitionFilterSet
+    filterset_form = forms.PackerImageDefinitionFilterForm
+    template_name = "netbox_packer/packerimagedefinition_list.html"
+
+
+@register_model_view(PackerImageDefinition, "add", detail=False)
+@register_model_view(PackerImageDefinition, "edit")
+class PackerImageDefinitionEditView(generic.ObjectEditView):
+    queryset = PackerImageDefinition.objects.all()
+    form = forms.PackerImageDefinitionForm
+    template_name = "netbox_packer/packerimagedefinition_edit.html"
+
+
+@register_model_view(PackerImageDefinition, "delete")
+class PackerImageDefinitionDeleteView(generic.ObjectDeleteView):
+    queryset = PackerImageDefinition.objects.all()
+
+
+@register_model_view(PackerImageDefinition, "builds", path="builds")
+class PackerImageDefinitionBuildsView(generic.ObjectChildrenView):
+    queryset = PackerImageDefinition.objects.all()
+    child_model = PackerImageBuild
+    table = tables.PackerImageBuildTable
+    filterset = filtersets.PackerImageBuildFilterSet
+    template_name = "generic/object_children.html"
+    actions = {}
+    tab = ViewTab(
+        label="Builds",
+        badge=lambda obj: obj.builds.count(),
+        permission="netbox_packer.view_packerimagebuild",
+    )
+
+    def get_children(
+        self,
+        request: HttpRequest,
+        parent: PackerImageDefinition,
+    ):
+        return parent.builds.select_related(
+            "definition",
+            "proxmox_endpoint",
+            "created_by",
+            "cloud_image_template",
+        )
+
+
+@register_model_view(PackerImageDefinition, "build", path="build")
+class PackerImageBuildSubmitView(
+    ConditionalLoginRequiredMixin,
+    ContentTypePermissionRequiredMixin,
+    View,
+):
+    """POST-only PHASE3 build action placeholder."""
+
+    http_method_names = ["post"]
+    additional_permissions = [
+        get_permission_for_model(PackerImageBuild, "add"),
+    ]
+
+    def get_required_permission(self) -> str:
+        return get_permission_for_model(Job, "add")
+
+    def post(self, request: HttpRequest, pk: int | str) -> HttpResponse:
+        definition = get_object_or_404(
+            PackerImageDefinition.objects.restrict(request.user, "view"),
+            pk=pk,
+        )
+        form = forms.PackerImageBuildSubmitForm(request.POST, definition=definition)
+        if not form.is_valid():
+            return HttpResponse(form.errors.as_json(), status=400)
+        return HttpResponse(
+            f'<div class="alert alert-info">{PHASE4_BUILD_MESSAGE}</div>',
+            status=202,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Image builds
+# ---------------------------------------------------------------------------
+
+
+@register_model_view(PackerImageBuild)
+class PackerImageBuildView(generic.ObjectView):
+    queryset = PackerImageBuild.objects.select_related(
+        "definition",
+        "proxmox_endpoint",
+        "created_by",
+        "cloud_image_template",
+    )
+    template_name = "netbox_packer/packerimagebuild.html"
+
+
+@register_model_view(PackerImageBuild, "list", path="", detail=False)
+class PackerImageBuildListView(generic.ObjectListView):
+    queryset = PackerImageBuild.objects.select_related(
+        "definition",
+        "proxmox_endpoint",
+        "created_by",
+        "cloud_image_template",
+    )
+    table = tables.PackerImageBuildTable
+    filterset = filtersets.PackerImageBuildFilterSet
+    filterset_form = forms.PackerImageBuildFilterForm
+    template_name = "netbox_packer/packerimagebuild_list.html"
+    actions = {}
+
+
+@register_model_view(PackerImageBuild, "logs", path="logs")
+class PackerImageBuildLogsView(PackerImageBuildView):
+    tab = ViewTab(
+        label="Logs",
+        permission="netbox_packer.view_packerimagebuild",
+    )
+
+
+@register_model_view(PackerImageBuild, "cancel", path="cancel")
+class PackerImageBuildCancelView(
+    ConditionalLoginRequiredMixin,
+    ContentTypePermissionRequiredMixin,
+    View,
+):
+    """POST-only PHASE3 cancel action placeholder."""
+
+    http_method_names = ["post"]
+    additional_permissions = [
+        get_permission_for_model(PackerImageBuild, "change"),
+    ]
+
+    def get_required_permission(self) -> str:
+        return get_permission_for_model(Job, "delete")
+
+    def post(self, request: HttpRequest, pk: int | str) -> HttpResponse:
+        get_object_or_404(
+            PackerImageBuild.objects.restrict(request.user, "view"),
+            pk=pk,
+        )
+        return HttpResponse(
+            f'<div class="alert alert-info">{PHASE4_CANCEL_MESSAGE}</div>',
+            status=202,
+        )

--- a/netbox_packer/netbox_packer/views.py
+++ b/netbox_packer/netbox_packer/views.py
@@ -71,7 +71,9 @@ class PackerSettingsSingletonRedirectView(
     def get_required_permission(self) -> str:
         return "netbox_packer.change_packerpluginsettings"
 
-    def get(self, request: HttpRequest, *args: object, **kwargs: object) -> HttpResponse:
+    def get(
+        self, request: HttpRequest, *args: object, **kwargs: object
+    ) -> HttpResponse:
         obj = PackerPluginSettings.get_solo()
         return redirect("plugins:netbox_packer:packerpluginsettings_edit", pk=obj.pk)
 

--- a/tests/netbox_test_configuration.py
+++ b/tests/netbox_test_configuration.py
@@ -1,7 +1,14 @@
 """Tests for netbox_test_configuration."""
 
+import sys
+from pathlib import Path
+
 from netbox.configuration_testing import *  # noqa: F403
 from netbox.configuration_testing import PLUGINS as BASE_PLUGINS
 
 
-PLUGINS = [*BASE_PLUGINS, "netbox_proxbox"]
+PACKER_ROOT = Path(__file__).resolve().parents[1] / "netbox_packer"
+if PACKER_ROOT.exists() and str(PACKER_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKER_ROOT))
+
+PLUGINS = [*BASE_PLUGINS, "netbox_proxbox", "netbox_packer"]

--- a/tests/test_packer_views.py
+++ b/tests/test_packer_views.py
@@ -1,0 +1,232 @@
+"""UI tests for the netbox-packer PHASE3 surface."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKER_ROOT = REPO_ROOT / "netbox_packer"
+NETBOX_ROOTS = (
+    Path("/opt/netbox/netbox"),
+    REPO_ROOT.parent / "netbox" / "netbox",
+)
+
+for candidate in reversed((PACKER_ROOT, REPO_ROOT, *NETBOX_ROOTS)):
+    candidate_str = str(candidate)
+    if candidate.exists() and candidate_str not in sys.path:
+        sys.path.insert(0, candidate_str)
+
+try:
+    import django
+except ModuleNotFoundError:
+    pytest.skip(
+        "Django/NetBox test dependencies are not installed in this environment.",
+        allow_module_level=True,
+    )
+
+os.environ.setdefault("NETBOX_CONFIGURATION", "tests.netbox_test_configuration")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
+
+try:
+    django.setup()
+except Exception as exc:  # pragma: no cover - depends on external test services
+    pytest.skip(
+        f"NetBox test environment is not available: {exc}",
+        allow_module_level=True,
+    )
+
+from django.contrib.auth import get_user_model  # noqa: E402
+from django.contrib.contenttypes.models import ContentType  # noqa: E402
+from django.test import TestCase  # noqa: E402
+from django.urls import reverse  # noqa: E402
+from users.models import ObjectPermission  # noqa: E402
+from virtualization.models import Cluster, ClusterType  # noqa: E402
+
+from core.models import Job  # noqa: E402
+from netbox_packer.choices import (  # noqa: E402
+    PackerBuilderTypeChoices,
+    PackerOSFamilyChoices,
+    PackerProvisionerRecipeChoices,
+)
+from netbox_packer.filtersets import (  # noqa: E402
+    PackerImageBuildFilterSet,
+    PackerImageDefinitionFilterSet,
+)
+from netbox_packer.models import PackerImageBuild, PackerImageDefinition  # noqa: E402
+from netbox_proxbox.models import ProxmoxEndpoint  # noqa: E402
+
+
+class PackerViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.endpoint = ProxmoxEndpoint.objects.create(name="pve-ui")
+        cls.cluster_type = ClusterType.objects.create(name="Proxmox", slug="proxmox")
+        cls.cluster = Cluster.objects.create(name="pve-ui-cluster", type=cls.cluster_type)
+        cls.view_user = get_user_model().objects.create_user(
+            username="packer-view",
+            is_staff=True,
+        )
+        cls.edit_user = get_user_model().objects.create_user(
+            username="packer-edit",
+            is_staff=True,
+        )
+        cls.build_user = get_user_model().objects.create_user(
+            username="packer-build",
+            is_staff=True,
+        )
+
+        cls.definition = PackerImageDefinition.objects.create(
+            name="Ubuntu 24.04 base",
+            slug="ubuntu-2404-base",
+            description="Jammy successor image definition",
+            builder_type=PackerBuilderTypeChoices.PROXMOX_CLONE,
+            proxmox_endpoint=cls.endpoint,
+            target_cluster=cls.cluster,
+            target_node="pve01",
+            source_template_vmid=9000,
+            default_storage="local-lvm",
+            default_bridge="vmbr0",
+            os_family=PackerOSFamilyChoices.UBUNTU,
+            os_release="24.04",
+            default_ciuser="ubuntu",
+            provisioner_recipe=PackerProvisionerRecipeChoices.UBUNTU_BASE,
+            default_variables={"bridge": "vmbr0"},
+        )
+        cls.build = PackerImageBuild.objects.create(
+            definition=cls.definition,
+            proxmox_endpoint=cls.endpoint,
+            target_node="pve01",
+            output_vmid=9100,
+            output_name="ubuntu-2404-base-20260517",
+            image_version="2026.05.17",
+            created_by=cls.build_user,
+        )
+
+        cls._grant(cls.view_user, PackerImageDefinition, ["view"])
+        cls._grant(cls.edit_user, PackerImageDefinition, ["view", "add", "change"])
+        cls._grant(cls.build_user, PackerImageDefinition, ["view"])
+        cls._grant(cls.build_user, PackerImageBuild, ["add"])
+        cls._grant(cls.build_user, Job, ["add"])
+
+    @classmethod
+    def _grant(cls, user, model: type, actions: list[str]) -> None:
+        content_type = ContentType.objects.get_for_model(model)
+        permission = ObjectPermission.objects.create(
+            name=f"packer-ui-{user.username}-{model._meta.model_name}-{'-'.join(actions)}",
+            actions=actions,
+        )
+        permission.object_types.add(content_type)
+        permission.users.add(user)
+
+    def test_anonymous_user_redirected_from_list_views(self) -> None:
+        for view_name in (
+            "plugins:netbox_packer:packerimagedefinition_list",
+            "plugins:netbox_packer:packerimagebuild_list",
+        ):
+            response = self.client.get(reverse(view_name))
+            self.assertEqual(response.status_code, 302, response.content)
+            self.assertIn("/login/", response["Location"])
+
+    def test_view_permission_can_list_and_view_but_not_edit(self) -> None:
+        self.client.force_login(self.view_user)
+
+        list_response = self.client.get(
+            reverse("plugins:netbox_packer:packerimagedefinition_list")
+        )
+        self.assertEqual(list_response.status_code, 200, list_response.content)
+
+        detail_response = self.client.get(
+            reverse(
+                "plugins:netbox_packer:packerimagedefinition",
+                args=[self.definition.pk],
+            )
+        )
+        self.assertEqual(detail_response.status_code, 200, detail_response.content)
+
+        edit_response = self.client.get(
+            reverse(
+                "plugins:netbox_packer:packerimagedefinition_edit",
+                args=[self.definition.pk],
+            )
+        )
+        self.assertEqual(edit_response.status_code, 403, edit_response.content)
+
+    def test_add_and_change_permission_can_edit(self) -> None:
+        self.client.force_login(self.edit_user)
+        response = self.client.post(
+            reverse(
+                "plugins:netbox_packer:packerimagedefinition_edit",
+                args=[self.definition.pk],
+            ),
+            data={
+                "name": "Ubuntu 24.04 golden",
+                "slug": self.definition.slug,
+                "description": self.definition.description,
+                "enabled": "on",
+                "builder_type": PackerBuilderTypeChoices.PROXMOX_CLONE,
+                "proxmox_endpoint": self.endpoint.pk,
+                "target_cluster": self.cluster.pk,
+                "target_node": self.definition.target_node,
+                "source_template_vmid": self.definition.source_template_vmid,
+                "default_storage": self.definition.default_storage,
+                "default_bridge": self.definition.default_bridge,
+                "os_family": PackerOSFamilyChoices.UBUNTU,
+                "os_release": self.definition.os_release,
+                "default_ciuser": self.definition.default_ciuser,
+                "provisioner_recipe": PackerProvisionerRecipeChoices.UBUNTU_BASE,
+                "default_variables": "{}",
+                "allowed_tenants": [],
+                "tags": [],
+                "_update": "Save",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302, response.content)
+        self.definition.refresh_from_db()
+        self.assertEqual(self.definition.name, "Ubuntu 24.04 golden")
+
+    def test_build_post_returns_202_without_creating_build(self) -> None:
+        self.client.force_login(self.build_user)
+        before = PackerImageBuild.objects.count()
+
+        response = self.client.post(
+            reverse(
+                "plugins:netbox_packer:packerimagedefinition_build",
+                args=[self.definition.pk],
+            ),
+            data={
+                "output_vmid": "9300",
+                "output_name": "ubuntu-2404-base-20260517",
+                "image_version": "2026.05.17",
+                "dry_run": "",
+                "force": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 202, response.content)
+        self.assertIn(b"Build queueing wired in PHASE4", response.content)
+        self.assertEqual(PackerImageBuild.objects.count(), before)
+
+    def test_filterset_search_hits_definition_and_build_text(self) -> None:
+        by_name = PackerImageDefinitionFilterSet(
+            data={"q": "Ubuntu 24.04"},
+            queryset=PackerImageDefinition.objects.all(),
+        )
+        self.assertIn(self.definition, by_name.qs)
+
+        by_description = PackerImageDefinitionFilterSet(
+            data={"q": "successor"},
+            queryset=PackerImageDefinition.objects.all(),
+        )
+        self.assertIn(self.definition, by_description.qs)
+
+        by_output_name = PackerImageBuildFilterSet(
+            data={"q": "20260517"},
+            queryset=PackerImageBuild.objects.all(),
+        )
+        self.assertIn(self.build, by_output_name.qs)

--- a/tests/test_packer_views.py
+++ b/tests/test_packer_views.py
@@ -66,7 +66,9 @@ class PackerViewTest(TestCase):
     def setUpTestData(cls) -> None:
         cls.endpoint = ProxmoxEndpoint.objects.create(name="pve-ui")
         cls.cluster_type = ClusterType.objects.create(name="Proxmox", slug="proxmox")
-        cls.cluster = Cluster.objects.create(name="pve-ui-cluster", type=cls.cluster_type)
+        cls.cluster = Cluster.objects.create(
+            name="pve-ui-cluster", type=cls.cluster_type
+        )
         cls.view_user = get_user_model().objects.create_user(
             username="packer-view",
             is_staff=True,


### PR DESCRIPTION
## Summary

Implements PHASE3 of epic #463 — full NetBox UI surface for the
`netbox_packer` plugin scaffolded in PHASE2 (#457 / PR #466).

Closes #458 once merged.

## Scope

- **Navigation** — three menu items under "Image Factory":
  Image Definitions, Image Builds, Plugin Settings (icon
  `mdi mdi-package-variant-closed`).
- **Tables** — `PackerImageDefinitionTable`, `PackerImageBuildTable`
  with colored status column.
- **Filtersets** — text search on `name`/`description` (definitions),
  `output_name`/`backend_build_id`/`error` (builds); status, OS family,
  endpoint, tenant filters.
- **Forms** — `PackerImageDefinitionForm` with `DynamicModelChoiceField`s,
  `PackerImageBuildSubmitForm` (action shape, not ModelForm),
  filter forms.
- **Views** — CRUD via `register_model_view`; settings singleton edit;
  build/cancel/republish stubs.
- **URLs** — detail-tab routes for definitions and builds.
- **Templates** — prominent **Build** button (modal); logs placeholder;
  settings edit page.
- **Tests** — `tests/test_packer_views.py` covering perms, list/detail
  access, submit 202 banner, and filter search.

## PHASE4 boundary

The Build action returns **HTTP 202 with banner
\`Build queueing wired in PHASE4\`** and **does NOT create a
\`PackerImageBuild\` row**. Real enqueue + SSE consumption lands in
PHASE4 (#459).

## Test plan

- [x] \`python -m compileall netbox_packer\`
- [x] \`ruff check netbox_packer\`
- [x] \`ruff check .\`
- [ ] CI: lint, typecheck, compile, test (3.12 + 3.13) — pending on this PR