### PR TITLE
fix: resolve TemplateSyntaxError for get_bg_color in vmsnapshot detail (#472)

### DIFF
--- a/netbox_proxbox/models/vm_snapshot.py
+++ b/netbox_proxbox/models/vm_snapshot.py
@@ -95,3 +95,9 @@ class VMSnapshot(NetBoxModel):
     def get_absolute_url(self) -> str:
         """Plugin UI URL for this snapshot's detail page."""
         return reverse("plugins:netbox_proxbox:vmsnapshot", args=[self.pk])
+
+    def get_status_color(self) -> str | None:
+        return ProxmoxSnapshotStatusChoices.colors.get(self.status)
+
+    def get_subtype_color(self) -> str | None:
+        return ProxmoxSnapshotSubtypeChoices.colors.get(self.subtype)

--- a/netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html
+++ b/netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html
@@ -43,11 +43,11 @@
 				</tr>
 				<tr>
 					<th scope="row">{% trans "Subtype" %}</th>
-					<td>{% badge object.get_subtype_display bg_color=object.subtype|get_bg_color %}</td>
+					<td>{% badge object.get_subtype_display bg_color=object.get_subtype_color %}</td>
 				</tr>
 				<tr>
 					<th scope="row">{% trans "Status" %}</th>
-					<td>{% badge object.get_status_display bg_color=object.status|get_bg_color %}</td>
+					<td>{% badge object.get_status_display bg_color=object.get_status_color %}</td>
 				</tr>
 			</table>
 		</div>

--- a/tests/test_views_snapshot.py
+++ b/tests/test_views_snapshot.py
@@ -24,11 +24,7 @@ def _method_names_in_class(source: str, class_name: str) -> list[str]:
     tree = ast.parse(source)
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == class_name:
-            return [
-                n.name
-                for n in ast.walk(node)
-                if isinstance(n, ast.FunctionDef)
-            ]
+            return [n.name for n in ast.walk(node) if isinstance(n, ast.FunctionDef)]
     return []
 
 
@@ -66,9 +62,7 @@ def test_vmsnapshot_model_color_methods_use_choices_colors():
 
 
 def test_vmsnapshot_template_does_not_use_get_bg_color():
-    src = _src(
-        "netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html"
-    )
+    src = _src("netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html")
     assert "get_bg_color" not in src, (
         "vmsnapshot.html must not call the non-existent 'get_bg_color' "
         "Django template filter. Use bg_color=object.get_status_color "
@@ -77,9 +71,7 @@ def test_vmsnapshot_template_does_not_use_get_bg_color():
 
 
 def test_vmsnapshot_template_uses_get_status_color():
-    src = _src(
-        "netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html"
-    )
+    src = _src("netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html")
     assert "object.get_status_color" in src, (
         "vmsnapshot.html must use bg_color=object.get_status_color "
         "for the Status badge."
@@ -87,9 +79,7 @@ def test_vmsnapshot_template_uses_get_status_color():
 
 
 def test_vmsnapshot_template_uses_get_subtype_color():
-    src = _src(
-        "netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html"
-    )
+    src = _src("netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html")
     assert "object.get_subtype_color" in src, (
         "vmsnapshot.html must use bg_color=object.get_subtype_color "
         "for the Subtype badge."

--- a/tests/test_views_snapshot.py
+++ b/tests/test_views_snapshot.py
@@ -1,0 +1,96 @@
+"""Source contracts for VMSnapshot model and detail template (issue #472).
+
+Guards against a regression where ``vmsnapshot.html`` called the non-existent
+``get_bg_color`` Django template filter instead of the NetBox-standard
+``get_<field>_color()`` instance-method pattern.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _src(path: str) -> str:
+    return (REPO_ROOT / path).read_text()
+
+
+# ── Model method contracts ─────────────────────────────────────────────────────
+
+
+def _method_names_in_class(source: str, class_name: str) -> list[str]:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return [
+                n.name
+                for n in ast.walk(node)
+                if isinstance(n, ast.FunctionDef)
+            ]
+    return []
+
+
+def test_vmsnapshot_model_has_get_status_color():
+    src = _src("netbox_proxbox/models/vm_snapshot.py")
+    methods = _method_names_in_class(src, "VMSnapshot")
+    assert "get_status_color" in methods, (
+        "VMSnapshot must define get_status_color() following the NetBox "
+        "get_<field>_color() convention for badge rendering."
+    )
+
+
+def test_vmsnapshot_model_has_get_subtype_color():
+    src = _src("netbox_proxbox/models/vm_snapshot.py")
+    methods = _method_names_in_class(src, "VMSnapshot")
+    assert "get_subtype_color" in methods, (
+        "VMSnapshot must define get_subtype_color() following the NetBox "
+        "get_<field>_color() convention for badge rendering."
+    )
+
+
+def test_vmsnapshot_model_color_methods_use_choices_colors():
+    src = _src("netbox_proxbox/models/vm_snapshot.py")
+    assert "ProxmoxSnapshotStatusChoices.colors.get" in src, (
+        "get_status_color() must look up the color via "
+        "ProxmoxSnapshotStatusChoices.colors.get(self.status)."
+    )
+    assert "ProxmoxSnapshotSubtypeChoices.colors.get" in src, (
+        "get_subtype_color() must look up the color via "
+        "ProxmoxSnapshotSubtypeChoices.colors.get(self.subtype)."
+    )
+
+
+# ── Template contracts ─────────────────────────────────────────────────────────
+
+
+def test_vmsnapshot_template_does_not_use_get_bg_color():
+    src = _src(
+        "netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html"
+    )
+    assert "get_bg_color" not in src, (
+        "vmsnapshot.html must not call the non-existent 'get_bg_color' "
+        "Django template filter. Use bg_color=object.get_status_color "
+        "and bg_color=object.get_subtype_color instead."
+    )
+
+
+def test_vmsnapshot_template_uses_get_status_color():
+    src = _src(
+        "netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html"
+    )
+    assert "object.get_status_color" in src, (
+        "vmsnapshot.html must use bg_color=object.get_status_color "
+        "for the Status badge."
+    )
+
+
+def test_vmsnapshot_template_uses_get_subtype_color():
+    src = _src(
+        "netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html"
+    )
+    assert "object.get_subtype_color" in src, (
+        "vmsnapshot.html must use bg_color=object.get_subtype_color "
+        "for the Subtype badge."
+    )


### PR DESCRIPTION
## Summary

Fixes #472 — `TemplateSyntaxError: Invalid filter: 'get_bg_color'` when opening a VM snapshot detail page on NetBox 4.6.0.

**Root cause:** `vmsnapshot.html` called `object.subtype|get_bg_color` and `object.status|get_bg_color` as Django template filters. The filter `get_bg_color` has never been defined anywhere — not in `proxbox_tags.py`, not in any NetBox built-in tag library. NetBox's convention is a model instance method `get_<field>_color()` called directly in the template.

## Changes

- **`netbox_proxbox/models/vm_snapshot.py`** — added `get_status_color()` and `get_subtype_color()` instance methods that look up the color via the existing `ProxmoxSnapshotStatusChoices.colors` and `ProxmoxSnapshotSubtypeChoices.colors` dicts (already populated by `ChoiceSetMeta` from the three-tuple CHOICES).
- **`netbox_proxbox/templates/netbox_proxbox/vmsnapshot.html`** — replaced `bg_color=object.subtype|get_bg_color` → `bg_color=object.get_subtype_color` and `bg_color=object.status|get_bg_color` → `bg_color=object.get_status_color` on lines 46 and 50.
- **`tests/test_views_snapshot.py`** — new AST-based source contracts that assert the model methods exist and the template no longer contains the broken filter. All 6 tests fail before the fix and pass after.

## Test plan

- [x] `rtk ruff check .` — no issues
- [x] `tests/test_views_snapshot.py` — 6 new tests, all pass
- [x] Full suite (`pytest tests/ --ignore=tests/e2e`) — 812 passed, 4 skipped, 0 failures
- [ ] Manual: navigate to `/plugins/proxbox/snapshots/<id>/` in NetBox 4.6.0 with netbox-proxbox installed — page renders without TemplateSyntaxError and status/subtype badges show correct colors