### PR TITLE
Add PyO3 Rust backend E2E gate

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: ""
+      proxbox_api_runtime:
+        description: "proxbox-api runtime selection: both, python, or pyo3-rust"
+        required: false
+        type: string
+        default: both
       netbox_image:
         description: "Override NetBox image (e.g. netboxcommunity/netbox:v4.6.0). Empty = workflow default."
         required: false
@@ -56,6 +61,15 @@ on:
         required: false
         type: string
         default: ""
+      proxbox_api_runtime:
+        description: "proxbox-api runtime"
+        required: false
+        type: choice
+        options:
+          - both
+          - python
+          - pyo3-rust
+        default: both
       netbox_image:
         description: "Override NetBox image (full ref). Leave empty for workflow default."
         required: false
@@ -83,7 +97,7 @@ env:
 
 jobs:
   e2e-docker-stack:
-    name: E2E Docker / ${{ matrix.install_source }} / ${{ matrix.netbox_image }} / proxmox=${{ matrix.proxmox_service }} [${{ matrix.network_stack }}]
+    name: E2E Docker / ${{ matrix.install_source }} / ${{ matrix.netbox_image }} / api=${{ matrix.proxbox_api_runtime }} / proxmox=${{ matrix.proxmox_service }} [${{ matrix.network_stack }}]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -99,6 +113,7 @@ jobs:
         # Re-add once netbox-community/netbox-docker ships the v4.6.1 image.
         netbox_image: ${{ fromJSON(inputs.netbox_image != '' && format('["{0}"]', inputs.netbox_image) || '["netboxcommunity/netbox:v4.5.8","netboxcommunity/netbox:v4.5.9","netboxcommunity/netbox:v4.6.0"]') }}
         network_stack: [ipv4]
+        proxbox_api_runtime: ${{ fromJSON((inputs.proxbox_api_runtime == 'python' || inputs.proxbox_api_runtime == 'pyo3-rust') && format('["{0}"]', inputs.proxbox_api_runtime) || '["python","pyo3-rust"]') }}
         proxmox_service: ${{ fromJSON((inputs.proxmox_service == 'pve' || inputs.proxmox_service == 'pbs' || inputs.proxmox_service == 'pdm') && format('["{0}"]', inputs.proxmox_service) || '["pve","pbs","pdm"]') }}
     steps:
       - name: Checkout repository
@@ -151,11 +166,24 @@ jobs:
             PROXBOX_API_VERSION="${PROXBOX_API_RELEASE_VERSION}"
           fi
           echo "PROXBOX_API_VERSION=${PROXBOX_API_VERSION}" >> "$GITHUB_ENV"
+          echo "PROXBOX_API_RUNTIME=${{ matrix.proxbox_api_runtime }}" >> "$GITHUB_ENV"
           echo "PROXBOX_API_PACKAGE_INDEX=" >> "$GITHUB_ENV"
           if [ "${{ inputs.dependency_mode }}" = "testpypi-package" ]; then
             echo "PROXBOX_API_PACKAGE_INDEX=--index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/" >> "$GITHUB_ENV"
           elif [ "${{ inputs.dependency_mode }}" = "pypi-package" ]; then
             echo "PROXBOX_API_PACKAGE_INDEX=--index-url https://pypi.org/simple/" >> "$GITHUB_ENV"
+          fi
+          if [ "${{ matrix.proxbox_api_runtime }}" = "pyo3-rust" ]; then
+            echo "PROXBOX_API_BUILD_TARGET=raw-pyo3-rust" >> "$GITHUB_ENV"
+            echo "PROXBOX_API_DOCKER_TAG=${PROXBOX_API_VERSION}-pyo3-rust" >> "$GITHUB_ENV"
+            echo "PROXBOX_API_PACKAGE_SPEC=proxbox-api[pyo3-rust]==${PROXBOX_API_VERSION}" >> "$GITHUB_ENV"
+          elif [ "${{ matrix.proxbox_api_runtime }}" = "python" ]; then
+            echo "PROXBOX_API_BUILD_TARGET=raw" >> "$GITHUB_ENV"
+            echo "PROXBOX_API_DOCKER_TAG=${PROXBOX_API_VERSION}" >> "$GITHUB_ENV"
+            echo "PROXBOX_API_PACKAGE_SPEC=proxbox-api==${PROXBOX_API_VERSION}" >> "$GITHUB_ENV"
+          else
+            echo "Unsupported proxbox-api runtime: ${{ matrix.proxbox_api_runtime }}" >&2
+            exit 1
           fi
 
       - name: Start E2E stack
@@ -255,41 +283,51 @@ jobs:
             PROXBOX_BIND_HOST_VALUE="0.0.0.0"
           fi
 
-          if [ "${{ inputs.dependency_mode }}" = "published" ]; then
-            docker pull "${PROXBOX_API_IMAGE}:${PROXBOX_API_VERSION}"
+          PROXBOX_API_RUNTIME_ARGS=()
+          if [ "${PROXBOX_API_RUNTIME}" = "pyo3-rust" ]; then
+            PROXBOX_API_RUNTIME_ARGS=(-e PROXBOX_RECONCILIATION_ENGINE=rust)
+          fi
+
+          start_proxbox_api_container() {
+            image_ref="$1"
             docker run -d --name proxbox-e2e-api --network proxbox-e2e -p "${HOST_BIND}18800:8000" \
               -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=true \
               -e PROXBOX_ENCRYPTION_KEY \
               -e PROXBOX_BIND_HOST="${PROXBOX_BIND_HOST_VALUE}" \
-              "${PROXBOX_API_IMAGE}:${PROXBOX_API_VERSION}"
+              "${PROXBOX_API_RUNTIME_ARGS[@]}" \
+              "${image_ref}"
+          }
+
+          if [ "${{ inputs.dependency_mode }}" = "published" ]; then
+            docker pull "${PROXBOX_API_IMAGE}:${PROXBOX_API_DOCKER_TAG}"
+            start_proxbox_api_container "${PROXBOX_API_IMAGE}:${PROXBOX_API_DOCKER_TAG}"
           elif [ "${{ inputs.dependency_mode }}" = "testpypi-package" ] || [ "${{ inputs.dependency_mode }}" = "pypi-package" ]; then
             cat > /tmp/proxbox-api-package.Dockerfile <<'EOF'
           FROM python:3.13-slim
           RUN python -m pip install --upgrade pip
-          ARG PROXBOX_API_VERSION
           ARG PROXBOX_API_PACKAGE_INDEX
-          RUN python -m pip install --no-cache-dir ${PROXBOX_API_PACKAGE_INDEX} "proxbox-api==${PROXBOX_API_VERSION}"
+          ARG PROXBOX_API_PACKAGE_SPEC
+          RUN python -m pip install --no-cache-dir ${PROXBOX_API_PACKAGE_INDEX} "${PROXBOX_API_PACKAGE_SPEC}"
           CMD ["python", "-m", "uvicorn", "proxbox_api.main:app", "--host", "0.0.0.0", "--port", "8000"]
           EOF
-            docker build \
-              --build-arg "PROXBOX_API_VERSION=${PROXBOX_API_VERSION}" \
+            if docker build \
               --build-arg "PROXBOX_API_PACKAGE_INDEX=${PROXBOX_API_PACKAGE_INDEX}" \
+              --build-arg "PROXBOX_API_PACKAGE_SPEC=${PROXBOX_API_PACKAGE_SPEC}" \
               -t proxbox-api-e2e:package \
               -f /tmp/proxbox-api-package.Dockerfile \
-              /tmp
-            docker run -d --name proxbox-e2e-api --network proxbox-e2e -p "${HOST_BIND}18800:8000" \
-              -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=true \
-              -e PROXBOX_ENCRYPTION_KEY \
-              -e PROXBOX_BIND_HOST="${PROXBOX_BIND_HOST_VALUE}" \
-              proxbox-api-e2e:package
+              /tmp; then
+              start_proxbox_api_container proxbox-api-e2e:package
+            elif [ "${PROXBOX_API_RUNTIME}" = "pyo3-rust" ]; then
+              echo "::warning title=proxbox-api pyo3-rust package extra unavailable::Falling back to ${PROXBOX_API_IMAGE}:${PROXBOX_API_DOCKER_TAG}"
+              docker pull "${PROXBOX_API_IMAGE}:${PROXBOX_API_DOCKER_TAG}"
+              start_proxbox_api_container "${PROXBOX_API_IMAGE}:${PROXBOX_API_DOCKER_TAG}"
+            else
+              exit 1
+            fi
           else
             git clone --depth 1 https://github.com/emersonfelipesp/proxbox-api.git /tmp/proxbox-api-src
-            docker build --target raw -t proxbox-api-e2e:dev /tmp/proxbox-api-src
-            docker run -d --name proxbox-e2e-api --network proxbox-e2e -p "${HOST_BIND}18800:8000" \
-              -e PROXBOX_SKIP_NETBOX_BOOTSTRAP=true \
-              -e PROXBOX_ENCRYPTION_KEY \
-              -e PROXBOX_BIND_HOST="${PROXBOX_BIND_HOST_VALUE}" \
-              proxbox-api-e2e:dev
+            docker build --target "${PROXBOX_API_BUILD_TARGET}" -t proxbox-api-e2e:dev /tmp/proxbox-api-src
+            start_proxbox_api_container proxbox-api-e2e:dev
           fi
 
           if [ -n "${NETBOX_PLUGIN_MOUNT}" ]; then
@@ -336,6 +374,12 @@ jobs:
               --entrypoint /bin/bash \
               "${NETBOX_IMAGE}" -ec "i=0; until uv pip install --upgrade ${NETBOX_PLUGIN_INSTALL_INDEX} ${NETBOX_PLUGIN_INSTALL_SPEC}; do i=\$((i+1)); [ \$i -ge 30 ] && exit 1; sleep 10; done && mkdir -p /etc/netbox/config && printf 'PLUGINS = [\"netbox_proxbox\"]\n' > /etc/netbox/config/plugins.py && /opt/netbox/docker-entrypoint.sh /opt/netbox/launch-netbox.sh"
           fi
+
+      - name: Verify proxbox-api PyO3/Rust runtime
+        if: matrix.proxbox_api_runtime == 'pyo3-rust'
+        run: |
+          set -eux
+          docker exec proxbox-e2e-api python -c "import os; from proxbox_api.services.sync.reconciliation.rust_bridge import rust_available; assert os.environ.get('PROXBOX_RECONCILIATION_ENGINE') == 'rust'; assert rust_available()"
 
       - name: Get container IPs
         run: |

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -287,6 +287,7 @@ jobs:
       install_source: testpypi
       dependency_mode: testpypi-package
       proxbox_api_version: ${{ needs.prepare-release.outputs.proxbox_api_version }}
+      proxbox_api_runtime: both
 
   validate-pypi-candidate:
     name: validate PyPI candidate / py${{ matrix.python-version }}
@@ -332,6 +333,7 @@ jobs:
       install_source: local
       dependency_mode: pypi-package
       proxbox_api_version: ${{ needs.prepare-release.outputs.proxbox_api_version }}
+      proxbox_api_runtime: both
 
   publish-pypi:
     name: publish to PyPI
@@ -426,3 +428,4 @@ jobs:
       install_source: pypi
       dependency_mode: pypi-package
       proxbox_api_version: ${{ needs.prepare-release.outputs.proxbox_api_version }}
+      proxbox_api_runtime: both

--- a/docs/developer/ci-e2e-workflows.md
+++ b/docs/developer/ci-e2e-workflows.md
@@ -52,8 +52,16 @@ The reusable inputs select what is under test:
 | `install_source` | `local`, `pypi`, `testpypi`, `container`, `both` | Selects how `netbox-proxbox` is installed inside the NetBox container. |
 | `dependency_mode` | `dev`, `published`, `testpypi-package`, `pypi-package` | Selects how the separate `proxbox-api` container is built or installed. |
 | `proxbox_api_version` | Version string | Pins the backend package version for TestPyPI/PyPI package-index E2E modes. |
+| `proxbox_api_runtime` | `python`, `pyo3-rust`, `both` | Selects the backend reconciliation runtime. `both` is the default and doubles the matrix. |
 | `netbox_image` | Full image ref | Overrides the NetBox image; default matrix covers `v4.5.8`, `v4.5.9`, and `v4.6.0`. |
 | `proxmox_service` | `pve`, `pbs`, `pdm`, `all` | Selects the proxmox-sdk mock image suffix. `all` runs the full per-service matrix. |
+
+The `pyo3-rust` runtime uses the `proxbox-api` `raw-pyo3-rust` Docker target in
+development mode, `<version>-pyo3-rust` Docker tags in published-image mode, and
+`proxbox-api[pyo3-rust]` in package-index modes with a fallback to the matching
+Docker tag when the selected backend package has not shipped the extra yet.
+Each Rust cell asserts `PROXBOX_RECONCILIATION_ENGINE=rust` and
+`rust_available()` before running sync checks.
 
 ### Proxmox Service Matrix
 
@@ -79,17 +87,17 @@ sequenceDiagram
 
     Tag->>WF: vX.Y.Z or vX.Y.Z.postN
     WF->>TP: Upload netbox-proxbox
-    WF->>E2E: install_source=testpypi + dependency_mode=testpypi-package
+    WF->>E2E: install_source=testpypi + dependency_mode=testpypi-package + runtime=both
     E2E->>NB: Install netbox-proxbox==X.Y.Z from TestPyPI
-    E2E->>API: Install proxbox-api==configured version from TestPyPI
-    E2E-->>WF: Full stack E2E passed
+    E2E->>API: Validate proxbox-api Python and PyO3/Rust runtimes
+    E2E-->>WF: Full stack E2E passed for both runtimes
 
     Tag->>WF: vX.Y.ZrcN or publish_target=pypi
     WF->>PY: Upload netbox-proxbox
-    WF->>E2E: install_source=pypi/local + dependency_mode=pypi-package
+    WF->>E2E: install_source=pypi/local + dependency_mode=pypi-package + runtime=both
     E2E->>NB: Install netbox-proxbox from PyPI or current checkout
-    E2E->>API: Install proxbox-api==configured version from PyPI
-    E2E-->>WF: Candidate/final E2E passed
+    E2E->>API: Validate proxbox-api Python and PyO3/Rust runtimes
+    E2E-->>WF: Candidate/final E2E passed for both runtimes
 ```
 
 ## Developer Checklist
@@ -98,6 +106,8 @@ sequenceDiagram
   `netbox_proxbox/__init__.py`, `uv.lock`, and the Git tag.
 - Use TestPyPI `proxbox-api` for TestPyPI `netbox-proxbox` E2E.
 - Use PyPI `proxbox-api` for PyPI release-candidate and final E2E.
+- Keep `proxbox_api_runtime: both` in release workflow callers so PyPI
+  publication is blocked when Rust-backed sync fails.
 - Do not add `twine --skip-existing`; consumed versions are immutable and must
   be fixed forward.
 - When changing sync contracts shared with the backend, run the mocked tests,

--- a/docs/developer/release-publishing.md
+++ b/docs/developer/release-publishing.md
@@ -55,15 +55,15 @@ sequenceDiagram
     WF->>TP: Upload netbox-proxbox package
     WF->>E2E: install_source=testpypi, dependency_mode=testpypi-package
     E2E->>NB: pip install netbox-proxbox==X.Y.ZrcN from TestPyPI
-    E2E->>API: pip install proxbox-api==configured version from TestPyPI
-    E2E-->>WF: Release-candidate checks pass
+    E2E->>API: validate proxbox-api Python and PyO3/Rust runtimes
+    E2E-->>WF: Release-candidate checks pass for both runtimes
 
     Tag->>WF: vX.Y.Z, vX.Y.Z.postN, or publish_target=pypi
     WF->>PY: Upload netbox-proxbox package
     WF->>E2E: install_source=pypi, dependency_mode=pypi-package
     E2E->>NB: pip install netbox-proxbox==X.Y.Z or X.Y.Z.postN from PyPI
-    E2E->>API: pip install proxbox-api==configured version from PyPI
-    E2E-->>WF: Post-publish checks pass
+    E2E->>API: validate proxbox-api Python and PyO3/Rust runtimes
+    E2E-->>WF: Post-publish checks pass for both runtimes
 ```
 
 ## Workflow Rules
@@ -78,6 +78,11 @@ sequenceDiagram
   dispatch with `publish_target=pypi` also publishes to PyPI.
 - Package uploads intentionally omit `twine --skip-existing`; a consumed version
   must move forward to the next `.postN` or `rcN`.
+- Release E2E runs with `proxbox_api_runtime: both`. The Python backend and the
+  PyO3/Rust backend must both pass before PyPI publication can proceed.
+- In package-index E2E, Rust mode tries `proxbox-api[pyo3-rust]` first and
+  falls back to the matching `<version>-pyo3-rust` Docker image when the backend
+  package has not published that extra yet.
 - `proxbox_api_version` can be supplied manually. If omitted, the workflow reads
   repository variables in this order:
   `PROXBOX_API_TESTPYPI_VERSION` / `PROXBOX_API_PYPI_VERSION`,

--- a/docs/features/e2e-docker-testing.md
+++ b/docs/features/e2e-docker-testing.md
@@ -16,7 +16,7 @@ pipeline that reuses this workflow), see
 
 ## Matrix Shape
 
-`e2e-docker.yml` fans the test out across four axes. Each cell runs on its
+`e2e-docker.yml` fans the test out across five axes. Each cell runs on its
 own GitHub Actions runner with `fail-fast: false`, so failures in one cell
 do not abort the others.
 
@@ -25,11 +25,27 @@ do not abort the others.
 | `install_source` | `local`, `pypi`, `container` | How `netbox-proxbox` is installed inside NetBox. |
 | `netbox_image` | `v4.5.8`, `v4.5.9`, `v4.6.0` | The three NetBox releases the plugin is currently certified against. |
 | `network_stack` | `ipv4` | Reserved for future dual-stack runs. |
+| `proxbox_api_runtime` | `python`, `pyo3-rust` | Runs each cell against the default Python backend and the experimental PyO3/Rust reconciliation backend. |
 | `proxmox_service` | `pve`, `pbs`, `pdm` | Selects which `proxmox-sdk` mock service image is used as the Proxmox side. |
 
-The default cross-product is **3 × 3 × 1 × 3 = 27 cells**. Manual
+The default cross-product is **3 × 3 × 1 × 2 × 3 = 54 cells**. Manual
 dispatch (`workflow_dispatch`) and reusable callers can pin any axis to a
 single value (for example `proxmox_service: pve`) to run a narrower slice.
+
+### proxbox-api Runtime Axis
+
+The backend container is split between the stable Python reconciliation path
+and the experimental PyO3/Rust reconciliation path:
+
+| Runtime | Dev mode | Published Docker mode | Package-index mode |
+|---|---|---|---|
+| `python` | Builds `proxbox-api` target `raw`. | Pulls `emersonfelipesp/proxbox-api:<version>`. | Installs `proxbox-api==<version>`. |
+| `pyo3-rust` | Builds target `raw-pyo3-rust`. | Pulls `emersonfelipesp/proxbox-api:<version>-pyo3-rust`. | Tries `proxbox-api[pyo3-rust]==<version>`, then falls back to the matching `-pyo3-rust` Docker image with a workflow warning. |
+
+Rust cells set `PROXBOX_RECONCILIATION_ENGINE=rust` and run an early
+`rust_available()` assertion inside the backend container before the NetBox
+sync checks begin. A Rust import or runtime mismatch therefore fails the E2E
+cell before package publication can proceed.
 
 ### Proxmox Service Axis
 
@@ -72,7 +88,7 @@ flowchart LR
   subgraph D[Docker network: proxbox-e2e]
     NB[NetBox container<br>netbox-proxbox installed]
     RQ[NetBox rqworker<br>manage.py rqworker]
-    API[proxbox-api container]
+    API[proxbox-api container<br>python / pyo3-rust runtime]
     PM[proxmox-sdk mock<br>tag latest-pve / latest-pbs / latest-pdm]
     PG[(PostgreSQL)]
     RD[(Redis)]
@@ -231,6 +247,7 @@ env:
 ```bash
 # Pick the cell you want to reproduce
 export PROXMOX_SERVICE=pbs
+export PROXBOX_API_RUNTIME=pyo3-rust
 export NETBOX_IMAGE=netboxcommunity/netbox:v4.6.0
 
 # Stand up the stack the way the workflow does


### PR DESCRIPTION
Closes #511

## Summary
- Add a proxbox_api_runtime axis to Docker E2E with python and pyo3-rust runtimes.
- Run release E2E callers with both runtimes so PyPI publishing is blocked if Rust-backed syncing fails.
- Teach dev, published-image, and package-index backend modes how to start the Rust backend, including the package-extra-first / Docker-tag fallback path.
- Document the new matrix axis and release gate behavior.

## Verification
- git diff --check
- PyYAML parse of .github/workflows/e2e-docker.yml and .github/workflows/publish-testpypi.yml
- bash -n over workflow run scripts after scrubbing GitHub expressions