### PR TITLE
feat: Quick Edit button with modal form on homepage endpoint cards (#474)

### DIFF
--- a/netbox_proxbox/templates/netbox_proxbox/home.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home.html
@@ -21,6 +21,97 @@
         <link rel="stylesheet" href="{% static 'netbox_proxbox/css/quick_schedule_home.css' %}">
         {{ quick_schedule_form.media }}
     {% endif %}
+    <script>
+    (function () {
+        "use strict";
+
+        function getCsrfToken() {
+            const name = "csrftoken";
+            const cookies = document.cookie.split(";");
+            for (const c of cookies) {
+                const [k, v] = c.trim().split("=");
+                if (k === name) return decodeURIComponent(v);
+            }
+            return "";
+        }
+
+        document.addEventListener("DOMContentLoaded", function () {
+            const modalEl = document.getElementById("proxbox-quick-edit-modal");
+            if (!modalEl) return;
+
+            const bsModal = new bootstrap.Modal(modalEl);
+            const modalBody = document.getElementById("proxbox-quick-edit-body");
+            const modalTitle = modalEl.querySelector(".modal-title");
+
+            const spinner = '<div class="text-center p-4"><div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading…</span></div></div>';
+
+            function attachFormHandler(form) {
+                form.addEventListener("submit", function (e) {
+                    e.preventDefault();
+                    const submitBtn = form.querySelector('[type="submit"]');
+                    if (submitBtn) { submitBtn.disabled = true; }
+
+                    fetch(form.action, {
+                        method: "POST",
+                        headers: {
+                            "X-CSRFToken": getCsrfToken(),
+                            "X-Requested-With": "XMLHttpRequest",
+                        },
+                        body: new FormData(form),
+                    })
+                    .then(function (r) {
+                        if (r.ok) {
+                            r.json().then(function () {
+                                bsModal.hide();
+                                location.reload();
+                            });
+                        } else {
+                            r.text().then(function (html) {
+                                modalBody.innerHTML = html;
+                                const newForm = modalBody.querySelector("form");
+                                if (newForm) attachFormHandler(newForm);
+                            });
+                        }
+                    })
+                    .catch(function () {
+                        if (submitBtn) { submitBtn.disabled = false; }
+                    });
+                });
+            }
+
+            document.querySelectorAll("[data-proxbox-quick-edit-url]").forEach(function (btn) {
+                btn.addEventListener("click", function () {
+                    const url = btn.dataset.proxboxQuickEditUrl;
+                    modalBody.innerHTML = spinner;
+                    if (modalTitle) {
+                        const cardHeader = btn.closest(".card");
+                        const headerText = cardHeader ? cardHeader.querySelector(".card-header") : null;
+                        modalTitle.textContent = headerText
+                            ? "Edit " + headerText.textContent.trim()
+                            : "Edit Endpoint";
+                    }
+                    bsModal.show();
+
+                    fetch(url, {
+                        headers: { "X-Requested-With": "XMLHttpRequest" },
+                    })
+                    .then(function (r) {
+                        if (!r.ok) throw new Error("HTTP " + r.status);
+                        return r.text();
+                    })
+                    .then(function (html) {
+                        modalBody.innerHTML = html;
+                        const form = modalBody.querySelector("form");
+                        if (form) attachFormHandler(form);
+                    })
+                    .catch(function (err) {
+                        modalBody.innerHTML = '<div class="alert alert-danger">Failed to load the edit form. ' + err.message + "</div>";
+                    });
+                });
+            });
+        });
+    }());
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -158,4 +249,32 @@
 {% block footer_links %}
     {{ block.super }}
     {% include "netbox_proxbox/footer.html" %}
+{% endblock %}
+
+{% block modals %}
+    {{ block.super }}
+    {# Shared modal used by the quick-edit buttons on the homepage endpoint cards. #}
+    <div
+        class="modal fade"
+        id="proxbox-quick-edit-modal"
+        tabindex="-1"
+        aria-labelledby="proxbox-quick-edit-modal-label"
+        aria-hidden="true"
+    >
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="proxbox-quick-edit-modal-label">Edit Endpoint</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body" id="proxbox-quick-edit-body">
+                    <div class="text-center p-4">
+                        <div class="spinner-border text-primary" role="status">
+                            <span class="visually-hidden">Loading…</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/netbox_proxbox/templates/netbox_proxbox/home/fastapi_card.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home/fastapi_card.html
@@ -35,14 +35,22 @@
                 {% if fastapi_websocket_url and object.use_websocket %}<tr><th scope="row"><strong>WebSocket URL</strong></th><td><a href="{{ fastapi_websocket_url }}" target="_blank">{{ fastapi_websocket_url }}</a></td></tr>{% endif %}
                 <tr><th scope="row"><strong>Port</strong></th><td>{{ object.port }}</td></tr>
             </table>
-            <div class="d-flex flex-row justify-content-center align-items-center p-2 mt-1">
-                <div class="d-flex ms-auto" style="margin: 0 40px 0 0">
-                    <a
-                        class="btn btn-outline-primary"
-                        target="_blank"
-                        href="https://fastapi.tiangolo.com/deployment/manually/"
-                    >Show Example</a>
-                </div>
+            <div class="d-flex justify-content-between align-items-center p-2 mt-1">
+                <a
+                    class="btn btn-outline-primary"
+                    target="_blank"
+                    href="https://fastapi.tiangolo.com/deployment/manually/"
+                >Show Example</a>
+                {% if perms.netbox_proxbox.change_fastapiendpoint %}
+                <button
+                    type="button"
+                    class="btn btn-outline-warning btn-sm"
+                    data-proxbox-quick-edit-url="{% url 'plugins:netbox_proxbox:home_quick_edit' 'fastapi' object.pk %}"
+                    title="Quick edit this FastAPI endpoint"
+                >
+                    <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit
+                </button>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/netbox_proxbox/templates/netbox_proxbox/home/netbox_card.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home/netbox_card.html
@@ -37,12 +37,22 @@
                 <tr><th scope="row"><strong>Token</strong></th><td>{% if object.has_configured_token %}<span class="badge text-bg-gray">Token will not show here for security.</span>{% else %}<span class="badge text-bg-grey">Not configured</span>{% endif %}</td></tr>
                 <tr><th scope="row"><strong>SSL</strong></th><td>{% if object.verify_ssl %}<span class="text-success"><i class="mdi mdi-check-bold"></i></span>{% else %}<span class="text-danger"><i class="mdi mdi-close-thick"></i></span>{% endif %}</td></tr>
             </table>
-            <div align="right">
+            <div class="d-flex justify-content-between">
                 <a
                     class="btn btn-outline-primary"
                     target="_blank"
                     href="https://github.com/emersonfelipesp/netbox-proxbox/blob/develop/netbox_proxbox/__init__.py"
                 >Show Example</a>
+                {% if perms.netbox_proxbox.change_netboxendpoint %}
+                <button
+                    type="button"
+                    class="btn btn-outline-warning btn-sm"
+                    data-proxbox-quick-edit-url="{% url 'plugins:netbox_proxbox:home_quick_edit' 'netbox' object.pk %}"
+                    title="Quick edit this NetBox endpoint"
+                >
+                    <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit
+                </button>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/netbox_proxbox/templates/netbox_proxbox/home/proxmox_card.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home/proxmox_card.html
@@ -99,6 +99,16 @@
                 target="_blank"
                 href="https://github.com/emersonfelipesp/netbox-proxbox#13-configure-plugin"
             >Show Example</a>
+            {% if perms.netbox_proxbox.change_proxmoxendpoint %}
+            <button
+                type="button"
+                class="btn btn-outline-warning btn-sm"
+                data-proxbox-quick-edit-url="{% url 'plugins:netbox_proxbox:home_quick_edit' 'proxmox' object.pk %}"
+                title="Quick edit this Proxmox endpoint"
+            >
+                <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit
+            </button>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/netbox_proxbox/templates/netbox_proxbox/home/quick_edit_form.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home/quick_edit_form.html
@@ -1,0 +1,58 @@
+{% load i18n %}
+{# Minimal form fragment rendered inside the quick-edit Bootstrap modal. #}
+{# No <html>/<body> wrapper — injected via fetch() into #proxbox-quick-edit-body. #}
+
+<form
+    method="post"
+    action="{% url 'plugins:netbox_proxbox:home_quick_edit' endpoint_type object.pk %}"
+    id="proxbox-quick-edit-form"
+    class="proxbox-quick-edit-form"
+>
+    {% csrf_token %}
+
+    {% if form.non_field_errors %}
+        <div class="alert alert-danger">
+            {% for error in form.non_field_errors %}
+                <div>{{ error }}</div>
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    {% for field in form.visible_fields %}
+        <div class="mb-3 row{% if field.errors %} has-validation{% endif %}">
+            <label class="col-sm-3 col-form-label fw-bold" for="{{ field.id_for_label }}">
+                {{ field.label }}
+                {% if field.field.required %}<span class="text-danger ms-1" aria-hidden="true">*</span>{% endif %}
+            </label>
+            <div class="col-sm-9">
+                {{ field }}
+                {% if field.help_text %}
+                    <div class="form-text text-muted">{{ field.help_text }}</div>
+                {% endif %}
+                {% for error in field.errors %}
+                    <div class="invalid-feedback d-block">{{ error }}</div>
+                {% endfor %}
+            </div>
+        </div>
+    {% endfor %}
+
+    {# Hidden fields (e.g. object_id from GenericForeignKey fields) #}
+    {% for field in form.hidden_fields %}
+        {{ field }}
+    {% endfor %}
+
+    <div class="modal-footer px-0 pb-0">
+        <a
+            class="btn btn-outline-secondary"
+            href="{{ object.get_absolute_url }}"
+            target="_blank"
+        >
+            <i class="mdi mdi-open-in-new"></i>
+            {% trans "Full edit page" %}
+        </a>
+        <button type="submit" class="btn btn-primary ms-auto">
+            <i class="mdi mdi-content-save"></i>
+            {% trans "Save" %}
+        </button>
+    </div>
+</form>

--- a/netbox_proxbox/urls.py
+++ b/netbox_proxbox/urls.py
@@ -22,6 +22,11 @@ app_name = "netbox_proxbox"
 
 urlpatterns = [
     path("", views.HomeView.as_view(), name="home"),
+    path(
+        "quick-edit/<str:endpoint_type>/<int:pk>/",
+        views.HomeQuickEditView.as_view(),
+        name="home_quick_edit",
+    ),
     path("dashboard/", views.DashboardView.as_view(), name="dashboard"),
     path("ha/", views.HAClusterView.as_view(), name="ha"),
     path("clusters/", views.ClustersView.as_view(), name="clusters"),

--- a/netbox_proxbox/views/__init__.py
+++ b/netbox_proxbox/views/__init__.py
@@ -58,6 +58,7 @@ from .endpoints import (
     ProxmoxEndpointView,
 )
 from .external_pages import discord_redirect, discussions_redirect, telegram_redirect
+from .home_quick_edit import HomeQuickEditView
 from .keepalive_status import get_service_status
 from .logs import BackendLogPathUpdateView, BackendLogsView
 from .replication import (

--- a/netbox_proxbox/views/home_quick_edit.py
+++ b/netbox_proxbox/views/home_quick_edit.py
@@ -1,0 +1,68 @@
+"""Quick-edit modal view for homepage endpoint cards."""
+
+from __future__ import annotations
+
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404, render
+from django.views import View
+from utilities.views import ConditionalLoginRequiredMixin
+
+from netbox_proxbox.forms import (
+    FastAPIEndpointForm,
+    NetBoxEndpointForm,
+    ProxmoxEndpointForm,
+)
+from netbox_proxbox.models import FastAPIEndpoint, NetBoxEndpoint, ProxmoxEndpoint
+
+__all__ = ("HomeQuickEditView",)
+
+_ENDPOINT_MAP: dict[
+    str,
+    tuple[type, type, str],
+] = {
+    "netbox": (NetBoxEndpoint, NetBoxEndpointForm, "change_netboxendpoint"),
+    "proxmox": (ProxmoxEndpoint, ProxmoxEndpointForm, "change_proxmoxendpoint"),
+    "fastapi": (FastAPIEndpoint, FastAPIEndpointForm, "change_fastapiendpoint"),
+}
+
+_FRAGMENT = "netbox_proxbox/home/quick_edit_form.html"
+
+
+class HomeQuickEditView(ConditionalLoginRequiredMixin, View):
+    """
+    Serves the edit form for a single endpoint as an HTML fragment (GET) and
+    processes the POST submission (returning JSON on success, re-rendered
+    fragment with field errors on failure).
+
+    URL: GET/POST /plugins/proxbox/quick-edit/<endpoint_type>/<pk>/
+    """
+
+    def _resolve(self, endpoint_type: str, pk: int, user):
+        if endpoint_type not in _ENDPOINT_MAP:
+            from django.http import Http404
+            raise Http404(f"Unknown endpoint type: {endpoint_type!r}")
+        model_cls, form_cls, _perm = _ENDPOINT_MAP[endpoint_type]
+        obj = get_object_or_404(model_cls.objects.restrict(user, "change"), pk=pk)
+        return obj, form_cls
+
+    def get(self, request: HttpRequest, endpoint_type: str, pk: int) -> HttpResponse:
+        obj, form_cls = self._resolve(endpoint_type, pk, request.user)
+        form = form_cls(instance=obj)
+        return render(
+            request,
+            _FRAGMENT,
+            {"form": form, "object": obj, "endpoint_type": endpoint_type},
+        )
+
+    def post(self, request: HttpRequest, endpoint_type: str, pk: int) -> HttpResponse:
+        obj, form_cls = self._resolve(endpoint_type, pk, request.user)
+        form = form_cls(data=request.POST, files=request.FILES, instance=obj)
+        if form.is_valid():
+            form.save()
+            return JsonResponse({"success": True, "name": str(obj)})
+        return render(
+            request,
+            _FRAGMENT,
+            {"form": form, "object": obj, "endpoint_type": endpoint_type},
+            status=422,
+        )


### PR DESCRIPTION
## Summary

Adds a one-click **Edit** button to each endpoint card (NetBox, Proxmox, FastAPI) on the `/plugins/proxbox/` dashboard. Clicking it opens a Bootstrap 5 modal with the endpoint's edit form pre-populated with current values.

Closes #474.

## Changes

- **New `HomeQuickEditView`** (`netbox_proxbox/views/home_quick_edit.py`)
  - `GET /plugins/proxbox/quick-edit/<type>/<pk>/` — returns the endpoint's edit form as an HTML fragment (no full layout)
  - `POST` — validates and saves; returns `{"success": true}` on success (HTTP 200) or the re-rendered form with inline field errors on failure (HTTP 422)
  - Permission guard: resolves object via `.restrict(user, "change")` — returns 403/404 if the user lacks `change_<model>` permission
- **New template `home/quick_edit_form.html`** — minimal `<form>` fragment injected into the modal body via `fetch()`
- **`netbox_card.html`, `proxmox_card.html`, `fastapi_card.html`** — Edit button added to card footer, conditionally shown based on change permission
- **`home.html`** — shared Bootstrap 5 modal container in `{% block modals %}` + ~80 lines of inline AJAX JavaScript in `{% block head %}` (consistent with the existing `home_inline.js` inlining strategy)
- **`urls.py`** — new `home_quick_edit` URL
- **`views/__init__.py`** — re-exports `HomeQuickEditView`

## JavaScript flow

1. User clicks Edit → `fetch(url)` loads form fragment → injected into modal body → modal opens
2. User edits and submits → `fetch(action, {method: 'POST', body: FormData})`
3. On success → modal closes + `location.reload()` refreshes the cards
4. On error (422) → re-injects the returned HTML with inline field errors, keeping modal open

## Test plan

- [ ] Edit button appears on all three card types when the user has `change_<model>` permission
- [ ] Edit button is hidden when the user lacks change permission
- [ ] Clicking Edit shows a spinner then the pre-filled form in the modal
- [ ] Valid form submission closes modal and reloads page with updated values
- [ ] Invalid form submission keeps modal open and shows field errors inline
- [ ] "Full edit page" link in modal footer opens the standard edit page in a new tab
- [ ] No regressions: existing card hydration (status badges, Proxmox cluster data), sync buttons, and keepalive checks continue to work