### PR TITLE
docs: add custom cert mounting guidance and fix image tag in backend docs

### DIFF
--- a/docs/backend/using-docker.md
+++ b/docs/backend/using-docker.md
@@ -15,5 +15,6 @@ docker run -d --name proxbox-api -p 8800:8000 emersonfelipesp/proxbox-api:latest
 - The container exposes `8000` internally (nginx in front of uvicorn), so map host `8800` to container `8000`.
 - If you publish a different port, make the same change in the `FastAPIEndpoint` object inside NetBox.
 - If you front the container with TLS or a reverse proxy, configure the NetBox endpoint object accordingly.
-- For HTTPS in local or staging environments, use `emersonfelipesp/proxbox-api:latest-mkcert` and point the NetBox `FastAPIEndpoint` at `https://<host>:8800` with `verify_ssl` enabled.
+- For HTTPS in local or staging environments, use `emersonfelipesp/proxbox-api:latest-nginx` and point the NetBox `FastAPIEndpoint` at `https://<host>:8800` with `verify_ssl` disabled (the mkcert cert is self-signed; tick enabled only after installing the mkcert root CA into NetBox's trust store).
 - The backend image keeps nginx buffering off for `/stream` endpoints, so SSE progress stays chunked even when the service is proxied.
+- To use your own CA-signed or Let's Encrypt certificate, mount it read-only at `/certs` (the directory must contain `cert.pem` and `key.pem`); mkcert generation is automatically skipped. With a trusted certificate you can also enable `verify_ssl` on the `FastAPIEndpoint`.

--- a/docs/installation/backend-setup.md
+++ b/docs/installation/backend-setup.md
@@ -59,6 +59,34 @@ set:
 Earlier releases coupled them, which made the `*-nginx` + self-signed-cert combo
 unreachable from the UI.
 
+### Custom certificates
+
+If you supply your own CA-signed, Let's Encrypt, or corporate certificates,
+the `*-nginx` and `*-granian` images detect them automatically and skip
+mkcert generation. Mount the certificate directory read-only:
+
+```bash
+docker run -d --name proxbox-api-tls \
+  -p 8800:8000 \
+  -v /path/to/certs:/certs:ro \
+  emersonfelipesp/proxbox-api:latest-nginx
+```
+
+The `/certs` directory must contain `cert.pem` and `key.pem`. If either file is
+absent, mkcert auto-generation runs as normal.
+
+When using a publicly trusted or internally-trusted certificate (not self-signed),
+you can enable certificate verification on the FastAPIEndpoint:
+
+| Field | Value |
+|---|---|
+| **Use HTTPS** | ✓ enabled |
+| **Verify SSL** | ✓ enabled |
+| **Port** | host port mapped to container `8000` |
+
+For the granian image, see the full certificate handling notes in the
+[proxbox-api installation docs](https://emersonfelipesp.github.io/proxbox-api/getting-started/installation/#mounting-custom-certificates).
+
 ## Option 3: Run It As A systemd Service
 
 This repository includes sample service files:


### PR DESCRIPTION
## Summary

- `docs/backend/using-docker.md`: fixes wrong image tag (`latest-mkcert` → `latest-nginx`) and corrects `verify_ssl` guidance (should be **disabled** for self-signed mkcert certs, not enabled); adds a bullet noting custom cert mounting support
- `docs/installation/backend-setup.md`: adds `### Custom certificates` subsection after the FastAPIEndpoint table showing how to mount a read-only `/certs` volume, the required cert files, and when `verify_ssl` can be enabled (trusted certs only); links to proxbox-api installation docs for Granian PKCS#8 handling

Follows the custom certificate support landed in [proxbox-api PR #127](https://github.com/emersonfelipesp/proxbox-api/pull/127).

## Test plan

- [ ] Verify `latest-mkcert` no longer appears in `using-docker.md`
- [ ] Verify `verify_ssl` guidance in `using-docker.md` says **disabled** for self-signed mkcert
- [ ] Verify `### Custom certificates` subsection is present in `backend-setup.md`