### PR TITLE
Add live PBS connection status badge

### DIFF
--- a/netbox_proxbox/services/service_status.py
+++ b/netbox_proxbox/services/service_status.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Any
 
 import requests
 
@@ -21,6 +22,7 @@ from netbox_proxbox.utils import (
 from netbox_proxbox.views.error_utils import (
     extract_backend_error_detail,
     extract_proxmox_backend_error_detail,
+    parse_requests_response_json,
 )
 
 logger = logging.getLogger(__name__)
@@ -609,5 +611,146 @@ class ServiceStatus:
             target_port=target_port,
             authentication=authentication,
             api_access=api_access,
+            detail=self.last_error_detail,
+        )
+
+    @staticmethod
+    def _pbs_status_item_value(item: object, key: str) -> object:
+        if isinstance(item, dict):
+            return item.get(key)
+        return getattr(item, key, None)
+
+    @classmethod
+    def _match_pbs_status_item(
+        cls,
+        *,
+        items: list[object],
+        endpoint_id: int | None,
+        host: str,
+        port: int,
+        name: str,
+    ) -> object | None:
+        for item in items:
+            if cls._pbs_status_item_value(item, "endpoint_id") == endpoint_id:
+                return item
+
+        for item in items:
+            item_host = str(cls._pbs_status_item_value(item, "host") or "")
+            item_port = cls._pbs_status_item_value(item, "port")
+            if item_host == host and item_port == port:
+                return item
+
+        for item in items:
+            if str(cls._pbs_status_item_value(item, "name") or "") == name:
+                return item
+
+        return None
+
+    def pbs_status(
+        self,
+        endpoint: object,
+        base_url: str,
+        auth_headers: dict[str, str] | None = None,
+        backend_verify_ssl: bool = True,
+    ) -> tuple[str, ServiceCheckResult]:
+        """Fetch proxbox-api PBS reachability and normalize it for a home badge."""
+        status = "error"
+        self._clear_error()
+
+        endpoint_id = getattr(endpoint, "pk", getattr(endpoint, "id", None))
+        name = str(getattr(endpoint, "name", "") or endpoint)
+        host = str(
+            getattr(endpoint, "host", "")
+            or getattr(endpoint, "domain", "")
+            or get_ip_address_host(getattr(endpoint, "ip_address", None))
+        )
+        port = int(getattr(endpoint, "port", 8007) or 8007)
+        request_headers = auth_headers or {}
+        url = f"{base_url.rstrip('/')}/pbs/status"
+
+        try:
+            response = requests.get(
+                url,
+                headers=request_headers,
+                verify=backend_verify_ssl,
+                timeout=self.request_timeout,
+            )
+            response.raise_for_status()
+            payload, json_err = parse_requests_response_json(
+                response, log_label="pbs/status"
+            )
+        except requests.exceptions.RequestException as exc:
+            detail, http_status = self._extract_error_detail(exc)
+            self._set_error(
+                f"Failed to check PBS status through ProxBox backend: {detail}",
+                http_status=http_status,
+            )
+            return status, ServiceCheckResult(
+                target_address=host,
+                target_port=port,
+                authentication="error",
+                api_access="error",
+                detail=self.last_error_detail,
+                http_status=self.last_error_http_status,
+            )
+
+        if json_err:
+            self._set_error(json_err)
+            return status, ServiceCheckResult(
+                target_address=host,
+                target_port=port,
+                authentication="success",
+                api_access="error",
+                detail=self.last_error_detail,
+            )
+
+        items: list[Any] = []
+        if isinstance(payload, dict) and isinstance(payload.get("items"), list):
+            items = payload["items"]
+        else:
+            self._set_error("ProxBox backend returned invalid PBS status payload.")
+            return status, ServiceCheckResult(
+                target_address=host,
+                target_port=port,
+                authentication="success",
+                api_access="error",
+                detail=self.last_error_detail,
+            )
+
+        item = self._match_pbs_status_item(
+            items=items,
+            endpoint_id=endpoint_id,
+            host=host,
+            port=port,
+            name=name,
+        )
+        if item is None:
+            self._set_error(f"PBS status for {name} was not returned by proxbox-api.")
+            return status, ServiceCheckResult(
+                target_address=host,
+                target_port=port,
+                authentication="success",
+                api_access="error",
+                detail=self.last_error_detail,
+            )
+
+        if bool(self._pbs_status_item_value(item, "reachable")):
+            self._clear_error()
+            return "success", ServiceCheckResult(
+                target_address=host,
+                target_port=port,
+                authentication="success",
+                api_access="success",
+            )
+
+        reason = self._pbs_status_item_value(item, "reason")
+        self._set_error(
+            str(reason) if reason else f"PBS endpoint {name} is not reachable."
+        )
+        return status, ServiceCheckResult(
+            target_address=host,
+            target_port=port,
+            authentication="success",
+            api_access="error",
             detail=self.last_error_detail,
         )

--- a/netbox_proxbox/templates/netbox_proxbox/home/companion_endpoint_card.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home/companion_endpoint_card.html
@@ -2,6 +2,9 @@
     <h2 class="card-header">{{ endpoint_group.plugin_name }}</h2>
 
     <div class="card-body">
+        {% if companion_endpoint.connection_status %}
+            <div class="p-1" id="{{ companion_endpoint.connection_status.message_id }}"></div>
+        {% endif %}
         <table class="table table-hover attr-table">
             <tr>
                 <th scope="row"><strong>{{ endpoint_group.model_label }}</strong></th>
@@ -13,6 +16,18 @@
                     {% endif %}
                 </td>
             </tr>
+            {% if companion_endpoint.connection_status %}
+                <tr>
+                    <th scope="row"><strong>{{ companion_endpoint.connection_status.label }}</strong></th>
+                    <td>
+                        <span
+                            id="{{ companion_endpoint.connection_status.badge_id }}"
+                            class="badge p-1"
+                            data-service-status-url="{{ companion_endpoint.connection_status.url }}"
+                        >Unknown</span>
+                    </td>
+                </tr>
+            {% endif %}
             {% for field in companion_endpoint.fields %}
                 <tr>
                     <th scope="row"><strong>{{ field.label }}</strong></th>

--- a/netbox_proxbox/views/home_context.py
+++ b/netbox_proxbox/views/home_context.py
@@ -209,6 +209,37 @@ def _field_display_value(obj: object, field_name: str) -> str:
     return str(value)
 
 
+def _companion_endpoint_status_service(obj: object) -> str:
+    model_meta = getattr(obj.__class__, "_meta", None)
+    app_label = getattr(model_meta, "app_label", "")
+    model_name = getattr(model_meta, "model_name", "")
+    class_name = obj.__class__.__name__
+    if (
+        app_label == "netbox_pbs"
+        and model_name == "pbsserver"
+        and class_name == "PBSServer"
+    ):
+        return "pbs"
+    return ""
+
+
+def _companion_endpoint_connection_status(obj: object) -> dict[str, object] | None:
+    service = _companion_endpoint_status_service(obj)
+    endpoint_id = getattr(obj, "pk", getattr(obj, "id", None))
+    if not service or endpoint_id is None:
+        return None
+    return {
+        "label": "Connection Status",
+        "service": service,
+        "badge_id": f"{service}-status-badge-{endpoint_id}",
+        "message_id": f"{service}-connection-error-{endpoint_id}",
+        "url": reverse(
+            "plugins:netbox_proxbox:keepalive_status",
+            args=[service, endpoint_id],
+        ),
+    }
+
+
 def _serialize_companion_endpoint(
     obj: object, request: HttpRequest, *, absolute_urls: bool
 ) -> dict[str, object]:
@@ -226,6 +257,7 @@ def _serialize_companion_endpoint(
         "name": str(obj),
         "url": _object_url(obj, request, absolute_urls=absolute_urls),
         "fields": fields,
+        "connection_status": _companion_endpoint_connection_status(obj),
     }
 
 

--- a/netbox_proxbox/views/keepalive_status.py
+++ b/netbox_proxbox/views/keepalive_status.py
@@ -1,4 +1,4 @@
-"""Check backend, NetBox, and Proxmox service reachability for the plugin UI."""
+"""Check backend, NetBox, Proxmox, and PBS service reachability for the UI."""
 
 from __future__ import annotations
 
@@ -14,6 +14,21 @@ from utilities.views import TokenConditionalLoginRequiredMixin
 
 logger = logging.getLogger(__name__)
 
+DEPENDENT_SERVICES = ("netbox", "proxmox", "pbs")
+KNOWN_SERVICES = ("fastapi", *DEPENDENT_SERVICES)
+
+
+def _visible_pbs_server(request: HttpRequest, pk: int) -> object | None:
+    try:
+        from netbox_pbs.models import PBSServer  # noqa: PLC0415
+    except ImportError:
+        return None
+
+    return get_object_or_404(
+        PBSServer.objects.restrict(request.user, "view"),
+        pk=pk,
+    )
+
 
 class GetServiceStatusView(TokenConditionalLoginRequiredMixin, View):
     """JSON keepalive; object visibility enforced via QuerySet.restrict per service."""
@@ -28,9 +43,10 @@ class GetServiceStatusView(TokenConditionalLoginRequiredMixin, View):
 def get_service_status_impl(
     request: HttpRequest, service: str, pk: int
 ) -> JsonResponse:
-    """Build JSON status for fastapi, netbox, or proxmox service checks."""
+    """Build JSON status for fastapi, netbox, proxmox, or pbs service checks."""
     status = "unknown"
     service_status = ServiceStatus()
+    pbs_server = None
 
     if service == "fastapi":
         get_object_or_404(
@@ -59,13 +75,13 @@ def get_service_status_impl(
             payload["detail"] = fastapi_response.detail
         return JsonResponse(payload)
 
-    if service not in ("netbox", "proxmox"):
+    if service not in DEPENDENT_SERVICES:
         return JsonResponse(
             {
                 "status": "error",
                 "detail": (
                     f"Unknown service {service!r}. "
-                    "Expected fastapi, netbox, or proxmox."
+                    f"Expected {', '.join(KNOWN_SERVICES[:-1])}, or {KNOWN_SERVICES[-1]}."
                 ),
             },
             status=400,
@@ -81,6 +97,16 @@ def get_service_status_impl(
             ProxmoxEndpoint.objects.restrict(request.user, "view"),
             pk=pk,
         )
+    elif service == "pbs":
+        pbs_server = _visible_pbs_server(request, pk)
+        if pbs_server is None:
+            return JsonResponse(
+                {
+                    "status": "error",
+                    "detail": "netbox-pbs is not installed.",
+                },
+                status=404,
+            )
 
     fastapi_object = (
         FastAPIEndpoint.objects.restrict(request.user, "view")
@@ -133,6 +159,13 @@ def get_service_status_impl(
     elif service == "proxmox":
         status, details = service_status.proxmox_status(
             pk=pk,
+            base_url=connected_url,
+            auth_headers=auth_headers,
+            backend_verify_ssl=service_status.connected_verify_ssl,
+        )
+    elif service == "pbs" and pbs_server is not None:
+        status, details = service_status.pbs_status(
+            endpoint=pbs_server,
             base_url=connected_url,
             auth_headers=auth_headers,
             backend_verify_ssl=service_status.connected_verify_ssl,

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -94,6 +94,9 @@ def test_home_template_renders_companion_plugin_endpoint_groups():
     assert "Additional Proxbox Plugin Endpoints" in contents
     assert "companion_endpoint_card.html" in contents
     assert "endpoint_group.plugin_name" in partial
+    assert "companion_endpoint.connection_status" in partial
+    assert "connection_status.label" in partial
+    assert "data-service-status-url" in partial
     assert "companion_endpoint.fields" in partial
     assert "endpoint_group.plugin_package" in partial
 

--- a/tests/test_home_context.py
+++ b/tests/test_home_context.py
@@ -181,6 +181,13 @@ def test_companion_endpoint_groups_render_required_plugin_endpoint_models(monkey
                     "id": 7,
                     "name": "PBS01",
                     "url": "https://netbox.example/plugins/pbs/servers/7/",
+                    "connection_status": {
+                        "label": "Connection Status",
+                        "service": "pbs",
+                        "badge_id": "pbs-status-badge-7",
+                        "message_id": "pbs-connection-error-7",
+                        "url": "/dummy/",
+                    },
                     "fields": [
                         {"name": "host", "label": "Host", "value": "10.0.30.134"},
                         {"name": "port", "label": "Port", "value": "8007"},

--- a/tests/test_keepalive_status.py
+++ b/tests/test_keepalive_status.py
@@ -3,15 +3,65 @@
 from __future__ import annotations
 
 import importlib
+import sys
+import types
 from types import SimpleNamespace
 
 import requests
 
-from tests.conftest import ResponseStub, load_plugin_module
+from tests.conftest import ResponseStub, _make_model_class, load_plugin_module
 
 
 def _service_status_module():
     return importlib.import_module("netbox_proxbox.services.service_status")
+
+
+def _install_pbs_server_stub(monkeypatch, pbs_server):
+    netbox_pbs_module = types.ModuleType("netbox_pbs")
+    models_module = types.ModuleType("netbox_pbs.models")
+    models_module.PBSServer = _make_model_class(
+        "PBSServer",
+        first=pbs_server,
+        objects_by_pk={getattr(pbs_server, "pk", 1): pbs_server},
+    )
+    netbox_pbs_module.models = models_module
+    monkeypatch.setitem(sys.modules, "netbox_pbs", netbox_pbs_module)
+    monkeypatch.setitem(sys.modules, "netbox_pbs.models", models_module)
+
+
+def _keepalive_request():
+    return SimpleNamespace(
+        user=SimpleNamespace(
+            is_authenticated=True,
+            has_perms=lambda *a, **k: True,
+            has_perm=lambda *a, **k: True,
+        ),
+        method="GET",
+    )
+
+
+def _pbs_server():
+    return SimpleNamespace(
+        id=7,
+        pk=7,
+        name="PBS01",
+        host="10.0.30.134",
+        port=8007,
+        verify_ssl=True,
+    )
+
+
+def _patch_backend_and_pbs_status(monkeypatch, ss, status_payload):
+    def fake_get(url, verify=True, timeout=None, params=None, headers=None):
+        if url == "https://proxbox.local:8800":
+            return ResponseStub({"ok": True})
+        if url.endswith("/version"):
+            return ResponseStub({"version": "0.0.15"})
+        if url.endswith("/pbs/status"):
+            return ResponseStub(status_payload)
+        raise AssertionError(url)
+
+    monkeypatch.setattr(ss.requests, "get", fake_get)
 
 
 def test_fastapi_status_falls_back_to_ip_after_ssl_error(
@@ -579,6 +629,118 @@ def test_proxmox_status_returns_sync_error_before_backend_version_call(
     assert calls == []
 
 
+def test_pbs_keepalive_uses_backend_status_host_fallback(
+    monkeypatch,
+    fastapi_endpoint,
+):
+    module = load_plugin_module(
+        "netbox_proxbox.views.keepalive_status",
+        monkeypatch=monkeypatch,
+        fastapi_endpoint=fastapi_endpoint,
+    )
+    pbs_server = _pbs_server()
+    _install_pbs_server_stub(monkeypatch, pbs_server)
+    ss = _service_status_module()
+    _patch_backend_and_pbs_status(
+        monkeypatch,
+        ss,
+        {
+            "items": [
+                {
+                    "endpoint_id": 99,
+                    "name": "Backend PBS",
+                    "host": "10.0.30.134",
+                    "port": 8007,
+                    "reachable": True,
+                    "version": "3.3.2",
+                }
+            ]
+        },
+    )
+
+    response = module.get_service_status_impl(_keepalive_request(), "pbs", 7)
+
+    assert response.status_code == 200
+    assert response.payload["status"] == "success"
+    assert response.payload["target_address"] == "10.0.30.134"
+    assert response.payload["target_port"] == 8007
+    assert response.payload["authentication"] == "success"
+    assert response.payload["api_access"] == "success"
+
+
+def test_pbs_keepalive_reports_unreachable_reason(
+    monkeypatch,
+    fastapi_endpoint,
+):
+    module = load_plugin_module(
+        "netbox_proxbox.views.keepalive_status",
+        monkeypatch=monkeypatch,
+        fastapi_endpoint=fastapi_endpoint,
+    )
+    pbs_server = _pbs_server()
+    _install_pbs_server_stub(monkeypatch, pbs_server)
+    ss = _service_status_module()
+    _patch_backend_and_pbs_status(
+        monkeypatch,
+        ss,
+        {
+            "items": [
+                {
+                    "endpoint_id": 7,
+                    "name": "PBS01",
+                    "host": "10.0.30.134",
+                    "port": 8007,
+                    "reachable": False,
+                    "reason": "Token rejected",
+                }
+            ]
+        },
+    )
+
+    response = module.get_service_status_impl(_keepalive_request(), "pbs", 7)
+
+    assert response.status_code == 200
+    assert response.payload["status"] == "error"
+    assert response.payload["authentication"] == "success"
+    assert response.payload["api_access"] == "error"
+    assert response.payload["detail"] == "Token rejected"
+
+
+def test_pbs_keepalive_reports_missing_backend_match(
+    monkeypatch,
+    fastapi_endpoint,
+):
+    module = load_plugin_module(
+        "netbox_proxbox.views.keepalive_status",
+        monkeypatch=monkeypatch,
+        fastapi_endpoint=fastapi_endpoint,
+    )
+    pbs_server = _pbs_server()
+    _install_pbs_server_stub(monkeypatch, pbs_server)
+    ss = _service_status_module()
+    _patch_backend_and_pbs_status(
+        monkeypatch,
+        ss,
+        {
+            "items": [
+                {
+                    "endpoint_id": 42,
+                    "name": "Other PBS",
+                    "host": "10.0.30.200",
+                    "port": 8007,
+                    "reachable": True,
+                }
+            ]
+        },
+    )
+
+    response = module.get_service_status_impl(_keepalive_request(), "pbs", 7)
+
+    assert response.status_code == 200
+    assert response.payload["status"] == "error"
+    assert "PBS status for PBS01 was not returned" in response.payload["detail"]
+
+
 def test_get_service_status_unknown_service_returns_400(monkeypatch, fastapi_endpoint):
     module = load_plugin_module(
         "netbox_proxbox.views.keepalive_status",
@@ -598,3 +760,4 @@ def test_get_service_status_unknown_service_returns_400(monkeypatch, fastapi_end
     assert resp.payload["status"] == "error"
     assert "not-a-service" in resp.payload["detail"]
     assert "fastapi" in resp.payload["detail"]
+    assert "pbs" in resp.payload["detail"]


### PR DESCRIPTION
Closes #520

## Summary
- Adds a live PBS keepalive path for netbox-pbs companion endpoint cards.
- Renders a Connection Status badge in the Additional Proxbox Plugin Endpoints card when the companion endpoint is a PBS server.
- Normalizes proxbox-api /pbs/status into the existing home badge JSON contract.

## Tests
- uv run --extra test python -m pytest tests/test_home_context.py tests/test_frontend_contracts.py tests/test_keepalive_status.py
- uv run --extra dev ruff check netbox_proxbox/views/home_context.py netbox_proxbox/views/keepalive_status.py netbox_proxbox/services/service_status.py tests/test_home_context.py tests/test_frontend_contracts.py tests/test_keepalive_status.py
- uv run --extra test python -m pytest