### PR TITLE
Add firewall intent apply support

### DIFF
--- a/netbox_proxbox/intent/apply_job.py
+++ b/netbox_proxbox/intent/apply_job.py
@@ -18,6 +18,14 @@ except ImportError:  # pragma: no cover - test stubs expose only JobRunner
 
 from netbox_proxbox.intent.cf_writes import stamp_intent_state
 from netbox_proxbox.intent.diff_classify import classify_diff
+from netbox_proxbox.intent.firewall_common import save_status_for_firewall_object
+from netbox_proxbox.intent.firewall_payload import (
+    build_firewall_apply_diff,
+    default_proxmox_endpoint_id,
+    firewall_changediffs,
+    firewall_result_key,
+    unsupported_firewall_diff_message,
+)
 from netbox_proxbox.intent.payload import (
     build_lxc_payload,
     build_update_delta,
@@ -101,6 +109,7 @@ def _call_apply_endpoint(
     payload: dict[str, Any],
     *,
     actor_username: str | None,
+    endpoint_id: int | None = None,
     timeout: float = PROXBOX_APPLY_JOB_TIMEOUT,
 ) -> dict[str, Any]:
     context = get_fastapi_request_context()
@@ -112,14 +121,18 @@ def _call_apply_endpoint(
         raise RuntimeError("FastAPIEndpoint has no resolvable http_url.")
 
     url = f"{http_url.rstrip('/')}/intent/apply"
+    if endpoint_id is not None:
+        url = f"{url}?endpoint_id={int(endpoint_id)}"
     headers = dict(context.headers or {})
     headers.setdefault("Content-Type", "application/json")
     headers["X-Proxbox-Actor"] = actor_username or ""
+    request_payload = dict(payload)
+    request_payload.setdefault("actor", actor_username)
 
     try:
         response = requests.post(
             url,
-            json=payload,
+            json=request_payload,
             headers=headers,
             timeout=timeout,
             verify=bool(context.verify_ssl),
@@ -431,6 +444,7 @@ class ProxmoxApplyJob(JobRunner):
                         body = _call_apply_endpoint(
                             apply_payload,
                             actor_username=actor_username,
+                            endpoint_id=default_proxmox_endpoint_id(),
                         )
                         item = _first_apply_result(body)
                         status = str(item.get("status") or "failed")
@@ -481,6 +495,7 @@ class ProxmoxApplyJob(JobRunner):
                     body = _call_apply_endpoint(
                         apply_payload,
                         actor_username=actor_username,
+                        endpoint_id=default_proxmox_endpoint_id(),
                     )
                     item = _first_apply_result(body)
                     status = str(item.get("status") or "failed")
@@ -508,6 +523,59 @@ class ProxmoxApplyJob(JobRunner):
                         vmid=vmid,
                         op=op,
                         kind=kind,
+                        status="failed",
+                        message=str(exc),
+                    )
+
+            for index, row in enumerate(firewall_changediffs(branch), start=1):
+                key = firewall_result_key(row, index)
+                op = "update"
+                try:
+                    apply_diff = build_firewall_apply_diff(row)
+                    if apply_diff is None:
+                        results[key] = _result_entry(
+                            vmid=0,
+                            op=getattr(row, "action", None) or op,
+                            kind="firewall",
+                            status="skipped",
+                            message=unsupported_firewall_diff_message(row),
+                        )
+                        continue
+
+                    op = str(apply_diff.diff.get("op") or op)
+                    apply_payload = {
+                        "diffs": [apply_diff.diff],
+                        "run_uuid": str(normalized_uuid),
+                    }
+                    body = _call_apply_endpoint(
+                        apply_payload,
+                        actor_username=actor_username,
+                        endpoint_id=apply_diff.endpoint_id,
+                    )
+                    item = _first_apply_result(body)
+                    status = str(item.get("status") or "failed")
+                    proxmox_upid = item.get("proxmox_upid") or item.get("upid")
+                    results[key] = _result_entry(
+                        vmid=item.get("vmid", 0),
+                        op=op,
+                        kind="firewall",
+                        status=status,
+                        message=str(item.get("message") or ""),
+                        proxmox_upid=proxmox_upid,
+                    )
+                    if _status_is_success(status) and apply_diff.obj is not None:
+                        save_status_for_firewall_object(apply_diff.obj, "active")
+                except Exception as exc:  # noqa: BLE001
+                    logger.exception(
+                        "Proxmox apply %s failed for firewall ChangeDiff %s: %s",
+                        run_uuid,
+                        key,
+                        exc,
+                    )
+                    results[key] = _result_entry(
+                        vmid=0,
+                        op=op,
+                        kind="firewall",
                         status="failed",
                         message=str(exc),
                     )

--- a/netbox_proxbox/intent/firewall_payload.py
+++ b/netbox_proxbox/intent/firewall_payload.py
@@ -1,0 +1,482 @@
+"""Build proxbox-api firewall intent payloads from Branching ChangeDiff rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from netbox_proxbox.choices import FirewallScopeChoices, FirewallZoneChoices
+from netbox_proxbox.intent.firewall_common import (
+    firewall_object_state,
+    resolve_firewall_endpoint,
+)
+
+FIREWALL_MODEL_NAMES = (
+    "proxmoxfirewallsecuritygroup",
+    "proxmoxfirewallrule",
+    "proxmoxfirewallipset",
+    "proxmoxfirewallipsetentry",
+    "proxmoxfirewallalias",
+    "proxmoxfirewalloptions",
+)
+
+_SUPPORTED_OPS = {"create", "update", "delete"}
+
+
+@dataclass(frozen=True)
+class FirewallApplyDiff:
+    """One firewall apply diff plus the Proxmox endpoint gate target."""
+
+    diff: dict[str, Any]
+    endpoint_id: int | None
+    obj: object | None = None
+
+
+def firewall_changediffs(branch: Any) -> list[Any]:
+    """Return ChangeDiff rows for persisted firewall models on a branch."""
+    changediff_qs = getattr(branch, "changediff_set", None)
+    if changediff_qs is None:
+        return []
+
+    try:
+        return list(changediff_qs.filter(object_type__model__in=FIREWALL_MODEL_NAMES))
+    except Exception:  # noqa: BLE001 - test stubs may not support __in lookups
+        rows: list[Any] = []
+        for model_name in FIREWALL_MODEL_NAMES:
+            try:
+                rows.extend(list(changediff_qs.filter(object_type__model=model_name)))
+            except Exception:  # noqa: BLE001
+                continue
+        return rows
+
+
+def build_firewall_plan_diffs(branch: Any) -> list[dict[str, Any]]:
+    """Build read-only /intent/plan diffs for firewall ChangeDiff rows."""
+    diffs: list[dict[str, Any]] = []
+    for row in firewall_changediffs(branch):
+        apply_diff = build_firewall_apply_diff(row)
+        if apply_diff is None:
+            continue
+        plan_diff = {
+            "op": apply_diff.diff["op"],
+            "kind": "firewall",
+            "netbox_id": apply_diff.diff.get("netbox_id"),
+            "name": _row_name(row),
+            "type": apply_diff.diff["payload"].get("action"),
+        }
+        if apply_diff.endpoint_id is not None:
+            plan_diff["endpoint_id"] = apply_diff.endpoint_id
+        diffs.append(_drop_none(plan_diff))
+    return diffs
+
+
+def build_firewall_apply_diff(row: Any) -> FirewallApplyDiff | None:
+    """Build one proxbox-api ApplyDiff for a firewall ChangeDiff row."""
+    op = _row_op(row)
+    if op not in _SUPPORTED_OPS:
+        return None
+
+    model_name = _row_model_name(row)
+    obj = _row_object(row)
+    data = _row_data(row, op)
+    action = _action_for(model_name, op)
+    if action is None:
+        return None
+
+    payload = _firewall_payload(model_name, op, action, obj, data)
+    if payload is None:
+        return None
+
+    diff = {
+        "op": op,
+        "kind": "firewall",
+        "netbox_id": _row_object_id(row, obj),
+        "payload": payload,
+    }
+    return FirewallApplyDiff(
+        diff=_drop_none(diff),
+        endpoint_id=_endpoint_id_for(obj, data),
+        obj=obj,
+    )
+
+
+def firewall_result_key(row: Any, fallback: int) -> str:
+    """Stable result key for a firewall ChangeDiff row."""
+    model_name = _row_model_name(row) or "firewall"
+    identifier = _row_object_id(row, _row_object(row)) or _row_name(row) or fallback
+    return f"firewall:{model_name}:{identifier}"
+
+
+def unsupported_firewall_diff_message(row: Any) -> str:
+    """Return a user-facing message for unsupported firewall intent rows."""
+    return (
+        f"Firewall intent for {_row_model_name(row) or 'object'} "
+        f"{_row_op(row)!r} is not supported by proxbox-api apply."
+    )
+
+
+def first_endpoint_id_from_diffs(diffs: list[dict[str, Any]]) -> int | None:
+    """Return the first endpoint_id embedded in classified diffs."""
+    for diff in diffs:
+        endpoint_id = _int_or_none(diff.get("endpoint_id"))
+        if endpoint_id is not None:
+            return endpoint_id
+    return None
+
+
+def default_proxmox_endpoint_id() -> int | None:
+    """Best-effort default ProxmoxEndpoint ID for legacy intent paths."""
+    try:
+        from netbox_proxbox.models import ProxmoxEndpoint  # noqa: PLC0415
+    except Exception:  # pragma: no cover - defensive import guard
+        return None
+
+    try:
+        endpoint = ProxmoxEndpoint.objects.filter(allow_writes=True).first()
+        if endpoint is None:
+            endpoint = ProxmoxEndpoint.objects.first()
+    except Exception:  # pragma: no cover - test stubs may be partial
+        return None
+    return _object_id(endpoint)
+
+
+def _firewall_payload(
+    model_name: str,
+    op: str,
+    action: str,
+    obj: object | None,
+    data: dict[str, Any],
+) -> dict[str, Any] | None:
+    body = {} if op == "delete" else _body_for(model_name, op, obj, data)
+    payload: dict[str, Any] = {
+        "action": action,
+        "zone": _zone_for(model_name, obj, data),
+        "node": _node_for(model_name, obj, data),
+        "vmid": _vmid_for(model_name, obj, data),
+        "vm_type": _vm_type_for(model_name, obj, data),
+        "vnet": _vnet_for(model_name, obj, data),
+        "group": _group_for(model_name, obj, data),
+        "pos": _int_or_none(_field(obj, data, "pos")),
+        "name": _name_for(model_name, obj, data),
+        "cidr": _field(obj, data, "cidr"),
+        "body": body,
+    }
+    return _drop_none(payload)
+
+
+def _action_for(model_name: str, op: str) -> str | None:
+    if model_name == "proxmoxfirewallrule":
+        return f"firewall.rule.{op}"
+    if model_name == "proxmoxfirewallsecuritygroup":
+        if op in {"create", "delete"}:
+            return f"firewall.group.{op}"
+        return None
+    if model_name == "proxmoxfirewallipset":
+        if op in {"create", "delete"}:
+            return f"firewall.ipset.{op}"
+        return None
+    if model_name == "proxmoxfirewallipsetentry":
+        return f"firewall.ipset.entry.{op}"
+    if model_name == "proxmoxfirewallalias":
+        return f"firewall.alias.{op}"
+    if model_name == "proxmoxfirewalloptions" and op in {"create", "update"}:
+        return "firewall.options.update"
+    return None
+
+
+def _body_for(
+    model_name: str,
+    op: str,
+    obj: object | None,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    if obj is not None:
+        if model_name == "proxmoxfirewallsecuritygroup":
+            return _drop_empty(
+                {"group": getattr(obj, "name", None), "comment": getattr(obj, "comment", None)}
+            )
+        if model_name == "proxmoxfirewallalias" and op == "update":
+            body = firewall_object_state(obj)
+            body.pop("name", None)
+            return body
+        return firewall_object_state(obj)
+
+    if model_name == "proxmoxfirewallrule":
+        return _drop_empty(
+            {
+                "pos": data.get("pos"),
+                "type": data.get("rule_type") or data.get("type"),
+                "action": data.get("action"),
+                "enable": data.get("enable"),
+                "macro": data.get("macro"),
+                "iface": data.get("iface"),
+                "source": data.get("source"),
+                "dest": data.get("dest"),
+                "proto": data.get("proto"),
+                "dport": data.get("dport"),
+                "sport": data.get("sport"),
+                "log": data.get("log"),
+                "icmp-type": data.get("icmp_type") or data.get("icmp-type"),
+                "comment": data.get("comment"),
+                "digest": data.get("digest"),
+            }
+        )
+    if model_name == "proxmoxfirewallsecuritygroup":
+        return _drop_empty({"group": data.get("name"), "comment": data.get("comment")})
+    if model_name == "proxmoxfirewallipset":
+        return _drop_empty({"name": data.get("name"), "comment": data.get("comment")})
+    if model_name == "proxmoxfirewallipsetentry":
+        return _drop_empty(
+            {
+                "cidr": data.get("cidr"),
+                "comment": data.get("comment"),
+                "nomatch": data.get("nomatch"),
+            }
+        )
+    if model_name == "proxmoxfirewallalias":
+        body = {"name": data.get("name"), "cidr": data.get("cidr"), "comment": data.get("comment")}
+        if op == "update":
+            body.pop("name", None)
+        return _drop_empty(body)
+    if model_name == "proxmoxfirewalloptions":
+        return _drop_empty(
+            {
+                "enable": data.get("enable"),
+                "policy_in": data.get("policy_in"),
+                "policy_out": data.get("policy_out"),
+                "options": data.get("options") or {},
+            }
+        )
+    return {}
+
+
+def _zone_for(model_name: str, obj: object | None, data: dict[str, Any]) -> str | None:
+    if model_name == "proxmoxfirewallsecuritygroup":
+        return FirewallZoneChoices.DATACENTER
+    if model_name in {"proxmoxfirewallrule", "proxmoxfirewalloptions"}:
+        return _field(obj, data, "zone")
+    if model_name in {"proxmoxfirewallipset", "proxmoxfirewallalias"}:
+        return _zone_from_scope(_field(obj, data, "scope"))
+    if model_name == "proxmoxfirewallipsetentry":
+        ipset = _related(obj, data, "ipset")
+        return _zone_from_scope(_field(ipset, data, "scope"))
+    return None
+
+
+def _zone_from_scope(scope: object) -> str | None:
+    if scope == FirewallScopeChoices.DATACENTER:
+        return FirewallZoneChoices.DATACENTER
+    if scope == FirewallScopeChoices.VM_QEMU:
+        return FirewallZoneChoices.VM_QEMU
+    if scope == FirewallScopeChoices.VM_LXC:
+        return FirewallZoneChoices.VM_LXC
+    return str(scope) if scope not in (None, "") else None
+
+
+def _node_for(model_name: str, obj: object | None, data: dict[str, Any]) -> str | None:
+    zone = _zone_for(model_name, obj, data)
+    if zone == FirewallZoneChoices.NODE:
+        return _object_name(_related(obj, data, "proxmox_node")) or _str_or_none(
+            data.get("node")
+        )
+    if zone in {FirewallZoneChoices.VM_QEMU, FirewallZoneChoices.VM_LXC}:
+        return _vm_node(_vm_for(model_name, obj, data), data)
+    return None
+
+
+def _vmid_for(model_name: str, obj: object | None, data: dict[str, Any]) -> int | None:
+    zone = _zone_for(model_name, obj, data)
+    if zone in {FirewallZoneChoices.VM_QEMU, FirewallZoneChoices.VM_LXC}:
+        return _vmid(_vm_for(model_name, obj, data), data)
+    return None
+
+
+def _vm_type_for(model_name: str, obj: object | None, data: dict[str, Any]) -> str | None:
+    zone = _zone_for(model_name, obj, data)
+    if zone == FirewallZoneChoices.VM_QEMU:
+        return "qemu"
+    if zone == FirewallZoneChoices.VM_LXC:
+        return "lxc"
+    return None
+
+
+def _vnet_for(model_name: str, obj: object | None, data: dict[str, Any]) -> str | None:
+    if _zone_for(model_name, obj, data) == FirewallZoneChoices.VNET:
+        return _str_or_none(_field(obj, data, "iface"))
+    return None
+
+
+def _group_for(model_name: str, obj: object | None, data: dict[str, Any]) -> str | None:
+    if model_name == "proxmoxfirewallsecuritygroup":
+        return _str_or_none(_field(obj, data, "name"))
+    if _zone_for(model_name, obj, data) == FirewallZoneChoices.SECURITY_GROUP:
+        return _object_name(_related(obj, data, "security_group")) or _str_or_none(
+            data.get("group")
+        )
+    return None
+
+
+def _name_for(model_name: str, obj: object | None, data: dict[str, Any]) -> str | None:
+    if model_name == "proxmoxfirewallipsetentry":
+        ipset = _related(obj, data, "ipset")
+        return _object_name(ipset) or _str_or_none(data.get("ipset_name"))
+    return _str_or_none(_field(obj, data, "name"))
+
+
+def _vm_for(model_name: str, obj: object | None, data: dict[str, Any]) -> object | None:
+    if model_name == "proxmoxfirewallipsetentry":
+        ipset = _related(obj, data, "ipset")
+        vm = _related(ipset, data, "virtual_machine")
+        return vm if vm is not None else _related(obj, data, "virtual_machine")
+    return _related(obj, data, "virtual_machine")
+
+
+def _endpoint_id_for(obj: object | None, data: dict[str, Any]) -> int | None:
+    if obj is not None:
+        try:
+            endpoint = resolve_firewall_endpoint(obj)
+        except Exception:  # noqa: BLE001
+            endpoint = None
+        endpoint_id = _object_id(endpoint)
+        if endpoint_id is not None:
+            return endpoint_id
+
+    for key in ("endpoint_id", "endpoint"):
+        endpoint_id = _object_id(data.get(key))
+        if endpoint_id is not None:
+            return endpoint_id
+    return None
+
+
+def _row_op(row: Any) -> str:
+    action = str(getattr(row, "action", "") or "").lower()
+    if action in _SUPPORTED_OPS:
+        return action
+    prechange_data = getattr(row, "prechange_data", None)
+    postchange_data = getattr(row, "postchange_data", None)
+    if prechange_data is None and isinstance(postchange_data, dict):
+        return "create"
+    if isinstance(prechange_data, dict) and postchange_data is None:
+        return "delete"
+    return "update"
+
+
+def _row_data(row: Any, op: str) -> dict[str, Any]:
+    preferred = "prechange_data" if op == "delete" else "postchange_data"
+    fallback = "postchange_data" if preferred == "prechange_data" else "prechange_data"
+    data = getattr(row, preferred, None)
+    if isinstance(data, dict):
+        return data
+    data = getattr(row, fallback, None)
+    return data if isinstance(data, dict) else {}
+
+
+def _row_model_name(row: Any) -> str:
+    object_type = getattr(row, "object_type", None)
+    model = getattr(object_type, "model", None)
+    if model:
+        return str(model).lower()
+    obj = _row_object(row)
+    meta = getattr(obj, "_meta", None)
+    model_name = getattr(meta, "model_name", None)
+    if model_name:
+        return str(model_name).lower()
+    return str(getattr(row, "model", "") or "").lower()
+
+
+def _row_object(row: Any) -> object | None:
+    return getattr(row, "object", None)
+
+
+def _row_object_id(row: Any, obj: object | None) -> int | None:
+    return _int_or_none(getattr(row, "object_id", None)) or _object_id(obj)
+
+
+def _row_name(row: Any) -> str | None:
+    return _str_or_none(getattr(row, "object_repr", None))
+
+
+def _field(obj: object | None, data: dict[str, Any], *names: str) -> Any:
+    for name in names:
+        if isinstance(obj, dict) and obj.get(name) not in (None, ""):
+            return obj[name]
+        if obj is not None and hasattr(obj, name):
+            value = getattr(obj, name)
+            if value not in (None, ""):
+                return value
+        if name in data and data[name] not in (None, ""):
+            return data[name]
+    return None
+
+
+def _related(obj: object | None, data: dict[str, Any], name: str) -> object | None:
+    value = _field(obj, data, name)
+    if value is not None:
+        return value
+    return data.get(f"{name}_id")
+
+
+def _object_name(value: object | None) -> str | None:
+    if isinstance(value, dict):
+        return _str_or_none(value.get("name") or value.get("display"))
+    return _str_or_none(getattr(value, "name", None) or value)
+
+
+def _object_id(value: object | None) -> int | None:
+    if isinstance(value, dict):
+        return _int_or_none(value.get("id") or value.get("pk"))
+    return _int_or_none(getattr(value, "pk", None) or getattr(value, "id", None) or value)
+
+
+def _vmid(vm: object | None, data: dict[str, Any]) -> int | None:
+    cf = _custom_fields(vm)
+    return _int_or_none(
+        cf.get("proxmox_vm_id")
+        or cf.get("cf_proxmox_vm_id")
+        or data.get("vmid")
+        or data.get("proxmox_vm_id")
+    )
+
+
+def _vm_node(vm: object | None, data: dict[str, Any]) -> str | None:
+    device = getattr(vm, "device", None)
+    if device is not None and getattr(device, "name", None):
+        return str(device.name)
+    cf = _custom_fields(vm)
+    return _str_or_none(
+        cf.get("proxmox_node")
+        or cf.get("cf_proxmox_node")
+        or data.get("node")
+        or data.get("proxmox_node")
+    )
+
+
+def _custom_fields(value: object | None) -> dict[str, Any]:
+    if isinstance(value, dict):
+        cf = value.get("custom_field_data") or value.get("custom_fields")
+    else:
+        cf = getattr(value, "custom_field_data", None)
+    return cf if isinstance(cf, dict) else {}
+
+
+def _str_or_none(value: object) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _int_or_none(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _drop_none(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _drop_empty(payload: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value not in (None, "")}

--- a/netbox_proxbox/intent/firewall_payload.py
+++ b/netbox_proxbox/intent/firewall_payload.py
@@ -6,10 +6,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from netbox_proxbox.choices import FirewallScopeChoices, FirewallZoneChoices
-from netbox_proxbox.intent.firewall_common import (
-    firewall_object_state,
-    resolve_firewall_endpoint,
-)
 
 FIREWALL_MODEL_NAMES = (
     "proxmoxfirewallsecuritygroup",
@@ -199,10 +195,10 @@ def _body_for(
                 }
             )
         if model_name == "proxmoxfirewallalias" and op == "update":
-            body = firewall_object_state(obj)
+            body = _firewall_object_state(obj)
             body.pop("name", None)
             return body
-        return firewall_object_state(obj)
+        return _firewall_object_state(obj)
 
     if model_name == "proxmoxfirewallrule":
         return _drop_empty(
@@ -340,10 +336,26 @@ def _vm_for(model_name: str, obj: object | None, data: dict[str, Any]) -> object
     return _related(obj, data, "virtual_machine")
 
 
+def _firewall_object_state(obj: object) -> dict[str, Any]:
+    from netbox_proxbox.intent.firewall_common import (  # noqa: PLC0415
+        firewall_object_state,
+    )
+
+    return firewall_object_state(obj)
+
+
+def _resolve_firewall_endpoint(obj: object) -> object | None:
+    from netbox_proxbox.intent.firewall_common import (  # noqa: PLC0415
+        resolve_firewall_endpoint,
+    )
+
+    return resolve_firewall_endpoint(obj)
+
+
 def _endpoint_id_for(obj: object | None, data: dict[str, Any]) -> int | None:
     if obj is not None:
         try:
-            endpoint = resolve_firewall_endpoint(obj)
+            endpoint = _resolve_firewall_endpoint(obj)
         except Exception:  # noqa: BLE001
             endpoint = None
         endpoint_id = _object_id(endpoint)

--- a/netbox_proxbox/intent/firewall_payload.py
+++ b/netbox_proxbox/intent/firewall_payload.py
@@ -193,7 +193,10 @@ def _body_for(
     if obj is not None:
         if model_name == "proxmoxfirewallsecuritygroup":
             return _drop_empty(
-                {"group": getattr(obj, "name", None), "comment": getattr(obj, "comment", None)}
+                {
+                    "group": getattr(obj, "name", None),
+                    "comment": getattr(obj, "comment", None),
+                }
             )
         if model_name == "proxmoxfirewallalias" and op == "update":
             body = firewall_object_state(obj)
@@ -234,7 +237,11 @@ def _body_for(
             }
         )
     if model_name == "proxmoxfirewallalias":
-        body = {"name": data.get("name"), "cidr": data.get("cidr"), "comment": data.get("comment")}
+        body = {
+            "name": data.get("name"),
+            "cidr": data.get("cidr"),
+            "comment": data.get("comment"),
+        }
         if op == "update":
             body.pop("name", None)
         return _drop_empty(body)
@@ -291,7 +298,9 @@ def _vmid_for(model_name: str, obj: object | None, data: dict[str, Any]) -> int 
     return None
 
 
-def _vm_type_for(model_name: str, obj: object | None, data: dict[str, Any]) -> str | None:
+def _vm_type_for(
+    model_name: str, obj: object | None, data: dict[str, Any]
+) -> str | None:
     zone = _zone_for(model_name, obj, data)
     if zone == FirewallZoneChoices.VM_QEMU:
         return "qemu"
@@ -425,7 +434,9 @@ def _object_name(value: object | None) -> str | None:
 def _object_id(value: object | None) -> int | None:
     if isinstance(value, dict):
         return _int_or_none(value.get("id") or value.get("pk"))
-    return _int_or_none(getattr(value, "pk", None) or getattr(value, "id", None) or value)
+    return _int_or_none(
+        getattr(value, "pk", None) or getattr(value, "id", None) or value
+    )
 
 
 def _vmid(vm: object | None, data: dict[str, Any]) -> int | None:

--- a/netbox_proxbox/intent/merge_validator.py
+++ b/netbox_proxbox/intent/merge_validator.py
@@ -35,6 +35,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from netbox_proxbox.intent.firewall_payload import (
+    build_firewall_plan_diffs,
+    default_proxmox_endpoint_id,
+    first_endpoint_id_from_diffs,
+)
 from netbox_proxbox.intent.plan_client import (
     PlanClientError,
     PlanClientResult,
@@ -202,8 +207,8 @@ def _plaintext_password_warnings(branch: Any) -> list[dict[str, str]]:
     return warnings
 
 
-def _has_delete(diffs: list[dict[str, Any]]) -> bool:
-    return any(d.get("op") == "delete" for d in diffs)
+def _has_vm_delete(diffs: list[dict[str, Any]]) -> bool:
+    return any(d.get("op") == "delete" and d.get("kind") != "firewall" for d in diffs)
 
 
 def _format_remote_failure(result: PlanClientResult) -> str:
@@ -253,17 +258,18 @@ def validate_proxmox_intent(
         return _indicator(True)
 
     diffs = _classify_vm_diffs(branch)
+    diffs.extend(build_firewall_plan_diffs(branch))
     if not diffs:
         return _indicator(
             True,
-            "No VM diffs on branch; Proxmox merge will be a no-op.",
+            "No VM or firewall diffs on branch; Proxmox merge will be a no-op.",
         )
 
     # Local Safety Model invariant 3: DELETE diffs require the
     # per-branch ``apply_destroy_confirmed`` toggle BEFORE any
     # backend probe. Surface this at plan time so the operator can
     # fix it without round-tripping proxbox-api.
-    if _has_delete(diffs) and not _branch_destroy_confirmed(branch):
+    if _has_vm_delete(diffs) and not _branch_destroy_confirmed(branch):
         return _indicator(
             False,
             (
@@ -274,7 +280,15 @@ def validate_proxmox_intent(
         )
 
     local_warnings = _plaintext_password_warnings(branch)
+    endpoint_id = first_endpoint_id_from_diffs(diffs) or default_proxmox_endpoint_id()
+    if endpoint_id is None:
+        return _indicator(
+            False,
+            "No ProxmoxEndpoint is configured; cannot validate Proxmox intent.",
+        )
+
     payload: dict[str, Any] = {
+        "endpoint_id": endpoint_id,
         "branch_id": getattr(branch, "pk", None),
         "actor": getattr(user, "username", None) if user else None,
         "diffs": diffs,

--- a/tests/test_firewall_write_helpers.py
+++ b/tests/test_firewall_write_helpers.py
@@ -484,3 +484,12 @@ def test_firewall_alias_update_changediff_does_not_rename_alias(fw_common, fw_pa
     assert payload["action"] == "firewall.alias.update"
     assert payload["name"] == "web"
     assert payload["body"] == {"cidr": "10.0.0.10", "comment": "frontend"}
+
+
+def test_firewall_payload_does_not_import_firewall_common_at_module_load():
+    source = (
+        REPO_ROOT / "netbox_proxbox" / "intent" / "firewall_payload.py"
+    ).read_text(encoding="utf-8")
+    header = source.split("FIREWALL_MODEL_NAMES", 1)[0]
+
+    assert "netbox_proxbox.intent.firewall_common" not in header

--- a/tests/test_firewall_write_helpers.py
+++ b/tests/test_firewall_write_helpers.py
@@ -155,6 +155,21 @@ def fw_common(monkeypatch):
     return module
 
 
+@pytest.fixture
+def fw_payload(monkeypatch, fw_common):
+    module_name = "netbox_proxbox.intent.firewall_payload"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        REPO_ROOT / "netbox_proxbox" / "intent" / "firewall_payload.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def _endpoint(fw_common, *, allow_writes=True):
     endpoint = fw_common.ProxmoxEndpoint()
     endpoint.pk = 1
@@ -354,3 +369,118 @@ def test_firewall_options_status_migration_is_idempotent():
     assert "add_field_idempotent(" in source
     assert 'model_name="proxmoxfirewalloptions"' in source
     assert 'field_name="status"' in source
+
+
+def test_firewall_rule_changediff_builds_apply_payload(fw_common, fw_payload):
+    endpoint = _endpoint(fw_common)
+    rule = _rule(fw_common, endpoint)
+    row = SimpleNamespace(
+        action="create",
+        object=rule,
+        object_id=77,
+        object_repr="allow-ssh",
+        object_type=SimpleNamespace(model="proxmoxfirewallrule"),
+        prechange_data=None,
+        postchange_data={"zone": fw_common.FirewallZoneChoices.DATACENTER},
+    )
+
+    apply_diff = fw_payload.build_firewall_apply_diff(row)
+
+    assert apply_diff is not None
+    assert apply_diff.endpoint_id == 1
+    assert apply_diff.diff["op"] == "create"
+    assert apply_diff.diff["kind"] == "firewall"
+    payload = apply_diff.diff["payload"]
+    assert payload["action"] == "firewall.rule.create"
+    assert payload["zone"] == fw_common.FirewallZoneChoices.DATACENTER
+    assert payload["pos"] == 7
+    assert payload["body"]["type"] == "in"
+
+
+def test_firewall_ipset_entry_changediff_targets_parent_ipset(fw_common, fw_payload):
+    endpoint = _endpoint(fw_common)
+    ipset = fw_common.ProxmoxFirewallIPSet()
+    ipset.endpoint = endpoint
+    ipset.scope = fw_common.FirewallScopeChoices.DATACENTER
+    ipset.name = "mgmt"
+    ipset.status = "stale"
+
+    entry = fw_common.ProxmoxFirewallIPSetEntry()
+    entry.ipset = ipset
+    entry.cidr = "10.0.0.0/8"
+    entry.comment = "management"
+    entry.nomatch = False
+    entry.raw_config = {"cidr": entry.cidr}
+
+    row = SimpleNamespace(
+        action="update",
+        object=entry,
+        object_id=88,
+        object_repr="mgmt:10.0.0.0/8",
+        object_type=SimpleNamespace(model="proxmoxfirewallipsetentry"),
+        prechange_data={"cidr": entry.cidr},
+        postchange_data={"cidr": entry.cidr, "comment": entry.comment},
+    )
+
+    apply_diff = fw_payload.build_firewall_apply_diff(row)
+
+    assert apply_diff is not None
+    payload = apply_diff.diff["payload"]
+    assert payload["action"] == "firewall.ipset.entry.update"
+    assert payload["zone"] == fw_common.FirewallZoneChoices.DATACENTER
+    assert payload["name"] == "mgmt"
+    assert payload["cidr"] == "10.0.0.0/8"
+
+
+def test_firewall_security_group_changediff_uses_group_payload(fw_common, fw_payload):
+    endpoint = _endpoint(fw_common)
+    group = fw_common.ProxmoxFirewallSecurityGroup()
+    group.endpoint = endpoint
+    group.name = "web"
+    group.comment = "Web ingress"
+
+    row = SimpleNamespace(
+        action="create",
+        object=group,
+        object_id=89,
+        object_repr="web",
+        object_type=SimpleNamespace(model="proxmoxfirewallsecuritygroup"),
+        prechange_data=None,
+        postchange_data={"name": group.name},
+    )
+
+    apply_diff = fw_payload.build_firewall_apply_diff(row)
+
+    assert apply_diff is not None
+    payload = apply_diff.diff["payload"]
+    assert payload["action"] == "firewall.group.create"
+    assert payload["group"] == "web"
+    assert payload["body"] == {"group": "web", "comment": "Web ingress"}
+
+
+def test_firewall_alias_update_changediff_does_not_rename_alias(fw_common, fw_payload):
+    endpoint = _endpoint(fw_common)
+    alias = fw_common.ProxmoxFirewallAlias()
+    alias.endpoint = endpoint
+    alias.scope = fw_common.FirewallScopeChoices.DATACENTER
+    alias.name = "web"
+    alias.cidr = "10.0.0.10"
+    alias.comment = "frontend"
+
+    row = SimpleNamespace(
+        action="update",
+        object=alias,
+        object_id=90,
+        object_repr="web",
+        object_type=SimpleNamespace(model="proxmoxfirewallalias"),
+        prechange_data={"name": alias.name},
+        postchange_data={"name": alias.name, "cidr": alias.cidr},
+    )
+
+    apply_diff = fw_payload.build_firewall_apply_diff(row)
+
+    assert apply_diff is not None
+    payload = apply_diff.diff["payload"]
+    assert payload["action"] == "firewall.alias.update"
+    assert payload["name"] == "web"
+    assert payload["body"] == {"cidr": "10.0.0.10", "comment": "frontend"}


### PR DESCRIPTION
Closes #485

Depends on emersonfelipesp/proxbox-api#202.

## Summary
- Add firewall ChangeDiff payload construction for branch-driven intent apply.
- Include firewall diffs in merge planning without sending firewall deletes through VM safe-delete checks.
- Dispatch firewall diffs to /intent/apply with endpoint_id and actor context.
- Add focused plugin tests for rule, IP set entry, security-group, and alias payloads.

## Verification
- python3 -m compileall netbox_proxbox tests
- rtk ruff check .
- uv run --extra cli --extra test ty check proxbox_cli
- uv run --extra test python -m pytest tests/test_firewall_write_helpers.py -q
- uv run --extra test python -m pytest tests/ -q