### PR TITLE
test(migrations): retarget v0.0.16 squash assertions

### DIFF
--- a/tests/test_bootstrap_intent_cfs.py
+++ b/tests/test_bootstrap_intent_cfs.py
@@ -6,8 +6,10 @@ AST-only — does not bootstrap Django. Pins:
   * It declares ``VM_INTENT_FIELDS`` (10 entries) and
     ``BRANCH_INTENT_FIELDS`` (2 entries) with the exact field-name set
     required by Sub-PRs F/G/H/K.
-  * Migration ``0039_intent_custom_fields`` is a ``RunPython`` calling
-    the registration helper.
+  * The v0.0.16 release migration is a ``RunPython`` calling
+    the registration helper. Originally shipped as
+    ``0039_intent_custom_fields``; now consolidated into
+    ``0038_v0_0_16_release``.
   * The helper guards Branch CFs behind a ``ContentType.DoesNotExist``
     fallback so the migration survives when ``netbox_branching`` is not
     installed.
@@ -20,7 +22,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DATA_MODULE = REPO_ROOT / "netbox_proxbox" / "migrations" / "_v0_0_16_release_data.py"
-MIGRATION = REPO_ROOT / "netbox_proxbox" / "migrations" / "0039_intent_custom_fields.py"
+MIGRATION = REPO_ROOT / "netbox_proxbox" / "migrations" / "0038_v0_0_16_release.py"
 
 EXPECTED_VM_CFS = {
     "proxmox_node",
@@ -113,7 +115,7 @@ def test_branch_intent_fields_match_expected_set():
 
 
 def test_migration_0039_runs_python_helpers():
-    """Migration 0039 must be a RunPython calling the helper pair."""
+    """The release migration must run the intent-CF registration helpers."""
     module = _module_ast(MIGRATION)
     run_python_calls = [
         node
@@ -123,16 +125,25 @@ def test_migration_0039_runs_python_helpers():
         and node.func.attr == "RunPython"
     ]
     assert run_python_calls, (
-        "Migration 0039 must declare a migrations.RunPython operation."
+        "Release migration must declare a migrations.RunPython operation "
+        "calling the intent-CF registration helpers."
     )
-    call = run_python_calls[0]
-    forward = call.args[0] if call.args else None
+    matching = [
+        call
+        for call in run_python_calls
+        if call.args
+        and isinstance(call.args[0], ast.Name)
+        and call.args[0].id == "register_intent_custom_fields"
+    ]
+    assert matching, (
+        "Release migration must call migrations.RunPython("
+        "register_intent_custom_fields, ...)."
+    )
+    call = matching[0]
     reverse = next(
         (kw.value for kw in call.keywords if kw.arg == "reverse_code"),
         None,
     )
-    assert isinstance(forward, ast.Name)
-    assert forward.id == "register_intent_custom_fields"
     assert isinstance(reverse, ast.Name)
     assert reverse.id == "unregister_intent_custom_fields"
 
@@ -152,8 +163,16 @@ def test_helper_guards_missing_content_type():
 
 
 def test_migration_depends_on_0038():
+    """The release migration must still reference 0038_intent_permissions.
+
+    Originally a ``dependencies`` entry on the standalone
+    ``0039_intent_custom_fields`` migration; now appears in the
+    ``replaces`` list of the consolidated ``0038_v0_0_16_release`` squash
+    so historical databases that applied the individual chain remain
+    auditable.
+    """
     text = MIGRATION.read_text()
     assert "'0038_intent_permissions'" in text, (
-        "0039 must declare ('netbox_proxbox', '0038_intent_permissions') "
-        "in dependencies to keep the migration chain auditable."
+        "Release migration must reference ('netbox_proxbox', "
+        "'0038_intent_permissions') so the migration chain stays auditable."
     )

--- a/tests/test_cloud_image_template.py
+++ b/tests/test_cloud_image_template.py
@@ -34,11 +34,18 @@ def test_cloud_image_template_model_defines_catalog_fields_and_permission():
 
 
 def test_cloud_image_template_migration_exists_on_current_develop_head():
-    src = _read("netbox_proxbox/migrations/0044_cloud_image_template.py")
-    assert '("netbox_proxbox", "0043_pluginsettings_warn_plaintext")' in src
-    assert 'name="CloudImageTemplate"' in src
-    assert '"provision_cloud_vm"' in src
-    assert '"unique_together": {("cluster", "source_vmid")}' in src
+    """Pins CloudImageTemplate model creation in the v0.0.16 release migration.
+
+    Originally shipped as ``0044_cloud_image_template``; now consolidated
+    into ``0038_v0_0_16_release`` (squash references the original migration
+    name in its ``replaces`` list).
+    """
+    src = _read("netbox_proxbox/migrations/0038_v0_0_16_release.py")
+    assert "'0043_pluginsettings_warn_plaintext'" in src
+    assert "0044_cloud_image_template" in src
+    assert "name='CloudImageTemplate'" in src
+    assert "'provision_cloud_vm'" in src
+    assert "'unique_together': {('cluster', 'source_vmid')}" in src
 
 
 def test_cloud_image_template_ui_surface_is_registered():

--- a/tests/test_intent_permissions.py
+++ b/tests/test_intent_permissions.py
@@ -91,14 +91,16 @@ def test_deletion_request_meta_permissions():
 
 
 def test_migration_0038_lists_both_models():
-    """Migration 0038 must CreateModel both shells with matching permissions.
+    """Release migration must CreateModel both shells with matching permissions.
 
     Accepts either raw ``migrations.CreateModel(name=...)`` calls or the
     idempotent wrapper ``create_model_idempotent(name=...)`` introduced by
-    issue #454 so the chain stays reporter-safe.
+    issue #454 so the chain stays reporter-safe. Originally shipped as
+    ``0038_intent_permissions``; now consolidated into the
+    ``0038_v0_0_16_release`` squash.
     """
     module = _parse(
-        REPO_ROOT / "netbox_proxbox" / "migrations" / "0038_intent_permissions.py"
+        REPO_ROOT / "netbox_proxbox" / "migrations" / "0038_v0_0_16_release.py"
     )
     create_calls = [
         node

--- a/tests/test_proxmox_endpoint_environment.py
+++ b/tests/test_proxmox_endpoint_environment.py
@@ -10,8 +10,10 @@ Pinned wiring:
   slugs and is keyed for plugin admin override (``ProxmoxEndpoint.environment``).
 - The ``environment`` model field is a nullable ``CharField`` with
   ``blank=True`` so the field is optional in forms and admin.
-- A new ``0045_proxmoxendpoint_environment`` additive migration registers the
-  column on top of ``0044_cloud_image_template``.
+- The v0.0.16 release migration registers the column via
+  ``add_field_idempotent`` (originally shipped as
+  ``0045_proxmoxendpoint_environment`` on top of ``0044_cloud_image_template``;
+  now consolidated into ``0038_v0_0_16_release``).
 - The form, filterset, table, serializer, and template all surface the new
   field next to ``mode``.
 - The plugin's sync paths never overwrite the field (regex grep over the
@@ -31,7 +33,7 @@ PLUGIN_ROOT = REPO_ROOT / "netbox_proxbox"
 
 CHOICES_PATH = PLUGIN_ROOT / "choices.py"
 MODEL_PATH = PLUGIN_ROOT / "models" / "proxmox_endpoint.py"
-MIGRATION_PATH = PLUGIN_ROOT / "migrations" / "0045_proxmoxendpoint_environment.py"
+MIGRATION_PATH = PLUGIN_ROOT / "migrations" / "0038_v0_0_16_release.py"
 FORM_PATH = PLUGIN_ROOT / "forms" / "proxmox.py"
 FILTERSET_PATH = PLUGIN_ROOT / "filtersets.py"
 TABLE_PATH = PLUGIN_ROOT / "tables" / "__init__.py"
@@ -145,38 +147,60 @@ def test_environment_field_imported_in_model() -> None:
 
 
 def test_migration_exists_and_chains_after_0044() -> None:
-    """0045 must depend on 0044 and add the environment column additively.
+    """Release migration must reference 0044 and add the environment column.
 
     Accepts either the raw ``migrations.AddField(...)`` form or the
     idempotent ``add_field_idempotent(...)`` wrapper introduced by issue
-    #454 so the post-0036 chain stays reporter-safe.
+    #454 so the post-0036 chain stays reporter-safe. Originally shipped as
+    ``0045_proxmoxendpoint_environment``; now consolidated into the
+    ``0038_v0_0_16_release`` squash (which references the original migration
+    name in its ``replaces`` list).
     """
     assert MIGRATION_PATH.exists(), (
-        "Migration 0045_proxmoxendpoint_environment.py is missing"
+        f"{MIGRATION_PATH.name} is missing"
     )
     src = MIGRATION_PATH.read_text()
-    assert '("netbox_proxbox", "0044_cloud_image_template")' in src
+    assert "'0044_cloud_image_template'" in src
+    assert "0045_proxmoxendpoint_environment" in src
     assert ("migrations.AddField(" in src) or ("add_field_idempotent(" in src), (
-        "Migration 0045 must add the environment column via either "
+        "Release migration must add the environment column via either "
         "migrations.AddField(...) or add_field_idempotent(...)"
     )
-    assert 'name="environment"' in src
-    assert 'model_name="proxmoxendpoint"' in src
+    assert "field_name='environment'" in src or 'name="environment"' in src
+    assert (
+        "model_name='proxmoxendpoint'" in src
+        or 'model_name="proxmoxendpoint"' in src
+    )
     assert "blank=True" in src
     assert "null=True" in src
 
 
-def test_migration_uses_plain_addfield_or_idempotent_wrapper() -> None:
-    """Raw SQL is still off-limits; SeparateDatabaseAndState may only appear
-    indirectly through ``add_field_idempotent`` (whose helper module owns the
-    wrapper). The migration file itself must not import ``RunSQL`` or hand-roll
-    a ``SeparateDatabaseAndState`` literal."""
+def test_environment_addfield_uses_idempotent_wrapper() -> None:
+    """The environment AddField must use ``add_field_idempotent``.
+
+    The consolidated squash may use raw ``RunSQL`` for other absorbed
+    migrations (notably ``0044_overwrite_vm_proxmox_tags``), but the
+    environment column itself must go through the idempotent wrapper so
+    reporter-style partial installs stay safe."""
     src = MIGRATION_PATH.read_text()
-    assert "SeparateDatabaseAndState" not in src, (
-        "Use add_field_idempotent(...) instead of hand-rolling "
-        "SeparateDatabaseAndState in the migration file."
+    # Anchor on the section-comment marker for the absorbed migration so we
+    # land on the operations block, not the ``replaces`` tuple entry at the
+    # top of the file.
+    env_block_start = src.find("# ── 0045_proxmoxendpoint_environment")
+    if env_block_start == -1:
+        env_block_start = src.find("0045_proxmoxendpoint_environment ──")
+    assert env_block_start != -1, (
+        "Squash must include the 0045_proxmoxendpoint_environment section."
     )
-    assert "RunSQL" not in src
+    block = src[env_block_start:env_block_start + 4000]
+    addfield_idx = block.find("add_field_idempotent(")
+    env_idx = block.find("field_name='environment'")
+    assert addfield_idx != -1 and env_idx != -1, (
+        "Environment column must be added via add_field_idempotent(...)."
+    )
+    assert addfield_idx < env_idx, (
+        "add_field_idempotent(...) must wrap the environment field declaration."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proxmox_endpoint_environment.py
+++ b/tests/test_proxmox_endpoint_environment.py
@@ -156,9 +156,7 @@ def test_migration_exists_and_chains_after_0044() -> None:
     ``0038_v0_0_16_release`` squash (which references the original migration
     name in its ``replaces`` list).
     """
-    assert MIGRATION_PATH.exists(), (
-        f"{MIGRATION_PATH.name} is missing"
-    )
+    assert MIGRATION_PATH.exists(), f"{MIGRATION_PATH.name} is missing"
     src = MIGRATION_PATH.read_text()
     assert "'0044_cloud_image_template'" in src
     assert "0045_proxmoxendpoint_environment" in src
@@ -168,8 +166,7 @@ def test_migration_exists_and_chains_after_0044() -> None:
     )
     assert "field_name='environment'" in src or 'name="environment"' in src
     assert (
-        "model_name='proxmoxendpoint'" in src
-        or 'model_name="proxmoxendpoint"' in src
+        "model_name='proxmoxendpoint'" in src or 'model_name="proxmoxendpoint"' in src
     )
     assert "blank=True" in src
     assert "null=True" in src
@@ -192,7 +189,7 @@ def test_environment_addfield_uses_idempotent_wrapper() -> None:
     assert env_block_start != -1, (
         "Squash must include the 0045_proxmoxendpoint_environment section."
     )
-    block = src[env_block_start:env_block_start + 4000]
+    block = src[env_block_start : env_block_start + 4000]
     addfield_idx = block.find("add_field_idempotent(")
     env_idx = block.find("field_name='environment'")
     assert addfield_idx != -1 and env_idx != -1, (


### PR DESCRIPTION
## Summary
- Six contract tests pinned content in `0038_intent_permissions.py`, `0039_intent_custom_fields.py`, `0044_cloud_image_template.py`, and `0045_proxmoxendpoint_environment.py`, all of which were absorbed into the `0038_v0_0_16_release` squash and deleted.
- Redirect those assertions at the squash, adapt them to the squash's single-quote style and the `add_field_idempotent` / `create_model_idempotent` wrappers, and scope the no-raw-SQL invariant to the environment AddField only so the legitimate `RunSQL` ops carried over from `0044_overwrite_vm_proxmox_tags` no longer break the suite.

## Test plan
- [x] `pytest tests/test_bootstrap_intent_cfs.py tests/test_cloud_image_template.py tests/test_intent_permissions.py tests/test_proxmox_endpoint_environment.py` — 30 passed locally.
- [ ] Develop CI green.