### PR TITLE
feat: add dashboard widgets for NetBox home page

### DIFF
--- a/netbox_proxbox/__init__.py
+++ b/netbox_proxbox/__init__.py
@@ -167,6 +167,7 @@ class ProxboxConfig(PluginConfig):
         from .views import job_cancel, job_run  # noqa: F401 — core Job: proxbox-run / proxbox-cancel
         from . import signals  # noqa: F401 — ensures token auto-generation and backend registration
         from . import signal_receivers  # noqa: F401 — owns the post_merge receiver chain
+        from . import widgets  # noqa: F401 — registers dashboard widgets for the NetBox home page
 
         # Push any existing NetBox endpoint data to the proxbox-api backend shortly
         # after startup.  This ensures the backend always has the endpoint record even

--- a/netbox_proxbox/templates/netbox_proxbox/dashboard_widgets/endpoint_status.html
+++ b/netbox_proxbox/templates/netbox_proxbox/dashboard_widgets/endpoint_status.html
@@ -1,0 +1,56 @@
+{% load i18n %}
+
+<div class="px-2 py-1">
+  <h6 class="text-muted mb-2">{% trans "Proxmox" %}</h6>
+  {% if proxmox_endpoints %}
+    <div class="list-group list-group-flush mb-3">
+      {% for ep in proxmox_endpoints %}
+        <div class="list-group-item px-1 py-2">
+          <div class="d-flex justify-content-between align-items-center">
+            <div>
+              <i class="mdi mdi-server text-primary"></i>
+              <strong>{{ ep.name }}</strong>
+            </div>
+            <small class="text-muted">{{ ep.ip }}</small>
+          </div>
+          {% if ep.mode and ep.mode != "—" %}
+            <small class="text-muted">{% trans "Mode" %}: {{ ep.mode }}</small>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p class="text-muted"><em>{% trans "No Proxmox endpoints configured." %}</em></p>
+  {% endif %}
+
+  <div class="row">
+    <div class="col-6">
+      <h6 class="text-muted mb-1">{% trans "NetBox" %}</h6>
+      {% if netbox_endpoint %}
+        <div class="d-flex align-items-center gap-1">
+          <i class="mdi mdi-circle text-success" style="font-size: 0.6rem;"></i>
+          <small>{% trans "Configured" %}</small>
+        </div>
+      {% else %}
+        <div class="d-flex align-items-center gap-1">
+          <i class="mdi mdi-circle text-secondary" style="font-size: 0.6rem;"></i>
+          <small class="text-muted">{% trans "Not configured" %}</small>
+        </div>
+      {% endif %}
+    </div>
+    <div class="col-6">
+      <h6 class="text-muted mb-1">{% trans "FastAPI" %}</h6>
+      {% if fastapi_endpoint %}
+        <div class="d-flex align-items-center gap-1">
+          <i class="mdi mdi-circle text-success" style="font-size: 0.6rem;"></i>
+          <small>{% trans "Configured" %}</small>
+        </div>
+      {% else %}
+        <div class="d-flex align-items-center gap-1">
+          <i class="mdi mdi-circle text-secondary" style="font-size: 0.6rem;"></i>
+          <small class="text-muted">{% trans "Not configured" %}</small>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/netbox_proxbox/templates/netbox_proxbox/dashboard_widgets/object_counts.html
+++ b/netbox_proxbox/templates/netbox_proxbox/dashboard_widgets/object_counts.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+
+{% if rows %}
+  <div class="list-group list-group-flush">
+    {% for row in rows %}
+      <a {% if row.url %}href="{{ row.url }}"{% endif %} class="list-group-item list-group-item-action px-1 py-2">
+        <div class="d-flex w-100 justify-content-between align-items-center">
+          {{ row.label }}
+          <strong>{{ row.count }}</strong>
+        </div>
+      </a>
+    {% endfor %}
+  </div>
+{% else %}
+  <p class="text-muted px-2 py-1"><em>{% trans "No Proxbox objects found." %}</em></p>
+{% endif %}

--- a/netbox_proxbox/templates/netbox_proxbox/dashboard_widgets/sync_status.html
+++ b/netbox_proxbox/templates/netbox_proxbox/dashboard_widgets/sync_status.html
@@ -1,0 +1,79 @@
+{% load i18n %}
+
+<div class="px-2 py-1">
+  {% if latest_job %}
+    <div class="mb-3">
+      <h6 class="text-muted mb-1">{% trans "Last Sync" %}</h6>
+      <div class="d-flex align-items-center gap-2">
+        {% if latest_job.status == 'completed' %}
+          <span class="badge text-bg-success">{% trans "Completed" %}</span>
+        {% elif latest_job.status == 'running' %}
+          <span class="badge text-bg-primary">{% trans "Running" %}</span>
+        {% elif latest_job.status == 'pending' %}
+          <span class="badge text-bg-warning">{% trans "Pending" %}</span>
+        {% elif latest_job.status == 'errored' %}
+          <span class="badge text-bg-danger">{% trans "Errored" %}</span>
+        {% elif latest_job.status == 'failed' %}
+          <span class="badge text-bg-danger">{% trans "Failed" %}</span>
+        {% else %}
+          <span class="badge text-bg-secondary">{{ latest_job.status }}</span>
+        {% endif %}
+        <small class="text-muted">{{ latest_job.created }}</small>
+      </div>
+    </div>
+  {% else %}
+    <p class="text-muted mb-3"><em>{% trans "No sync jobs found." %}</em></p>
+  {% endif %}
+
+  {% if active_job %}
+    <div class="mb-3">
+      <h6 class="text-muted mb-1">{% trans "Active Job" %}</h6>
+      <div class="d-flex align-items-center gap-2">
+        <span class="badge text-bg-primary">
+          <i class="mdi mdi-sync mdi-spin"></i> {{ active_job.status }}
+        </span>
+        <small class="text-muted">{% trans "Started" %} {{ active_job.created }}</small>
+      </div>
+    </div>
+  {% endif %}
+
+  <h6 class="text-muted mb-1">{% trans "Synced Objects" %}</h6>
+  <div class="row g-2">
+    <div class="col-4">
+      <div class="text-center">
+        <div class="fs-4 fw-bold">{{ counts.clusters }}</div>
+        <small class="text-muted">{% trans "Clusters" %}</small>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="text-center">
+        <div class="fs-4 fw-bold">{{ counts.nodes }}</div>
+        <small class="text-muted">{% trans "Nodes" %}</small>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="text-center">
+        <div class="fs-4 fw-bold">{{ counts.endpoints }}</div>
+        <small class="text-muted">{% trans "Endpoints" %}</small>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="text-center">
+        <div class="fs-4 fw-bold">{{ counts.storage }}</div>
+        <small class="text-muted">{% trans "Storage" %}</small>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="text-center">
+        <div class="fs-4 fw-bold">{{ counts.backups }}</div>
+        <small class="text-muted">{% trans "Backups" %}</small>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="text-center">
+        <div class="fs-4 fw-bold">{{ counts.snapshots }}</div>
+        <small class="text-muted">{% trans "Snapshots" %}</small>
+      </div>
+    </div>
+  </div>
+</div>

--- a/netbox_proxbox/widgets.py
+++ b/netbox_proxbox/widgets.py
@@ -54,7 +54,10 @@ class ProxboxSyncStatusWidget(DashboardWidget):
                 continue
             if latest_job is None:
                 latest_job = job
-            if active_job is None and job.status in JobStatusChoices.ENQUEUED_STATE_CHOICES:
+            if (
+                active_job is None
+                and job.status in JobStatusChoices.ENQUEUED_STATE_CHOICES
+            ):
                 active_job = job
             if latest_job and active_job:
                 break
@@ -89,15 +92,27 @@ class ProxboxObjectCountsWidget(DashboardWidget):
         from django.urls import NoReverseMatch, reverse
 
         items = [
-            ("Proxmox Endpoints", ProxmoxEndpoint, "plugins:netbox_proxbox:proxmoxendpoint_list"),
+            (
+                "Proxmox Endpoints",
+                ProxmoxEndpoint,
+                "plugins:netbox_proxbox:proxmoxendpoint_list",
+            ),
             ("Clusters", ProxmoxCluster, "plugins:netbox_proxbox:proxmoxcluster_list"),
             ("Nodes", ProxmoxNode, "plugins:netbox_proxbox:proxmoxnode_list"),
             ("Storage", ProxmoxStorage, "plugins:netbox_proxbox:proxmoxstorage_list"),
             ("VM Backups", VMBackup, "plugins:netbox_proxbox:vmbackup_list"),
             ("VM Snapshots", VMSnapshot, "plugins:netbox_proxbox:vmsnapshot_list"),
-            ("Backup Routines", BackupRoutine, "plugins:netbox_proxbox:backuproutine_list"),
+            (
+                "Backup Routines",
+                BackupRoutine,
+                "plugins:netbox_proxbox:backuproutine_list",
+            ),
             ("Replications", Replication, "plugins:netbox_proxbox:replication_list"),
-            ("Task History", VMTaskHistory, "plugins:netbox_proxbox:vmtaskhistory_list"),
+            (
+                "Task History",
+                VMTaskHistory,
+                "plugins:netbox_proxbox:vmtaskhistory_list",
+            ),
         ]
 
         rows = []
@@ -131,11 +146,13 @@ class ProxboxEndpointStatusWidget(DashboardWidget):
         except AttributeError:
             qs = ProxmoxEndpoint.objects.all()
         for ep in qs:
-            proxmox_endpoints.append({
-                "name": str(ep),
-                "ip": get_endpoint_display_ip(ep),
-                "mode": getattr(ep, "mode", "—"),
-            })
+            proxmox_endpoints.append(
+                {
+                    "name": str(ep),
+                    "ip": get_endpoint_display_ip(ep),
+                    "mode": getattr(ep, "mode", "—"),
+                }
+            )
 
         netbox_ep = None
         try:

--- a/netbox_proxbox/widgets.py
+++ b/netbox_proxbox/widgets.py
@@ -1,0 +1,159 @@
+"""Dashboard widgets for the NetBox home page.
+
+Registered via ``@register_widget`` and imported in ``PluginConfig.ready()``.
+Each widget performs DB-only reads — no synchronous HTTP calls in ``render()``.
+"""
+
+from __future__ import annotations
+
+from django.template.loader import render_to_string
+from django.utils.translation import gettext_lazy as _
+from extras.dashboard.utils import register_widget
+from extras.dashboard.widgets import DashboardWidget
+
+from netbox_proxbox.models import (
+    BackupRoutine,
+    FastAPIEndpoint,
+    NetBoxEndpoint,
+    ProxmoxCluster,
+    ProxmoxEndpoint,
+    ProxmoxNode,
+    ProxmoxStorage,
+    Replication,
+    VMBackup,
+    VMSnapshot,
+    VMTaskHistory,
+)
+
+
+def _safe_count(model, request):
+    """Return the count for a model, respecting object-level permissions."""
+    try:
+        return model.objects.restrict(request.user, "view").count()
+    except AttributeError:
+        return model.objects.count()
+
+
+@register_widget
+class ProxboxSyncStatusWidget(DashboardWidget):
+    default_title = _("Proxbox Sync Status")
+    description = _("Last Proxbox sync job status and synced object summary.")
+    width = 6
+    height = 4
+
+    def render(self, request):
+        from core.choices import JobStatusChoices
+        from core.models import Job
+
+        from netbox_proxbox.jobs import is_proxbox_sync_job
+
+        latest_job = None
+        active_job = None
+        for job in Job.objects.restrict(request.user, "view").order_by("-created")[:50]:
+            if not is_proxbox_sync_job(job):
+                continue
+            if latest_job is None:
+                latest_job = job
+            if active_job is None and job.status in JobStatusChoices.ENQUEUED_STATE_CHOICES:
+                active_job = job
+            if latest_job and active_job:
+                break
+
+        counts = {
+            "clusters": _safe_count(ProxmoxCluster, request),
+            "nodes": _safe_count(ProxmoxNode, request),
+            "endpoints": _safe_count(ProxmoxEndpoint, request),
+            "storage": _safe_count(ProxmoxStorage, request),
+            "backups": _safe_count(VMBackup, request),
+            "snapshots": _safe_count(VMSnapshot, request),
+        }
+
+        return render_to_string(
+            "netbox_proxbox/dashboard_widgets/sync_status.html",
+            {
+                "latest_job": latest_job,
+                "active_job": active_job,
+                "counts": counts,
+            },
+        )
+
+
+@register_widget
+class ProxboxObjectCountsWidget(DashboardWidget):
+    default_title = _("Proxbox Object Counts")
+    description = _("Counts of all Proxbox plugin model objects.")
+    width = 4
+    height = 4
+
+    def render(self, request):
+        from django.urls import NoReverseMatch, reverse
+
+        items = [
+            ("Proxmox Endpoints", ProxmoxEndpoint, "plugins:netbox_proxbox:proxmoxendpoint_list"),
+            ("Clusters", ProxmoxCluster, "plugins:netbox_proxbox:proxmoxcluster_list"),
+            ("Nodes", ProxmoxNode, "plugins:netbox_proxbox:proxmoxnode_list"),
+            ("Storage", ProxmoxStorage, "plugins:netbox_proxbox:proxmoxstorage_list"),
+            ("VM Backups", VMBackup, "plugins:netbox_proxbox:vmbackup_list"),
+            ("VM Snapshots", VMSnapshot, "plugins:netbox_proxbox:vmsnapshot_list"),
+            ("Backup Routines", BackupRoutine, "plugins:netbox_proxbox:backuproutine_list"),
+            ("Replications", Replication, "plugins:netbox_proxbox:replication_list"),
+            ("Task History", VMTaskHistory, "plugins:netbox_proxbox:vmtaskhistory_list"),
+        ]
+
+        rows = []
+        for label, model, url_name in items:
+            count = _safe_count(model, request)
+            try:
+                url = reverse(url_name)
+            except NoReverseMatch:
+                url = None
+            rows.append({"label": label, "count": count, "url": url})
+
+        return render_to_string(
+            "netbox_proxbox/dashboard_widgets/object_counts.html",
+            {"rows": rows},
+        )
+
+
+@register_widget
+class ProxboxEndpointStatusWidget(DashboardWidget):
+    default_title = _("Proxbox Endpoints")
+    description = _("Overview of configured Proxmox, NetBox, and FastAPI endpoints.")
+    width = 6
+    height = 3
+
+    def render(self, request):
+        from netbox_proxbox.views.dashboard_data import get_endpoint_display_ip
+
+        proxmox_endpoints = []
+        try:
+            qs = ProxmoxEndpoint.objects.restrict(request.user, "view")
+        except AttributeError:
+            qs = ProxmoxEndpoint.objects.all()
+        for ep in qs:
+            proxmox_endpoints.append({
+                "name": str(ep),
+                "ip": get_endpoint_display_ip(ep),
+                "mode": getattr(ep, "mode", "—"),
+            })
+
+        netbox_ep = None
+        try:
+            netbox_ep = NetBoxEndpoint.objects.first()
+        except Exception:
+            pass
+
+        fastapi_ep = None
+        try:
+            fastapi_ep = FastAPIEndpoint.objects.first()
+        except Exception:
+            pass
+
+        return render_to_string(
+            "netbox_proxbox/dashboard_widgets/endpoint_status.html",
+            {
+                "proxmox_endpoints": proxmox_endpoints,
+                "netbox_endpoint": netbox_ep,
+                "fastapi_endpoint": fastapi_ep,
+            },
+        )

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,129 @@
+"""Tests for the dashboard widgets module.
+
+These tests verify widget structure and registration at the source level,
+without importing the full Django/NetBox stack.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+WIDGETS_PATH = Path(__file__).resolve().parents[1] / "netbox_proxbox" / "widgets.py"
+
+
+def _parse_widgets_module() -> ast.Module:
+    return ast.parse(WIDGETS_PATH.read_text(), filename=str(WIDGETS_PATH))
+
+
+def _class_names(tree: ast.Module) -> list[str]:
+    return [node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)]
+
+
+def _decorated_classes(tree: ast.Module) -> dict[str, list[str]]:
+    """Return {class_name: [decorator_names]} for all classes."""
+    result = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            decorators = []
+            for dec in node.decorator_list:
+                if isinstance(dec, ast.Name):
+                    decorators.append(dec.id)
+                elif isinstance(dec, ast.Attribute):
+                    decorators.append(dec.attr)
+            result[node.name] = decorators
+    return result
+
+
+def _function_names_in_class(tree: ast.Module, class_name: str) -> list[str]:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return [
+                n.name for n in ast.walk(node) if isinstance(n, ast.FunctionDef)
+            ]
+    return []
+
+
+class TestWidgetModuleStructure:
+    def test_widgets_file_exists(self):
+        assert WIDGETS_PATH.exists(), f"Expected widgets.py at {WIDGETS_PATH}"
+
+    def test_three_widget_classes_defined(self):
+        tree = _parse_widgets_module()
+        names = _class_names(tree)
+        expected = {
+            "ProxboxSyncStatusWidget",
+            "ProxboxObjectCountsWidget",
+            "ProxboxEndpointStatusWidget",
+        }
+        assert expected.issubset(set(names)), f"Missing widget classes: {expected - set(names)}"
+
+    def test_all_widgets_decorated_with_register_widget(self):
+        tree = _parse_widgets_module()
+        decorated = _decorated_classes(tree)
+        for widget_name in (
+            "ProxboxSyncStatusWidget",
+            "ProxboxObjectCountsWidget",
+            "ProxboxEndpointStatusWidget",
+        ):
+            assert widget_name in decorated, f"{widget_name} not found"
+            assert "register_widget" in decorated[widget_name], (
+                f"{widget_name} missing @register_widget decorator"
+            )
+
+    def test_all_widgets_have_render_method(self):
+        tree = _parse_widgets_module()
+        for widget_name in (
+            "ProxboxSyncStatusWidget",
+            "ProxboxObjectCountsWidget",
+            "ProxboxEndpointStatusWidget",
+        ):
+            methods = _function_names_in_class(tree, widget_name)
+            assert "render" in methods, f"{widget_name} missing render() method"
+
+    def test_widgets_import_from_extras_dashboard(self):
+        source = WIDGETS_PATH.read_text()
+        assert "from extras.dashboard.utils import register_widget" in source
+        assert "from extras.dashboard.widgets import DashboardWidget" in source
+
+    def test_no_http_calls_in_render(self):
+        """Widgets must not make synchronous HTTP calls in render()."""
+        source = WIDGETS_PATH.read_text()
+        forbidden = ["requests.get", "requests.post", "httpx.", "urllib.request"]
+        for pattern in forbidden:
+            assert pattern not in source, (
+                f"widgets.py contains '{pattern}' — render() must be DB-only"
+            )
+
+
+class TestWidgetTemplates:
+    TEMPLATE_DIR = (
+        Path(__file__).resolve().parents[1]
+        / "netbox_proxbox"
+        / "templates"
+        / "netbox_proxbox"
+        / "dashboard_widgets"
+    )
+
+    def test_template_directory_exists(self):
+        assert self.TEMPLATE_DIR.is_dir(), f"Expected template dir at {self.TEMPLATE_DIR}"
+
+    def test_sync_status_template_exists(self):
+        assert (self.TEMPLATE_DIR / "sync_status.html").exists()
+
+    def test_object_counts_template_exists(self):
+        assert (self.TEMPLATE_DIR / "object_counts.html").exists()
+
+    def test_endpoint_status_template_exists(self):
+        assert (self.TEMPLATE_DIR / "endpoint_status.html").exists()
+
+
+class TestPluginConfigImportsWidgets:
+    def test_ready_imports_widgets(self):
+        init_path = (
+            Path(__file__).resolve().parents[1] / "netbox_proxbox" / "__init__.py"
+        )
+        source = init_path.read_text()
+        assert "from . import widgets" in source, (
+            "PluginConfig.ready() must import widgets for registration"
+        )

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -38,9 +38,7 @@ def _decorated_classes(tree: ast.Module) -> dict[str, list[str]]:
 def _function_names_in_class(tree: ast.Module, class_name: str) -> list[str]:
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == class_name:
-            return [
-                n.name for n in ast.walk(node) if isinstance(n, ast.FunctionDef)
-            ]
+            return [n.name for n in ast.walk(node) if isinstance(n, ast.FunctionDef)]
     return []
 
 
@@ -56,7 +54,9 @@ class TestWidgetModuleStructure:
             "ProxboxObjectCountsWidget",
             "ProxboxEndpointStatusWidget",
         }
-        assert expected.issubset(set(names)), f"Missing widget classes: {expected - set(names)}"
+        assert expected.issubset(set(names)), (
+            f"Missing widget classes: {expected - set(names)}"
+        )
 
     def test_all_widgets_decorated_with_register_widget(self):
         tree = _parse_widgets_module()
@@ -106,7 +106,9 @@ class TestWidgetTemplates:
     )
 
     def test_template_directory_exists(self):
-        assert self.TEMPLATE_DIR.is_dir(), f"Expected template dir at {self.TEMPLATE_DIR}"
+        assert self.TEMPLATE_DIR.is_dir(), (
+            f"Expected template dir at {self.TEMPLATE_DIR}"
+        )
 
     def test_sync_status_template_exists(self):
         assert (self.TEMPLATE_DIR / "sync_status.html").exists()


### PR DESCRIPTION
Closes #527

## Summary

- Add three `DashboardWidget` subclasses to display Proxbox information on the NetBox home page dashboard, using the official NetBox v4.5+/v4.6 widget API
- **ProxboxSyncStatusWidget**: shows last sync job status/time and synced object counts (clusters, nodes, endpoints, storage, backups, snapshots)
- **ProxboxObjectCountsWidget**: per-model object counts with clickable links to list views
- **ProxboxEndpointStatusWidget**: overview of configured Proxmox, NetBox, and FastAPI endpoints
- All widgets use DB-only reads (no HTTP probes in `render()`) and respect object-level permissions via `.restrict()`

## Files changed

| File | Change |
|------|--------|
| `netbox_proxbox/widgets.py` | New — three widget classes with `@register_widget` |
| `netbox_proxbox/__init__.py` | Import widgets in `PluginConfig.ready()` |
| `templates/.../dashboard_widgets/sync_status.html` | New — sync status widget template |
| `templates/.../dashboard_widgets/object_counts.html` | New — object counts widget template |
| `templates/.../dashboard_widgets/endpoint_status.html` | New — endpoint status widget template |
| `tests/test_widgets.py` | New — 11 structural tests (AST-level) |

## Test plan

- [x] `python -m py_compile netbox_proxbox/widgets.py` — compiles cleanly
- [x] `ruff check` — no lint issues
- [x] `pytest tests/test_widgets.py` — 11/11 pass
- [ ] Restart NetBox → home page → Unlock Dashboard → Add Widget → verify three Proxbox widgets appear
- [ ] Add each widget and confirm it renders correctly with real data
- [ ] Test with user that has limited permissions — counts should respect object-level perms