### PR TITLE
Render companion plugin endpoints on ProxBox home

### DIFF
--- a/netbox_proxbox/api/views.py
+++ b/netbox_proxbox/api/views.py
@@ -478,6 +478,7 @@ class HomeAPIView(APIView):
         from netbox_proxbox.jobs import PROXBOX_SYNC_QUEUE_NAME, is_proxbox_sync_job
         from netbox_proxbox.schedule_hints import has_recurring_proxbox_sync_all
         from netbox_proxbox.utils import get_fastapi_url
+        from netbox_proxbox.views.home_context import build_companion_endpoint_groups
         from core.choices import JobStatusChoices
         from core.models import Job
 
@@ -534,6 +535,9 @@ class HomeAPIView(APIView):
                 "fastapi_endpoints": [_endpoint_dict(ep) for ep in fastapi_qs],
                 "fastapi_url": fastapi_info.get("http_url", ""),
                 "fastapi_websocket_url": fastapi_info.get("websocket_url", ""),
+                "companion_endpoint_groups": build_companion_endpoint_groups(
+                    request, absolute_urls=True
+                ),
                 "show_quick_full_sync_banner": not has_recurring_proxbox_sync_all(
                     request.user
                 ),

--- a/netbox_proxbox/templates/netbox_proxbox/home.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home.html
@@ -236,6 +236,27 @@
             </div>
             <hr>
         {% endif %}
+
+        {% if companion_endpoint_groups %}
+            <div class="col-12 mt-3">
+                <div class="d-flex justify-content-center flex-nowrap" style="margin-bottom: 15px;">
+                    <h2>Additional Proxbox Plugin Endpoints</h2>
+                </div>
+            </div>
+            {% for endpoint_group in companion_endpoint_groups %}
+                {% for companion_endpoint in endpoint_group.endpoints %}
+                    {% if endpoint_group.endpoints|length == 1 %}
+                        <div class="col">
+                    {% elif endpoint_group.endpoints|length == 2 %}
+                        <div class="col col-md-6">
+                    {% else %}
+                        <div class="col col-md-4">
+                    {% endif %}
+                            {% include "netbox_proxbox/home/companion_endpoint_card.html" with endpoint_group=endpoint_group companion_endpoint=companion_endpoint %}
+                        </div>
+                {% endfor %}
+            {% endfor %}
+        {% endif %}
     </div>
 
     <div class="text-center mt-4 mb-2">

--- a/netbox_proxbox/templates/netbox_proxbox/home/companion_endpoint_card.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home/companion_endpoint_card.html
@@ -1,0 +1,31 @@
+<div class="card h-100">
+    <h2 class="card-header">{{ endpoint_group.plugin_name }}</h2>
+
+    <div class="card-body">
+        <table class="table table-hover attr-table">
+            <tr>
+                <th scope="row"><strong>{{ endpoint_group.model_label }}</strong></th>
+                <td>
+                    {% if companion_endpoint.url %}
+                        <a href="{{ companion_endpoint.url }}">{{ companion_endpoint.name }}</a>
+                    {% else %}
+                        {{ companion_endpoint.name }}
+                    {% endif %}
+                </td>
+            </tr>
+            {% for field in companion_endpoint.fields %}
+                <tr>
+                    <th scope="row"><strong>{{ field.label }}</strong></th>
+                    <td>{{ field.value }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+
+        <div class="d-flex justify-content-between align-items-center">
+            <span class="badge text-bg-secondary">{{ endpoint_group.plugin_package }}</span>
+            {% if endpoint_group.plugin_version %}
+                <span class="small text-muted">v{{ endpoint_group.plugin_version }}</span>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/netbox_proxbox/views/home_context.py
+++ b/netbox_proxbox/views/home_context.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Iterable
 from urllib.parse import urlencode
 
 from core.choices import JobStatusChoices
@@ -21,7 +23,35 @@ from netbox_proxbox.schedule_hints import (
 from netbox_proxbox.utils import get_fastapi_url
 from netbox_proxbox.views.proxbox_access import permission_enqueue_proxbox_sync
 
-__all__ = ("build_home_dashboard_context",)
+__all__ = ("build_companion_endpoint_groups", "build_home_dashboard_context")
+
+logger = logging.getLogger(__name__)
+
+_COMPANION_PLUGIN_REQUIREMENT = "netbox_proxbox"
+_COMPANION_ENDPOINT_FIELD_LABELS = (
+    ("host", "Host"),
+    ("domain", "Domain"),
+    ("ip_address", "IP Address"),
+    ("port", "Port"),
+    ("status", "Status"),
+    ("version", "Version"),
+    ("verify_ssl", "Verify SSL"),
+    ("enabled", "Enabled"),
+    ("last_seen_at", "Last seen"),
+)
+_SENSITIVE_COMPANION_FIELDS = {
+    "api_key",
+    "fingerprint",
+    "key",
+    "password",
+    "proxbox_api_key",
+    "secret",
+    "token",
+    "token_id",
+    "token_name",
+    "token_secret",
+    "token_value",
+}
 
 
 def _build_add_url(view_name: str, params: dict[str, object]) -> str:
@@ -46,6 +76,220 @@ def _get_latest_active_proxbox_job(request: HttpRequest) -> Job | None:
         if is_proxbox_sync_job(job):
             return job
     return None
+
+
+def _model_field_names(model: type[object]) -> set[str]:
+    try:
+        return {field.name for field in model._meta.get_fields()}
+    except Exception:
+        return set()
+
+
+def _is_companion_plugin(app_config: object) -> bool:
+    plugin_name = getattr(app_config, "name", "")
+    required_plugins = getattr(app_config, "required_plugins", None) or ()
+    return (
+        plugin_name != _COMPANION_PLUGIN_REQUIREMENT
+        and _COMPANION_PLUGIN_REQUIREMENT in required_plugins
+    )
+
+
+def _iter_installed_companion_plugins() -> Iterable[object]:
+    try:
+        from django.apps import apps
+        from netbox.registry import registry
+    except Exception:
+        return ()
+
+    plugin_names = registry.get("plugins", {}).get("installed", ()) or ()
+    companion_plugins = []
+    for plugin_name in plugin_names:
+        try:
+            app_config = apps.get_app_config(plugin_name)
+        except Exception:
+            logger.debug(
+                "Unable to resolve installed plugin app config for %s",
+                plugin_name,
+                exc_info=True,
+            )
+            continue
+        if _is_companion_plugin(app_config):
+            companion_plugins.append(app_config)
+    return companion_plugins
+
+
+def _is_endpoint_like_model(model: type[object]) -> bool:
+    model_name = model.__name__.lower()
+    if "settings" in model_name:
+        return False
+
+    field_names = _model_field_names(model)
+    has_host_field = bool({"domain", "host", "ip_address"} & field_names)
+    has_http_shape = has_host_field and "port" in field_names
+    name_suggests_endpoint = model_name.endswith(("endpoint", "server"))
+    return has_http_shape and name_suggests_endpoint
+
+
+def _iter_visible_model_objects(model: type[object], user: object) -> Iterable[object]:
+    manager = getattr(model, "objects", None)
+    if manager is None:
+        return ()
+
+    try:
+        queryset = manager.restrict(user, "view")
+    except AttributeError:
+        all_objects = getattr(manager, "all", None)
+        queryset = all_objects() if callable(all_objects) else manager
+    except Exception:
+        logger.debug(
+            "Unable to restrict companion endpoint queryset for %s",
+            getattr(model, "__name__", model),
+            exc_info=True,
+        )
+        return ()
+
+    ordering = getattr(getattr(model, "_meta", None), "ordering", ()) or ("pk",)
+    try:
+        queryset = queryset.order_by(*ordering)
+    except Exception:
+        pass
+
+    try:
+        if not queryset.exists():
+            return ()
+    except Exception:
+        pass
+
+    try:
+        return list(queryset)
+    except Exception:
+        logger.debug(
+            "Unable to evaluate companion endpoint queryset for %s",
+            getattr(model, "__name__", model),
+            exc_info=True,
+        )
+        return ()
+
+
+def _object_url(obj: object, request: HttpRequest, *, absolute_urls: bool) -> str:
+    get_absolute_url = getattr(obj, "get_absolute_url", None)
+    if not callable(get_absolute_url):
+        return ""
+    try:
+        url = get_absolute_url()
+    except Exception:
+        return ""
+    if not absolute_urls:
+        return url
+    try:
+        return request.build_absolute_uri(url)
+    except Exception:
+        return url
+
+
+def _field_display_value(obj: object, field_name: str) -> str:
+    display_method = getattr(obj, f"get_{field_name}_display", None)
+    if callable(display_method):
+        try:
+            value = display_method()
+        except Exception:
+            value = getattr(obj, field_name, None)
+    else:
+        value = getattr(obj, field_name, None)
+
+    if value in (None, ""):
+        return ""
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if hasattr(value, "isoformat"):
+        try:
+            return value.isoformat()
+        except Exception:
+            pass
+    return str(value)
+
+
+def _serialize_companion_endpoint(
+    obj: object, request: HttpRequest, *, absolute_urls: bool
+) -> dict[str, object]:
+    field_names = _model_field_names(obj.__class__)
+    fields = []
+    for field_name, label in _COMPANION_ENDPOINT_FIELD_LABELS:
+        if field_name not in field_names or field_name in _SENSITIVE_COMPANION_FIELDS:
+            continue
+        value = _field_display_value(obj, field_name)
+        if value:
+            fields.append({"name": field_name, "label": label, "value": value})
+
+    return {
+        "id": getattr(obj, "pk", getattr(obj, "id", None)),
+        "name": str(obj),
+        "url": _object_url(obj, request, absolute_urls=absolute_urls),
+        "fields": fields,
+    }
+
+
+def build_companion_endpoint_groups(
+    request: HttpRequest, *, absolute_urls: bool = False
+) -> list[dict[str, object]]:
+    """
+    Return endpoint rows owned by installed Proxbox companion plugins.
+
+    This mirrors NetBox's installed-plugins API source server-side so the home
+    page can remain useful to non-superusers; the API itself is superuser-only.
+    """
+    groups = []
+    user = getattr(request, "user", None)
+
+    for app_config in _iter_installed_companion_plugins():
+        try:
+            models = app_config.get_models()
+        except Exception:
+            logger.debug(
+                "Unable to enumerate models for companion plugin %s",
+                getattr(app_config, "name", app_config),
+                exc_info=True,
+            )
+            continue
+
+        for model in models:
+            if not _is_endpoint_like_model(model):
+                continue
+            objects = list(_iter_visible_model_objects(model, user))
+            if not objects:
+                continue
+
+            model_meta = getattr(model, "_meta", None)
+            groups.append(
+                {
+                    "plugin_name": str(
+                        getattr(app_config, "verbose_name", "")
+                        or getattr(app_config, "name", "")
+                    ),
+                    "plugin_package": getattr(app_config, "name", ""),
+                    "plugin_version": getattr(app_config, "version", ""),
+                    "plugin_base_url": getattr(
+                        app_config, "base_url", getattr(app_config, "label", "")
+                    ),
+                    "model_name": getattr(model, "__name__", ""),
+                    "model_label": str(
+                        getattr(model_meta, "verbose_name", None)
+                        or getattr(model, "__name__", "Endpoint")
+                    ),
+                    "model_label_plural": str(
+                        getattr(model_meta, "verbose_name_plural", None)
+                        or getattr(model, "__name__", "Endpoints")
+                    ),
+                    "endpoints": [
+                        _serialize_companion_endpoint(
+                            obj, request, absolute_urls=absolute_urls
+                        )
+                        for obj in objects
+                    ],
+                }
+            )
+
+    return groups
 
 
 def build_home_dashboard_context(
@@ -117,4 +361,5 @@ def build_home_dashboard_context(
         "can_quick_schedule_sync": can_quick_schedule_sync,
         "quick_schedule_form": quick_schedule_form,
         "active_proxbox_job": active_proxbox_job,
+        "companion_endpoint_groups": build_companion_endpoint_groups(request),
     }

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -84,6 +84,20 @@ def test_home_template_exposes_prefilled_endpoint_quick_add_buttons():
     assert "token mode" in contents
 
 
+def test_home_template_renders_companion_plugin_endpoint_groups():
+    contents = _read("netbox_proxbox/templates/netbox_proxbox/home.html")
+    partial = _read(
+        "netbox_proxbox/templates/netbox_proxbox/home/companion_endpoint_card.html"
+    )
+
+    assert "companion_endpoint_groups" in contents
+    assert "Additional Proxbox Plugin Endpoints" in contents
+    assert "companion_endpoint_card.html" in contents
+    assert "endpoint_group.plugin_name" in partial
+    assert "companion_endpoint.fields" in partial
+    assert "endpoint_group.plugin_package" in partial
+
+
 def test_home_quick_schedule_banner_posts_to_quick_schedule_url():
     contents = _read(
         "netbox_proxbox/templates/netbox_proxbox/home/quick_schedule_banner.html"

--- a/tests/test_home_context.py
+++ b/tests/test_home_context.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+import types
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 from tests.conftest import load_plugin_module
@@ -19,6 +22,85 @@ class _JobQuerySet(list):
 
     def iterator(self, chunk_size=64):
         return iter(self)
+
+
+class _EndpointQuerySet(list):
+    def restrict(self, user, action):
+        self.restrict_call = (user, action)
+        return self
+
+    def order_by(self, *fields):
+        self.order_by_call = fields
+        return self
+
+    def exists(self):
+        return bool(self)
+
+
+class _FakeField:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeMeta:
+    app_label = "netbox_pbs"
+    model_name = "pbsserver"
+    verbose_name = "PBS server"
+    verbose_name_plural = "PBS servers"
+    ordering = ("name",)
+
+    def get_fields(self):
+        return [
+            _FakeField("name"),
+            _FakeField("host"),
+            _FakeField("port"),
+            _FakeField("token_id"),
+            _FakeField("fingerprint"),
+            _FakeField("verify_ssl"),
+            _FakeField("status"),
+            _FakeField("version"),
+            _FakeField("last_seen_at"),
+        ]
+
+
+class PBSServer:
+    _meta = _FakeMeta()
+
+    def __init__(self):
+        self.pk = 7
+        self.name = "PBS01"
+        self.host = "10.0.30.134"
+        self.port = 8007
+        self.token_id = "sensitive-token-id"
+        self.fingerprint = "sensitive-fingerprint"
+        self.verify_ssl = True
+        self.status = "online"
+        self.version = "3.2"
+        self.last_seen_at = datetime(2026, 5, 24, 12, 0, tzinfo=timezone.utc)
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return f"/plugins/pbs/servers/{self.pk}/"
+
+
+def _install_installed_plugin_stubs(monkeypatch, app_configs):
+    django_apps_module = types.ModuleType("django.apps")
+    configs_by_label = {config.label: config for config in app_configs}
+    django_apps_module.apps = SimpleNamespace(
+        get_app_config=lambda label: configs_by_label[label]
+    )
+
+    registry_module = types.ModuleType("netbox.registry")
+    registry_module.registry = {
+        "plugins": {"installed": [config.label for config in app_configs]}
+    }
+
+    monkeypatch.setitem(sys.modules, "django.apps", django_apps_module)
+    monkeypatch.setitem(sys.modules, "netbox.registry", registry_module)
+    setattr(sys.modules["django"], "apps", django_apps_module)
+    setattr(sys.modules["netbox"], "registry", registry_module)
 
 
 def test_home_context_exposes_latest_active_proxbox_job(monkeypatch):
@@ -58,3 +140,83 @@ def test_home_context_exposes_latest_active_proxbox_job(monkeypatch):
     )
 
     assert context["active_proxbox_job"] is proxbox_job
+
+
+def test_companion_endpoint_groups_render_required_plugin_endpoint_models(monkeypatch):
+    module = load_plugin_module(
+        "netbox_proxbox.views.home_context", monkeypatch=monkeypatch
+    )
+    endpoint = PBSServer()
+    PBSServer.objects = _EndpointQuerySet([endpoint])
+
+    app_config = SimpleNamespace(
+        label="netbox_pbs",
+        name="netbox_pbs",
+        verbose_name="NetBox PBS",
+        version="0.0.1",
+        base_url="pbs",
+        required_plugins=["netbox_proxbox"],
+        get_models=lambda: [PBSServer],
+    )
+    _install_installed_plugin_stubs(monkeypatch, [app_config])
+
+    request = SimpleNamespace(
+        user=SimpleNamespace(),
+        build_absolute_uri=lambda path: f"https://netbox.example{path}",
+    )
+
+    groups = module.build_companion_endpoint_groups(request, absolute_urls=True)
+
+    assert groups == [
+        {
+            "plugin_name": "NetBox PBS",
+            "plugin_package": "netbox_pbs",
+            "plugin_version": "0.0.1",
+            "plugin_base_url": "pbs",
+            "model_name": "PBSServer",
+            "model_label": "PBS server",
+            "model_label_plural": "PBS servers",
+            "endpoints": [
+                {
+                    "id": 7,
+                    "name": "PBS01",
+                    "url": "https://netbox.example/plugins/pbs/servers/7/",
+                    "fields": [
+                        {"name": "host", "label": "Host", "value": "10.0.30.134"},
+                        {"name": "port", "label": "Port", "value": "8007"},
+                        {"name": "status", "label": "Status", "value": "online"},
+                        {"name": "version", "label": "Version", "value": "3.2"},
+                        {"name": "verify_ssl", "label": "Verify SSL", "value": "Yes"},
+                        {
+                            "name": "last_seen_at",
+                            "label": "Last seen",
+                            "value": "2026-05-24T12:00:00+00:00",
+                        },
+                    ],
+                }
+            ],
+        }
+    ]
+    assert PBSServer.objects.restrict_call == (request.user, "view")
+
+
+def test_companion_endpoint_groups_ignore_unrelated_plugins(monkeypatch):
+    module = load_plugin_module(
+        "netbox_proxbox.views.home_context", monkeypatch=monkeypatch
+    )
+    PBSServer.objects = _EndpointQuerySet([PBSServer()])
+
+    app_config = SimpleNamespace(
+        label="netbox_dns",
+        name="netbox_dns",
+        verbose_name="NetBox DNS",
+        required_plugins=[],
+        get_models=lambda: [PBSServer],
+    )
+    _install_installed_plugin_stubs(monkeypatch, [app_config])
+
+    groups = module.build_companion_endpoint_groups(
+        SimpleNamespace(user=SimpleNamespace())
+    )
+
+    assert groups == []

--- a/uv.lock
+++ b/uv.lock
@@ -1179,7 +1179,7 @@ wheels = [
 
 [[package]]
 name = "netbox-proxbox"
-version = "0.0.18"
+version = "0.0.18.post1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Closes #508

## Summary
- discover installed plugins from NetBox's plugin registry and select companions that require netbox_proxbox
- render endpoint-shaped companion plugin resources on the ProxBox home page next to Proxmox VE endpoints
- include companion endpoint groups in the ProxBox home API payload while omitting credential fields

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check netbox_proxbox/views/home_context.py netbox_proxbox/api/views.py tests/test_home_context.py tests/test_frontend_contracts.py
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q
- curl https://netbox.nmulti.cloud/plugins/proxbox/
- curl https://netbox.nmulti.cloud/api/plugins/proxbox/home/