### PR TITLE
fix: 15 correctness bugs in PVE 9.2 sync, serializer, filterset, and migration

### DIFF
--- a/netbox_proxbox/api/serializers/cluster.py
+++ b/netbox_proxbox/api/serializers/cluster.py
@@ -133,6 +133,7 @@ class ProxmoxNodeSerializer(NetBoxModelSerializer):
             "memory_usage_percent",
             "max_memory",
             "ssl_fingerprint",
+            "location",
             "support_level",
             "default_role_qemu",
             "default_role_lxc",

--- a/netbox_proxbox/filtersets.py
+++ b/netbox_proxbox/filtersets.py
@@ -406,6 +406,7 @@ class ProxmoxNodeFilterSet(ProxboxModelFilterSet):
             "ip_address",
             "online",
             "local",
+            "location",
         )
 
     def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:

--- a/netbox_proxbox/migrations/0042_fix_sdn_prefix_list_unique_cidr.py
+++ b/netbox_proxbox/migrations/0042_fix_sdn_prefix_list_unique_cidr.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("netbox_proxbox", "0041_pve_9_2"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="proxmoxsdnprefixlist",
+            name="netbox_proxbox_sdnprefixlist_unique_endpoint_cluster_name",
+        ),
+        migrations.AddConstraint(
+            model_name="proxmoxsdnprefixlist",
+            constraint=models.UniqueConstraint(
+                fields=["endpoint", "cluster_name", "name", "cidr"],
+                name="netbox_proxbox_sdnprefixlist_unique_endpoint_cluster_name_cidr",
+            ),
+        ),
+    ]

--- a/netbox_proxbox/models/sdn_prefix_list.py
+++ b/netbox_proxbox/models/sdn_prefix_list.py
@@ -46,8 +46,8 @@ class ProxmoxSdnPrefixList(NetBoxModel):
         ordering = ("endpoint", "cluster_name", "name")
         constraints = [
             models.UniqueConstraint(
-                fields=["endpoint", "cluster_name", "name"],
-                name="netbox_proxbox_sdnprefixlist_unique_endpoint_cluster_name",
+                fields=["endpoint", "cluster_name", "name", "cidr"],
+                name="netbox_proxbox_sdnprefixlist_unique_endpoint_cluster_name_cidr",
             )
         ]
 

--- a/netbox_proxbox/services/sync_datacenter.py
+++ b/netbox_proxbox/services/sync_datacenter.py
@@ -45,8 +45,8 @@ def _resolve_endpoint_by_cluster_name(cluster_name: str) -> ProxmoxEndpoint | No
         )
         if cluster and cluster.endpoint_id:
             return cluster.endpoint
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("DB error resolving cluster %r: %s", cluster_name, exc)
     return ProxmoxEndpoint.objects.filter(name=cluster_name).first()
 
 
@@ -74,11 +74,11 @@ def _upsert_cpu_model(
     if created:
         result.cpu_models_created += 1
     else:
-        obj.base_cputype = item.get("base_cputype", obj.base_cputype)
-        obj.flags = item.get("flags", obj.flags)
-        obj.vendor_id = item.get("vendor-id", item.get("vendor_id", obj.vendor_id))
-        obj.level = item.get("level", obj.level)
-        obj.description = item.get("description", obj.description)
+        obj.base_cputype = item.get("base_cputype") or ""
+        obj.flags = item.get("flags") or ""
+        obj.vendor_id = item.get("vendor-id", item.get("vendor_id")) or ""
+        obj.level = item.get("level")
+        obj.description = item.get("description") or ""
         obj.status = FirewallSyncStatusChoices.ACTIVE
         obj.raw_config = item
         obj.save()
@@ -147,7 +147,7 @@ def sync_datacenter(
             pk = _upsert_cpu_model(endpoint, item, result)
             if pk:
                 synced_pks.append(pk)
-            processed_endpoints.add(endpoint.pk)
+                processed_endpoints.add(endpoint.pk)
 
         stale = (
             ProxmoxDatacenterCpuModel.objects.filter(

--- a/netbox_proxbox/services/sync_firewall.py
+++ b/netbox_proxbox/services/sync_firewall.py
@@ -109,8 +109,8 @@ def _resolve_endpoint_by_cluster_name(cluster_name: str) -> ProxmoxEndpoint | No
         )
         if cluster and cluster.endpoint_id:
             return cluster.endpoint
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("DB error resolving cluster %r: %s", cluster_name, exc)
 
     return ProxmoxEndpoint.objects.filter(name=cluster_name).first()
 
@@ -533,7 +533,7 @@ def sync_firewall(
     # -----------------------------------------------------------------------
     # DB phase — one atomic block per endpoint.
     # -----------------------------------------------------------------------
-    resolved_endpoints: list[ProxmoxEndpoint] = []
+    resolved_endpoints: dict[int, ProxmoxEndpoint] = {}
 
     for entry in summary_list:
         cluster_name = entry.get("cluster_name") or ""
@@ -553,7 +553,7 @@ def sync_firewall(
             _sync_one_endpoint(endpoint, entry, result)
             ep_result["success"] = True
             result.endpoints_processed += 1
-            resolved_endpoints.append(endpoint)
+            resolved_endpoints[endpoint.pk] = endpoint
             logger.info(
                 "Firewall sync for endpoint %s (%s): "
                 "%d sg, %d rules, %d ipsets, %d entries, %d aliases, %d opts created/updated",
@@ -585,7 +585,7 @@ def sync_firewall(
     if resolved_endpoints:
         from netbox_proxbox.models import ProxmoxNode  # noqa: PLC0415
 
-        for endpoint in resolved_endpoints:
+        for endpoint in resolved_endpoints.values():
             nodes = ProxmoxNode.objects.filter(endpoint=endpoint).values_list(
                 "name", flat=True
             )
@@ -658,7 +658,14 @@ def sync_node_firewall(
         )
         resp.raise_for_status()
         data = resp.json()
-        rules = data if isinstance(data, list) else []
+        if not isinstance(data, list):
+            logger.warning(
+                "Node %r firewall rules response is not a list (got %s) — skipping node firewall sync",
+                node_name,
+                type(data).__name__,
+            )
+            return
+        rules = data
     except requests.RequestException as exc:
         logger.warning("Failed to fetch node %r firewall rules: %s", node_name, exc)
         return
@@ -670,9 +677,26 @@ def sync_node_firewall(
             pos_raw = raw.get("pos")
             if pos_raw is None:
                 continue
-            pos = int(pos_raw)
+            try:
+                pos = int(pos_raw)
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Skipping node %r firewall rule with invalid pos=%r",
+                    node_name,
+                    pos_raw,
+                )
+                continue
             enable_raw = raw.get("enable", 1)
-            enable = bool(int(enable_raw)) if enable_raw is not None else True
+            try:
+                enable = bool(int(enable_raw)) if enable_raw is not None else True
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Node %r firewall rule at pos=%s has invalid enable=%r; defaulting to enabled",
+                    node_name,
+                    pos,
+                    enable_raw,
+                )
+                enable = True
             defaults = {
                 "rule_type": raw.get("type") or "",
                 "action": raw.get("action") or "",

--- a/netbox_proxbox/services/sync_sdn.py
+++ b/netbox_proxbox/services/sync_sdn.py
@@ -58,8 +58,8 @@ def _resolve_endpoint_by_cluster_name(cluster_name: str) -> ProxmoxEndpoint | No
         )
         if cluster and cluster.endpoint_id:
             return cluster.endpoint
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("DB error resolving cluster %r: %s", cluster_name, exc)
     return ProxmoxEndpoint.objects.filter(name=cluster_name).first()
 
 
@@ -73,7 +73,7 @@ def _upsert_fabric(endpoint: ProxmoxEndpoint, item: dict, result: SdnSyncResult)
         cluster_name=cluster_name,
         fabric_name=fabric_name,
         defaults={
-            "fabric_type": item.get("type", ""),
+            "fabric_type": item.get("type") or "",
             "asn": item.get("asn"),
             "advertise_subnets": bool(item.get("advertise_subnets", False)),
             "disable_arp_nd_suppression": bool(
@@ -88,16 +88,12 @@ def _upsert_fabric(endpoint: ProxmoxEndpoint, item: dict, result: SdnSyncResult)
     if created:
         result.fabrics_created += 1
     else:
-        obj.fabric_type = item.get("type", obj.fabric_type)
-        obj.asn = item.get("asn", obj.asn)
-        obj.advertise_subnets = bool(
-            item.get("advertise_subnets", obj.advertise_subnets)
-        )
-        obj.disable_arp_nd_suppression = bool(
-            item.get("disable_arp_nd_suppression", obj.disable_arp_nd_suppression)
-        )
-        obj.vrf_vxlan = item.get("vrf_vxlan", obj.vrf_vxlan)
-        obj.peers = item.get("peers", obj.peers)
+        obj.fabric_type = item.get("type") or obj.fabric_type
+        obj.asn = item.get("asn")
+        obj.advertise_subnets = bool(item.get("advertise_subnets"))
+        obj.disable_arp_nd_suppression = bool(item.get("disable_arp_nd_suppression"))
+        obj.vrf_vxlan = item.get("vrf_vxlan")
+        obj.peers = item.get("peers") if item.get("peers") is not None else obj.peers
         obj.status = FirewallSyncStatusChoices.ACTIVE
         obj.raw_config = item
         obj.save()
@@ -112,7 +108,7 @@ def _upsert_route_map(
     name = item.get("name", "")
     if not name:
         return 0
-    order = item.get("order", 0)
+    order = item.get("order") or 0
     obj, created = ProxmoxSdnRouteMap.objects.get_or_create(
         endpoint=endpoint,
         cluster_name=cluster_name,
@@ -152,8 +148,8 @@ def _upsert_prefix_list(
         endpoint=endpoint,
         cluster_name=cluster_name,
         name=name,
+        cidr=item.get("cidr", ""),
         defaults={
-            "cidr": item.get("cidr", ""),
             "action": item.get("action", ""),
             "le": item.get("le"),
             "ge": item.get("ge"),
@@ -166,8 +162,8 @@ def _upsert_prefix_list(
     else:
         obj.cidr = item.get("cidr", obj.cidr)
         obj.action = item.get("action", obj.action)
-        obj.le = item.get("le", obj.le)
-        obj.ge = item.get("ge", obj.ge)
+        obj.le = item.get("le")
+        obj.ge = item.get("ge")
         obj.status = FirewallSyncStatusChoices.ACTIVE
         obj.raw_config = item
         obj.save()
@@ -225,7 +221,9 @@ def sync_sdn(
         logger.error(result.error)
         return result
 
-    processed_endpoints: set[int] = set()
+    processed_fabric_endpoints: set[int] = set()
+    processed_route_map_endpoints: set[int] = set()
+    processed_prefix_list_endpoints: set[int] = set()
     synced_fabric_pks: set[int] = set()
     synced_route_map_pks: set[int] = set()
     synced_prefix_list_pks: set[int] = set()
@@ -247,7 +245,7 @@ def sync_sdn(
             pk = _upsert_fabric(endpoint, item, result)
             if pk:
                 synced_fabric_pks.add(pk)
-            processed_endpoints.add(endpoint.pk)
+                processed_fabric_endpoints.add(endpoint.pk)
 
         for item in route_maps:
             cluster_name = item.get("cluster_name", "")
@@ -261,7 +259,7 @@ def sync_sdn(
             pk = _upsert_route_map(endpoint, item, result)
             if pk:
                 synced_route_map_pks.add(pk)
-            processed_endpoints.add(endpoint.pk)
+                processed_route_map_endpoints.add(endpoint.pk)
 
         for item in prefix_lists:
             cluster_name = item.get("cluster_name", "")
@@ -275,26 +273,37 @@ def sync_sdn(
             pk = _upsert_prefix_list(endpoint, item, result)
             if pk:
                 synced_prefix_list_pks.add(pk)
-            processed_endpoints.add(endpoint.pk)
+                processed_prefix_list_endpoints.add(endpoint.pk)
 
-        if processed_endpoints:
-            ProxmoxSdnFabric.objects.filter(
-                endpoint_id__in=processed_endpoints
+        if processed_fabric_endpoints:
+            stale_fabrics = ProxmoxSdnFabric.objects.filter(
+                endpoint_id__in=processed_fabric_endpoints
             ).exclude(pk__in=synced_fabric_pks).update(
                 status=FirewallSyncStatusChoices.STALE
             )
-            ProxmoxSdnRouteMap.objects.filter(
-                endpoint_id__in=processed_endpoints
+            result.fabrics_stale += stale_fabrics
+
+        if processed_route_map_endpoints:
+            stale_route_maps = ProxmoxSdnRouteMap.objects.filter(
+                endpoint_id__in=processed_route_map_endpoints
             ).exclude(pk__in=synced_route_map_pks).update(
                 status=FirewallSyncStatusChoices.STALE
             )
-            ProxmoxSdnPrefixList.objects.filter(
-                endpoint_id__in=processed_endpoints
+            result.route_maps_stale += stale_route_maps
+
+        if processed_prefix_list_endpoints:
+            stale_prefix_lists = ProxmoxSdnPrefixList.objects.filter(
+                endpoint_id__in=processed_prefix_list_endpoints
             ).exclude(pk__in=synced_prefix_list_pks).update(
                 status=FirewallSyncStatusChoices.STALE
             )
+            result.prefix_lists_stale += stale_prefix_lists
 
-    result.endpoints_processed = len(processed_endpoints)
+    result.endpoints_processed = len(
+        processed_fabric_endpoints
+        | processed_route_map_endpoints
+        | processed_prefix_list_endpoints
+    )
     result.success = True
     logger.info(
         "SDN sync complete: %d endpoint(s) processed, "

--- a/netbox_proxbox/views/ha_actions.py
+++ b/netbox_proxbox/views/ha_actions.py
@@ -38,12 +38,17 @@ class _HaActionBaseView(ContentTypePermissionRequiredMixin, View):
                     timeout=30,
                     verify=ctx.verify_ssl,
                 )
+                try:
+                    body = resp.json()
+                except Exception:
+                    body = None
                 results.append(
                     {
                         "endpoint_id": endpoint.pk,
                         "endpoint_name": str(endpoint),
                         "status_code": resp.status_code,
                         "ok": resp.ok,
+                        "body": body,
                     }
                 )
             except requests.exceptions.RequestException as exc:


### PR DESCRIPTION
## Summary

Post-merge correctness fixes for PR #494 (PVE 9.2 full support) identified via maximum-effort code review.

### sync_sdn.py (Bugs 1–6)
- Replace bare `except Exception: pass` in `_resolve_endpoint_by_cluster_name` with logged warning
- Use `item.get("type") or ""` to avoid writing empty string to choices field on create and update
- Fix sticky boolean/nullable fallback in `_upsert_fabric` update path — `True→False` and non-null→null transitions were impossible
- Fix `item.get("order", 0)` returning `None` on JSON null (`None or 0 = 0`)
- Add `cidr` to `_upsert_prefix_list` `get_or_create` lookup key — was silently collapsing multiple entries per prefix-list name into one row
- Split shared `processed_endpoints` set into per-resource-type sets to prevent cross-type stale contamination; capture `.update()` return value into result counters

### sync_datacenter.py (Bugs 7–9)
- Replace bare except with logged warning
- Fix sticky fallback in `_upsert_cpu_model` update path (nullable `level` field and empty-string text fields)
- Make `processed_endpoints.add` conditional on a successful upsert (was unconditional, causing all CPU models to go stale when `cputype` was empty)

### sync_firewall.py (Bugs 10–13)
- Replace bare except with logged warning
- Change `resolved_endpoints` from `list` to `dict` keyed by `endpoint.pk` to deduplicate without repeated node-rule syncs
- Add `isinstance(data, list)` guard with early return when node firewall API returns a non-list (was silently stale-marking all existing node rules)
- Wrap `int(pos_raw)` and `int(enable_raw)` in `try/except (ValueError, TypeError)` with log + skip/default

### ha_actions.py (Bug 14)
- Capture `resp.json()` body and include it in the per-endpoint result dict (error detail was previously dropped)

### api/serializers/cluster.py + filtersets.py (Bug 15)
- Add `"location"` to `ProxmoxNodeSerializer.Meta.fields` — field was populated by migration but invisible in API responses
- Add `"location"` to `ProxmoxNodeFilterSet.Meta.fields`

### models/sdn_prefix_list.py + migration (Bug 16)
- Extend `UniqueConstraint` from `(endpoint, cluster_name, name)` to `(endpoint, cluster_name, name, cidr)` — prefix lists can have multiple entries with the same name but different CIDRs
- Migration `0042_fix_sdn_prefix_list_unique_cidr.py`: `RemoveConstraint` + `AddConstraint`

## Test plan

- [x] `python -m compileall netbox_proxbox tests` — passed
- [x] `rtk ruff check .` — passed
- [x] `rtk pytest tests/ -x -q` — 902 passed, 4 skipped