### PR TITLE
fix: use window.Modal for NetBox 4.6 compat

### DIFF
--- a/netbox_proxbox/templates/netbox_proxbox/home.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home.html
@@ -39,7 +39,7 @@
             const modalEl = document.getElementById("proxbox-quick-edit-modal");
             if (!modalEl) return;
 
-            const bsModal = new bootstrap.Modal(modalEl);
+            const bsModal = new Modal(modalEl);
             const modalBody = document.getElementById("proxbox-quick-edit-body");
             const modalTitle = modalEl.querySelector(".modal-title");
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -194,7 +194,14 @@ def test_e2e_workflow_supports_proxbox_api_package_index_runtime_modes():
     assert "--index-url https://test.pypi.org/simple/" in e2e_workflow
     assert "--extra-index-url https://pypi.org/simple/" in e2e_workflow
     assert "--index-url https://pypi.org/simple/" in e2e_workflow
-    assert '"proxbox-api==${PROXBOX_API_VERSION}"' in e2e_workflow
+    assert (
+        "PROXBOX_API_PACKAGE_SPEC=proxbox-api==${PROXBOX_API_VERSION}" in e2e_workflow
+    )
+    assert (
+        "PROXBOX_API_PACKAGE_SPEC=proxbox-api[pyo3-rust]==${PROXBOX_API_VERSION}"
+        in e2e_workflow
+    )
+    assert '"${PROXBOX_API_PACKAGE_SPEC}"' in e2e_workflow
 
 
 def test_current_release_pairing_is_documented_in_primary_docs():


### PR DESCRIPTION
## Summary
- NetBox 4.6.0 exports Bootstrap components directly on `window` (e.g. `window.Modal`) via `project-static/src/bs.ts`, not under `window.bootstrap`
- The `home.html` template used `new bootstrap.Modal(modalEl)` which threw `ReferenceError: bootstrap is not defined` in strict mode
- This killed the entire `DOMContentLoaded` handler before click listeners were attached, making all quick-edit Edit buttons completely non-functional
- Fixed by changing `bootstrap.Modal` to `Modal`

## Test plan
- [x] Deployed hotfix to production NetBox at netbox.nmulti.cloud
- [x] Verified `new Modal(modalEl)` appears in rendered page
- [x] Verified quick-edit endpoint returns HTTP 200
- [ ] Click an Edit button on the Proxbox dashboard and confirm the modal opens with the form