### PR TITLE
Add endpoint runtime cards for Proxbox sync jobs

### DIFF
--- a/netbox_proxbox/jobs.py
+++ b/netbox_proxbox/jobs.py
@@ -120,10 +120,217 @@ def _run_all_stages_sync(*args: object, **kwargs: object) -> list[dict[str, obje
     return sync_stages._run_all_stages_sync(*args, **kwargs)
 
 
+def _runtime_seconds_since(started: float) -> float:
+    """Return a rounded elapsed runtime for persisted job metadata."""
+    return round(max(time.monotonic() - started, 0.0), 3)
+
+
+def _normalize_endpoint_id(value: object) -> int | str | None:
+    """Normalize endpoint identifiers used in job metadata."""
+    if value in (None, ""):
+        return None
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _coerce_runtime_seconds(value: object) -> float | None:
+    """Return a rounded float runtime when a metadata value is numeric."""
+    if value in (None, ""):
+        return None
+    try:
+        return round(float(value), 3)
+    except (TypeError, ValueError):
+        return None
+
+
+def _endpoint_name_map(endpoint_ids: set[int | str]) -> dict[str, str]:
+    """Resolve endpoint labels for runtime cards with safe fallbacks."""
+    numeric_ids: list[int] = []
+    for endpoint_id in endpoint_ids:
+        try:
+            numeric_ids.append(int(str(endpoint_id)))
+        except (TypeError, ValueError):
+            continue
+
+    names: dict[str, str] = {}
+    if numeric_ids:
+        try:
+            for endpoint in ProxmoxEndpoint.objects.filter(pk__in=numeric_ids):
+                pk = _normalize_endpoint_id(getattr(endpoint, "pk", None))
+                if pk is None:
+                    continue
+                label = getattr(endpoint, "name", None) or str(endpoint)
+                names[str(pk)] = str(label)
+        except Exception:  # noqa: BLE001 - runtime panel metadata must not break sync
+            names = {}
+
+    for endpoint_id in endpoint_ids:
+        names.setdefault(str(endpoint_id), f"Endpoint {endpoint_id}")
+    return names
+
+
+def _endpoint_runtime_phase(
+    *,
+    endpoint_id: object,
+    endpoint_name: object = "",
+    kind: str,
+    label: str,
+    runtime_seconds: object,
+    status: str,
+    summary: str = "",
+    sync_type: object | None = None,
+    stream_path: object | None = None,
+) -> dict[str, object]:
+    """Build one persisted endpoint runtime phase."""
+    phase: dict[str, object] = {
+        "kind": kind,
+        "label": label,
+        "runtime_seconds": _coerce_runtime_seconds(runtime_seconds),
+        "status": status,
+        "summary": summary,
+    }
+    normalized_endpoint_id = _normalize_endpoint_id(endpoint_id)
+    if normalized_endpoint_id is not None:
+        phase["endpoint_id"] = normalized_endpoint_id
+    if endpoint_name:
+        phase["endpoint_name"] = str(endpoint_name)
+    if sync_type:
+        phase["sync_type"] = str(sync_type)
+    if stream_path:
+        phase["stream_path"] = str(stream_path)
+    return phase
+
+
+def _phases_from_service_result(
+    result: object,
+    *,
+    kind: str,
+    label: str,
+) -> list[dict[str, object]]:
+    """Convert service ``per_endpoint`` entries into runtime phases."""
+    phases: list[dict[str, object]] = []
+    per_endpoint = getattr(result, "per_endpoint", []) or []
+    for item in per_endpoint:
+        if not isinstance(item, dict):
+            continue
+        success = item.get("success")
+        status = "success" if success is not False else "warning"
+        summary = str(item.get("error") or f"{label} completed")
+        phases.append(
+            _endpoint_runtime_phase(
+                endpoint_id=item.get("endpoint_id"),
+                endpoint_name=item.get("endpoint_name", ""),
+                kind=kind,
+                label=label,
+                runtime_seconds=item.get("runtime_seconds"),
+                status=status,
+                summary=summary,
+            )
+        )
+    return phases
+
+
+def _phases_from_stage_results(
+    stages_out: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Convert SSE stage results into endpoint runtime phases."""
+    phases: list[dict[str, object]] = []
+    for stage in stages_out:
+        result_summary = stage.get("result_summary")
+        if not isinstance(result_summary, dict):
+            result_summary = {}
+        ok = result_summary.get("ok")
+        sync_type = stage.get("sync_type") or "sync stage"
+        stream_path = stage.get("stream_path") or result_summary.get("path")
+        phases.append(
+            _endpoint_runtime_phase(
+                endpoint_id=stage.get("endpoint_id"),
+                endpoint_name=stage.get("endpoint_name", ""),
+                kind="sse_stage",
+                label=str(sync_type),
+                runtime_seconds=stage.get("runtime_seconds"),
+                status="success" if ok is not False else "warning",
+                summary=str(stream_path or "Backend SSE stage completed"),
+                sync_type=sync_type,
+                stream_path=stream_path,
+            )
+        )
+    return phases
+
+
+def _build_endpoint_runtimes(
+    phases: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Group recorded runtime phases into per-endpoint cards."""
+    buckets: dict[str, dict[str, object]] = {}
+    endpoint_ids: set[int | str] = set()
+
+    for phase in phases:
+        endpoint_id = _normalize_endpoint_id(phase.get("endpoint_id"))
+        if endpoint_id is None:
+            continue
+        endpoint_ids.add(endpoint_id)
+        key = str(endpoint_id)
+        bucket = buckets.setdefault(
+            key,
+            {
+                "endpoint_id": endpoint_id,
+                "endpoint_name": "",
+                "runtime_seconds": 0.0,
+                "phases": [],
+            },
+        )
+        endpoint_name = str(phase.get("endpoint_name") or "").strip()
+        if endpoint_name:
+            bucket["endpoint_name"] = endpoint_name
+        bucket_phases = bucket["phases"]
+        if isinstance(bucket_phases, list):
+            bucket_phases.append(phase)
+        phase_runtime = _coerce_runtime_seconds(phase.get("runtime_seconds"))
+        if phase_runtime is not None:
+            bucket["runtime_seconds"] = round(
+                float(bucket["runtime_seconds"]) + phase_runtime,
+                3,
+            )
+
+    names = _endpoint_name_map(endpoint_ids)
+    endpoint_runtimes = list(buckets.values())
+    for endpoint_runtime in endpoint_runtimes:
+        key = str(endpoint_runtime["endpoint_id"])
+        if not endpoint_runtime.get("endpoint_name"):
+            endpoint_runtime["endpoint_name"] = names.get(key, f"Endpoint {key}")
+    endpoint_runtimes.sort(key=lambda item: str(item.get("endpoint_name") or ""))
+    return endpoint_runtimes
+
+
+def _runtime_summary(
+    *,
+    runtime_seconds: float,
+    endpoint_runtimes: list[dict[str, object]],
+) -> dict[str, object]:
+    """Build whole-job summary fields for the runtime panel."""
+    endpoint_runtime_seconds = round(
+        sum(float(item.get("runtime_seconds") or 0.0) for item in endpoint_runtimes),
+        3,
+    )
+    other_runtime_seconds = round(
+        max(runtime_seconds - endpoint_runtime_seconds, 0.0),
+        3,
+    )
+    return {
+        "runtime_seconds": runtime_seconds,
+        "endpoint_count": len(endpoint_runtimes),
+        "endpoint_runtime_seconds": endpoint_runtime_seconds,
+        "other_runtime_seconds": other_runtime_seconds,
+    }
+
+
 def _ensure_backend_endpoints(
     job: "ProxboxSyncJob",
     proxmox_endpoint_ids: list[str] | None = None,
-) -> None:
+) -> list[dict[str, object]]:
     """Push NetBox and Proxmox endpoint data to the proxbox-api backend before sync.
 
     Best-effort — logs warnings on failure but never raises so the sync can still
@@ -150,7 +357,7 @@ def _ensure_backend_endpoints(
         job.logger.warning(
             "No FastAPIEndpoint configured — cannot push endpoint data to backend"
         )
-        return
+        return []
 
     base_url = context.http_url.rstrip("/")
     auth_headers = dict(context.headers or {})
@@ -189,7 +396,9 @@ def _ensure_backend_endpoints(
     else:
         proxmox_qs = ProxmoxEndpoint.objects.filter(enabled=True)
 
+    phases: list[dict[str, object]] = []
     for px_ep in proxmox_qs:
+        endpoint_started = time.monotonic()
         ok, err, _ = sync_proxmox_endpoint_to_backend(
             px_ep,
             base_url=base_url,
@@ -207,6 +416,22 @@ def _ensure_backend_endpoints(
                 getattr(px_ep, "name", px_ep.pk),
                 err,
             )
+        phases.append(
+            _endpoint_runtime_phase(
+                endpoint_id=getattr(px_ep, "pk", None),
+                endpoint_name=getattr(px_ep, "name", None) or str(px_ep),
+                kind="preflight",
+                label="Backend endpoint push",
+                runtime_seconds=_runtime_seconds_since(endpoint_started),
+                status="success" if ok else "warning",
+                summary=(
+                    "Proxmox endpoint pushed to proxbox-api"
+                    if ok
+                    else f"Proxmox endpoint push failed: {err}"
+                ),
+            )
+        )
+    return phases
 
 
 def _coerce_endpoint_ids(
@@ -453,12 +678,16 @@ class ProxboxSyncJob(JobRunner):
             if netbox_vm_ids:
                 self.logger.info(f"NetBox virtual machines: {netbox_vm_ids}")
 
+            endpoint_runtime_phases: list[dict[str, object]] = []
+
             # Push NetBox and Proxmox endpoint configuration to the proxbox-api
             # backend before any SSE stage runs.  The backend needs its own copy
             # of these records to open NetBox and Proxmox sessions; the post_save
             # signals are best-effort and may have missed a push if the backend
             # was offline when the endpoints were first saved.
-            _ensure_backend_endpoints(self, proxmox_endpoint_ids or [])
+            endpoint_runtime_phases.extend(
+                _ensure_backend_endpoints(self, proxmox_endpoint_ids or [])
+            )
 
             # Sync cluster and node data before SSE stages so cluster/node records
             # are populated regardless of which stages are selected.
@@ -476,19 +705,37 @@ class ProxboxSyncJob(JobRunner):
             )
             for eid in endpoint_ids_to_sync:
                 self.logger.info(f"Syncing cluster/nodes for endpoint {eid}")
+                cluster_started = time.monotonic()
                 cluster_result = sync_cluster_and_nodes(endpoint_id=eid)
+                cluster_runtime = _runtime_seconds_since(cluster_started)
                 if cluster_result.success:
-                    self.logger.info(
-                        f"Cluster/node sync for endpoint {eid}: "
+                    cluster_summary = (
                         f"{cluster_result.clusters_created} cluster(s) created, "
                         f"{cluster_result.clusters_updated} updated, "
                         f"{cluster_result.nodes_created} node(s) created, "
                         f"{cluster_result.nodes_updated} updated"
                     )
+                    self.logger.info(
+                        f"Cluster/node sync for endpoint {eid}: {cluster_summary}"
+                    )
                 else:
+                    cluster_summary = str(
+                        cluster_result.error or "cluster/node sync failed"
+                    )
                     self.logger.warning(
                         f"Cluster/node sync for endpoint {eid} failed: {cluster_result.error}"
                     )
+                endpoint_runtime_phases.append(
+                    _endpoint_runtime_phase(
+                        endpoint_id=getattr(cluster_result, "endpoint_id", None) or eid,
+                        endpoint_name=getattr(cluster_result, "endpoint_name", ""),
+                        kind="cluster",
+                        label="Cluster/node sync",
+                        runtime_seconds=cluster_runtime,
+                        status="success" if cluster_result.success else "warning",
+                        summary=cluster_summary,
+                    )
+                )
 
             # Sync datacenter-level firewall objects (security groups, rules,
             # IP sets, aliases, options) after cluster/node records exist so
@@ -510,6 +757,13 @@ class ProxboxSyncJob(JobRunner):
                 self.logger.warning(
                     f"Firewall sync failed or partially failed: {fw_result.error or 'see per_endpoint log'}"
                 )
+            endpoint_runtime_phases.extend(
+                _phases_from_service_result(
+                    fw_result,
+                    kind="firewall",
+                    label="Firewall sync",
+                )
+            )
 
             # Sync SDN objects (fabrics, route maps, prefix lists).
             from netbox_proxbox.services.sync_sdn import sync_sdn  # noqa: PLC0415
@@ -527,6 +781,13 @@ class ProxboxSyncJob(JobRunner):
                 self.logger.warning(
                     f"SDN sync failed or partially failed: {sdn_result.error or 'see per_endpoint log'}"
                 )
+            endpoint_runtime_phases.extend(
+                _phases_from_service_result(
+                    sdn_result,
+                    kind="sdn",
+                    label="SDN sync",
+                )
+            )
 
             # Sync datacenter CPU models.
             from netbox_proxbox.services.sync_datacenter import sync_datacenter  # noqa: PLC0415
@@ -543,8 +804,16 @@ class ProxboxSyncJob(JobRunner):
                 self.logger.warning(
                     f"Datacenter CPU model sync failed: {dc_result.error or 'unknown error'}"
                 )
+            endpoint_runtime_phases.extend(
+                _phases_from_service_result(
+                    dc_result,
+                    kind="datacenter",
+                    label="Datacenter sync",
+                )
+            )
 
             stages_out = _run_all_stages_sync(self, stages, params, run_started)
+            endpoint_runtime_phases.extend(_phases_from_stage_results(stages_out))
 
             for stage in stages_out:
                 if stage.get("runtime_seconds") is None:
@@ -553,11 +822,19 @@ class ProxboxSyncJob(JobRunner):
                     )
 
             runtime_seconds = round(time.monotonic() - run_started, 3)
+            endpoint_runtimes = _build_endpoint_runtimes(endpoint_runtime_phases)
             self.job.data = {
                 "proxbox_sync": {
                     "params": params,
                     "runtime_seconds": runtime_seconds,
-                    "response": {"stages": stages_out},
+                    "response": {
+                        "stages": stages_out,
+                        "endpoint_runtimes": endpoint_runtimes,
+                        "runtime_summary": _runtime_summary(
+                            runtime_seconds=runtime_seconds,
+                            endpoint_runtimes=endpoint_runtimes,
+                        ),
+                    },
                 }
             }
             self.job.save(update_fields=["data"])

--- a/netbox_proxbox/services/sync_datacenter.py
+++ b/netbox_proxbox/services/sync_datacenter.py
@@ -9,6 +9,7 @@ Results are upserted into the ProxmoxDatacenterCpuModel Django model.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
 
 import requests
@@ -128,6 +129,16 @@ def sync_datacenter(
         return result
 
     processed_endpoints: set[int] = set()
+    endpoint_runtime_seconds: dict[int, float] = {}
+    endpoint_names: dict[int, str] = {}
+
+    def record_endpoint_runtime(
+        endpoint: ProxmoxEndpoint, runtime_seconds: float
+    ) -> None:
+        endpoint_names.setdefault(endpoint.pk, str(endpoint))
+        endpoint_runtime_seconds[endpoint.pk] = (
+            endpoint_runtime_seconds.get(endpoint.pk, 0.0) + runtime_seconds
+        )
 
     with transaction.atomic():
         synced_pks: list[int] = []
@@ -144,9 +155,12 @@ def sync_datacenter(
                     cluster_name,
                 )
                 continue
+            upsert_started = time.monotonic()
             pk = _upsert_cpu_model(endpoint, item, result)
+            upsert_runtime = time.monotonic() - upsert_started
             if pk:
                 synced_pks.append(pk)
+                record_endpoint_runtime(endpoint, upsert_runtime)
                 processed_endpoints.add(endpoint.pk)
 
         stale = (
@@ -159,6 +173,15 @@ def sync_datacenter(
         result.cpu_models_stale += stale
 
     result.endpoints_processed = len(processed_endpoints)
+    result.per_endpoint = [
+        {
+            "endpoint_id": endpoint_id,
+            "endpoint_name": endpoint_names.get(endpoint_id, f"Endpoint {endpoint_id}"),
+            "success": True,
+            "runtime_seconds": round(runtime_seconds, 3),
+        }
+        for endpoint_id, runtime_seconds in endpoint_runtime_seconds.items()
+    ]
     result.success = True
     logger.info(
         "Datacenter sync complete: %d endpoint(s) processed, cpu_models=%d/%d/%d (created/updated/stale)",

--- a/netbox_proxbox/services/sync_firewall.py
+++ b/netbox_proxbox/services/sync_firewall.py
@@ -15,6 +15,7 @@ per-VM ``vm_type`` (qemu vs lxc) source is available from the DB.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
 
 import requests
@@ -532,6 +533,8 @@ def sync_firewall(
     # DB phase — one atomic block per endpoint.
     # -----------------------------------------------------------------------
     resolved_endpoints: dict[int, ProxmoxEndpoint] = {}
+    endpoint_started_at: dict[int, float] = {}
+    per_endpoint_by_id: dict[int, dict] = {}
 
     for entry in summary_list:
         cluster_name = entry.get("cluster_name") or ""
@@ -547,6 +550,8 @@ def sync_firewall(
             continue
 
         ep_result: dict = {"endpoint_id": endpoint.pk, "endpoint_name": str(endpoint)}
+        endpoint_started_at[endpoint.pk] = time.monotonic()
+        per_endpoint_by_id[endpoint.pk] = ep_result
         try:
             _sync_one_endpoint(endpoint, entry, result)
             ep_result["success"] = True
@@ -572,6 +577,11 @@ def sync_firewall(
                 endpoint.pk,
                 endpoint,
                 exc,
+            )
+        finally:
+            ep_result["runtime_seconds"] = round(
+                time.monotonic() - endpoint_started_at[endpoint.pk],
+                3,
             )
 
         result.per_endpoint.append(ep_result)
@@ -603,6 +613,12 @@ def sync_firewall(
                         node_name,
                         exc,
                     )
+            ep_result = per_endpoint_by_id.get(endpoint.pk)
+            if ep_result is not None:
+                ep_result["runtime_seconds"] = round(
+                    time.monotonic() - endpoint_started_at[endpoint.pk],
+                    3,
+                )
 
     result.success = (
         all(ep.get("success", False) for ep in result.per_endpoint)

--- a/netbox_proxbox/services/sync_sdn.py
+++ b/netbox_proxbox/services/sync_sdn.py
@@ -11,6 +11,7 @@ Results are upserted into the three SDN Django models.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
 
 import requests
@@ -227,6 +228,16 @@ def sync_sdn(
     synced_fabric_pks: set[int] = set()
     synced_route_map_pks: set[int] = set()
     synced_prefix_list_pks: set[int] = set()
+    endpoint_runtime_seconds: dict[int, float] = {}
+    endpoint_names: dict[int, str] = {}
+
+    def record_endpoint_runtime(
+        endpoint: ProxmoxEndpoint, runtime_seconds: float
+    ) -> None:
+        endpoint_names.setdefault(endpoint.pk, str(endpoint))
+        endpoint_runtime_seconds[endpoint.pk] = (
+            endpoint_runtime_seconds.get(endpoint.pk, 0.0) + runtime_seconds
+        )
 
     with transaction.atomic():
         for item in fabrics:
@@ -242,8 +253,11 @@ def sync_sdn(
                     cluster_name,
                 )
                 continue
+            upsert_started = time.monotonic()
             pk = _upsert_fabric(endpoint, item, result)
+            upsert_runtime = time.monotonic() - upsert_started
             if pk:
+                record_endpoint_runtime(endpoint, upsert_runtime)
                 synced_fabric_pks.add(pk)
                 processed_fabric_endpoints.add(endpoint.pk)
 
@@ -256,8 +270,11 @@ def sync_sdn(
             )
             if endpoint is None:
                 continue
+            upsert_started = time.monotonic()
             pk = _upsert_route_map(endpoint, item, result)
+            upsert_runtime = time.monotonic() - upsert_started
             if pk:
+                record_endpoint_runtime(endpoint, upsert_runtime)
                 synced_route_map_pks.add(pk)
                 processed_route_map_endpoints.add(endpoint.pk)
 
@@ -270,8 +287,11 @@ def sync_sdn(
             )
             if endpoint is None:
                 continue
+            upsert_started = time.monotonic()
             pk = _upsert_prefix_list(endpoint, item, result)
+            upsert_runtime = time.monotonic() - upsert_started
             if pk:
+                record_endpoint_runtime(endpoint, upsert_runtime)
                 synced_prefix_list_pks.add(pk)
                 processed_prefix_list_endpoints.add(endpoint.pk)
 
@@ -310,6 +330,15 @@ def sync_sdn(
         | processed_route_map_endpoints
         | processed_prefix_list_endpoints
     )
+    result.per_endpoint = [
+        {
+            "endpoint_id": endpoint_id,
+            "endpoint_name": endpoint_names.get(endpoint_id, f"Endpoint {endpoint_id}"),
+            "success": True,
+            "runtime_seconds": round(runtime_seconds, 3),
+        }
+        for endpoint_id, runtime_seconds in endpoint_runtime_seconds.items()
+    ]
     result.success = True
     logger.info(
         "SDN sync complete: %d endpoint(s) processed, "

--- a/netbox_proxbox/sync_stages.py
+++ b/netbox_proxbox/sync_stages.py
@@ -398,10 +398,9 @@ def _run_all_stages_sync(
     )
 
     for endpoint_scope in endpoint_scopes:
+        endpoint_id = endpoint_scope[0] if endpoint_scope else None
         if endpoint_scope:
-            job.logger.info(
-                "Running SSE sync for Proxmox endpoint %s", endpoint_scope[0]
-            )
+            job.logger.info("Running SSE sync for Proxmox endpoint %s", endpoint_id)
         else:
             job.logger.info("Running SSE sync with no Proxmox endpoint filter")
         base_query = _build_base_query_params(
@@ -442,6 +441,8 @@ def _run_all_stages_sync(
                 stages_out.append(
                     {
                         "sync_type": st,
+                        "endpoint_id": endpoint_id,
+                        "stream_path": stream_path,
                         "runtime_seconds": stage_runtime,
                         "result_summary": {
                             "path": payload.get("path"),

--- a/netbox_proxbox/templates/netbox_proxbox/inc/job_runtime_panel.html
+++ b/netbox_proxbox/templates/netbox_proxbox/inc/job_runtime_panel.html
@@ -1,17 +1,99 @@
 {% load i18n %}
 {% with block=job.data.proxbox_sync %}
     {% if block %}
-        <div class="card">
-            <h5 class="card-header">{% trans "Proxbox sync" %}</h5>
-            <div class="card-body">
-                {% if block.runtime_seconds is not None %}
-                    <p class="mb-2"><strong>{% trans "Runtime" %}:</strong> {{ block.runtime_seconds }}s</p>
-                {% endif %}
-                {% if block.params.sync_types %}
-                    <p class="mb-0"><strong>{% trans "Sync types" %}:</strong> {{ block.params.sync_types|join:", " }}</p>
-                {% endif %}
-                {% if block.response.stages %}
-                    <hr class="my-2">
+        {% with summary=block.response.runtime_summary %}
+            <div class="card">
+                <h5 class="card-header">{% trans "Proxbox sync summary" %}</h5>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        {% if block.runtime_seconds is not None %}
+                            <dt class="col-6">{% trans "Job runtime" %}</dt>
+                            <dd class="col-6 text-end font-monospace">{{ block.runtime_seconds|floatformat:1 }}s</dd>
+                        {% endif %}
+                        {% if summary %}
+                            {% if summary.endpoint_count is not None %}
+                                <dt class="col-6">{% trans "Synced endpoints" %}</dt>
+                                <dd class="col-6 text-end font-monospace">{{ summary.endpoint_count }}</dd>
+                            {% endif %}
+                            {% if summary.endpoint_runtime_seconds is not None %}
+                                <dt class="col-6">{% trans "Endpoint runtime" %}</dt>
+                                <dd class="col-6 text-end font-monospace">{{ summary.endpoint_runtime_seconds|floatformat:1 }}s</dd>
+                            {% endif %}
+                            {% if summary.other_runtime_seconds is not None %}
+                                <dt class="col-6">{% trans "Other runtime" %}</dt>
+                                <dd class="col-6 text-end font-monospace">{{ summary.other_runtime_seconds|floatformat:1 }}s</dd>
+                            {% endif %}
+                        {% endif %}
+                        {% if block.params.sync_types %}
+                            <dt class="col-6">{% trans "Sync types" %}</dt>
+                            <dd class="col-6 text-end">{{ block.params.sync_types|join:", " }}</dd>
+                        {% endif %}
+                    </dl>
+                </div>
+            </div>
+        {% endwith %}
+
+        {% if block.response.endpoint_runtimes %}
+            {% for endpoint_runtime in block.response.endpoint_runtimes %}
+                <div class="card">
+                    <h5 class="card-header">
+                        {% if endpoint_runtime.endpoint_name %}
+                            {{ endpoint_runtime.endpoint_name }}
+                        {% else %}
+                            {% trans "Proxmox endpoint" %} {{ endpoint_runtime.endpoint_id }}
+                        {% endif %}
+                    </h5>
+                    <div class="card-body">
+                        <p class="mb-2">
+                            <strong>{% trans "Endpoint runtime" %}:</strong>
+                            <span class="font-monospace">{{ endpoint_runtime.runtime_seconds|floatformat:1 }}s</span>
+                            {% if endpoint_runtime.endpoint_id %}
+                                <span class="text-muted">({% trans "ID" %} {{ endpoint_runtime.endpoint_id }})</span>
+                            {% endif %}
+                        </p>
+                        {% if endpoint_runtime.phases %}
+                            <table class="table table-sm table-borderless mb-0">
+                                <thead>
+                                    <tr>
+                                        <th class="ps-0">{% trans "Stage" %}</th>
+                                        <th>{% trans "Status" %}</th>
+                                        <th>{% trans "Summary" %}</th>
+                                        <th class="text-end pe-0">{% trans "Runtime" %}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for phase in endpoint_runtime.phases %}
+                                        <tr>
+                                            <td class="ps-0 text-nowrap">{{ phase.label }}</td>
+                                            <td class="text-nowrap">
+                                                {% if phase.status == "success" %}
+                                                    <span class="badge text-bg-success">{% trans "Success" %}</span>
+                                                {% elif phase.status == "warning" %}
+                                                    <span class="badge text-bg-warning">{% trans "Warning" %}</span>
+                                                {% else %}
+                                                    <span class="badge text-bg-secondary">{{ phase.status }}</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>{{ phase.summary }}</td>
+                                            <td class="text-end pe-0 font-monospace text-nowrap">
+                                                {% if phase.runtime_seconds is not None and phase.runtime_seconds != "" %}
+                                                    {{ phase.runtime_seconds|floatformat:1 }}s
+                                                {% else %}
+                                                    &mdash;
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endfor %}
+        {% elif block.response.stages %}
+            <div class="card">
+                <h5 class="card-header">{% trans "Proxbox sync stages" %}</h5>
+                <div class="card-body">
                     <p class="mb-1"><strong>{% trans "Stage breakdown" %}:</strong></p>
                     <table class="table table-sm table-borderless mb-0">
                         <thead>
@@ -35,8 +117,8 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                {% endif %}
+                </div>
             </div>
-        </div>
+        {% endif %}
     {% endif %}
 {% endwith %}

--- a/tests/test_datacenter_models.py
+++ b/tests/test_datacenter_models.py
@@ -235,6 +235,8 @@ def test_sync_datacenter_service_has_result_dataclass():
     content = _read("netbox_proxbox/services/sync_datacenter.py")
     assert "DatacenterSyncResult" in content
     assert "cpu_models_created" in content
+    assert "per_endpoint" in content
+    assert "runtime_seconds" in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -176,6 +176,20 @@ def test_vm_detail_sync_now_button_contract():
     assert "Sync Now" in button_contents
 
 
+def test_job_runtime_panel_renders_endpoint_runtime_cards():
+    contents = _read(
+        "netbox_proxbox/templates/netbox_proxbox/inc/job_runtime_panel.html"
+    )
+
+    assert "Proxbox sync summary" in contents
+    assert "block.response.runtime_summary" in contents
+    assert "block.response.endpoint_runtimes" in contents
+    assert "endpoint_runtime.phases" in contents
+    assert "phase.runtime_seconds" in contents
+    assert "block.response.stages" in contents
+    assert "Proxbox sync stages" in contents
+
+
 def test_firewall_push_and_preview_ui_contracts():
     extension_contents = _read("netbox_proxbox/template_content.py")
     view_contents = _read("netbox_proxbox/views/firewall.py")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -731,6 +731,177 @@ def test_proxbox_sync_job_run_multi_stage_in_dependency_order(
     assert len(saved["proxbox_sync"]["response"]["stages"]) == 2
 
 
+def test_proxbox_sync_job_persists_endpoint_runtime_breakdown(
+    monkeypatch, proxbox_sync_job_module
+):
+    """Endpoint-scoped runs persist cards with local phases and SSE stage timings."""
+    services_mod = types.ModuleType("netbox_proxbox.services")
+
+    def run_sync_stream(path, query_params=None, **stream_kwargs):
+        return ({"stream": True, "response": {"ok": True}, "path": path}, 200)
+
+    services_mod.run_sync_stream = run_sync_stream
+    monkeypatch.setitem(sys.modules, "netbox_proxbox.services", services_mod)
+
+    class _EndpointQuerySet(list):
+        def first(self):
+            return self[0] if self else None
+
+    class _EndpointManager:
+        def filter(self, **kwargs):
+            endpoints = [
+                SimpleNamespace(pk=1, name="pve-a", effective_overwrites=lambda: {}),
+                SimpleNamespace(pk=2, name="pve-b", effective_overwrites=lambda: {}),
+            ]
+            if "pk__in" in kwargs:
+                ids = {int(value) for value in kwargs.get("pk__in", [])}
+                return _EndpointQuerySet(
+                    [endpoint for endpoint in endpoints if endpoint.pk in ids]
+                )
+            if "pk" in kwargs:
+                return _EndpointQuerySet(
+                    [
+                        endpoint
+                        for endpoint in endpoints
+                        if endpoint.pk == int(kwargs["pk"])
+                    ]
+                )
+            return _EndpointQuerySet(endpoints)
+
+        def values_list(self, *args, **kwargs):
+            return [1, 2]
+
+    proxbox_sync_job_module.ProxmoxEndpoint.objects = _EndpointManager()
+
+    sync_cluster_mod = sys.modules["netbox_proxbox.services.sync_cluster"]
+    sync_cluster_mod.sync_cluster_and_nodes = lambda endpoint_id=None: SimpleNamespace(
+        success=True,
+        endpoint_id=endpoint_id,
+        endpoint_name=f"pve-{endpoint_id}",
+        clusters_created=0,
+        clusters_updated=1,
+        nodes_created=0,
+        nodes_updated=2,
+        error=None,
+    )
+
+    sys.modules["netbox_proxbox.services.sync_firewall"].sync_firewall = (
+        lambda *a, **kw: SimpleNamespace(
+            success=True,
+            error=None,
+            endpoints_processed=2,
+            security_groups_created=0,
+            security_groups_updated=0,
+            rules_created=0,
+            ipsets_created=0,
+            aliases_created=0,
+            per_endpoint=[
+                {
+                    "endpoint_id": 1,
+                    "endpoint_name": "pve-1",
+                    "success": True,
+                    "runtime_seconds": 1.25,
+                },
+                {
+                    "endpoint_id": 2,
+                    "endpoint_name": "pve-2",
+                    "success": True,
+                    "runtime_seconds": 1.5,
+                },
+            ],
+        )
+    )
+    sys.modules["netbox_proxbox.services.sync_sdn"].sync_sdn = lambda *a, **kw: (
+        SimpleNamespace(
+            success=True,
+            error=None,
+            endpoints_processed=2,
+            fabrics_created=0,
+            fabrics_updated=0,
+            route_maps_created=0,
+            route_maps_updated=0,
+            prefix_lists_created=0,
+            prefix_lists_updated=0,
+            per_endpoint=[
+                {
+                    "endpoint_id": 1,
+                    "endpoint_name": "pve-1",
+                    "success": True,
+                    "runtime_seconds": 0.5,
+                },
+                {
+                    "endpoint_id": 2,
+                    "endpoint_name": "pve-2",
+                    "success": True,
+                    "runtime_seconds": 0.75,
+                },
+            ],
+        )
+    )
+    sys.modules["netbox_proxbox.services.sync_datacenter"].sync_datacenter = (
+        lambda *a, **kw: SimpleNamespace(
+            success=True,
+            error=None,
+            endpoints_processed=2,
+            cpu_models_created=0,
+            cpu_models_updated=0,
+            cpu_models_stale=0,
+            per_endpoint=[
+                {
+                    "endpoint_id": 1,
+                    "endpoint_name": "pve-1",
+                    "success": True,
+                    "runtime_seconds": 0.25,
+                },
+                {
+                    "endpoint_id": 2,
+                    "endpoint_name": "pve-2",
+                    "success": True,
+                    "runtime_seconds": 0.35,
+                },
+            ],
+        )
+    )
+
+    ticks = {"value": 100.0}
+
+    def monotonic():
+        ticks["value"] += 1.0
+        return ticks["value"]
+
+    monkeypatch.setattr(proxbox_sync_job_module.time, "monotonic", monotonic)
+
+    ProxboxSyncJob = proxbox_sync_job_module.ProxboxSyncJob
+    job = ProxboxSyncJob()
+    job.logger = logging.getLogger("test_proxbox_endpoint_runtime")
+    job.job = MagicMock()
+    job.job.data = None
+
+    st = proxbox_sync_job_module.SyncTypeChoices
+    ProxboxSyncJob.run(job, sync_types=[st.DEVICES], proxmox_endpoint_ids=["1", "2"])
+
+    response = job.job.data["proxbox_sync"]["response"]
+    assert len(response["stages"]) == 2
+    assert [stage["endpoint_id"] for stage in response["stages"]] == ["1", "2"]
+    assert {stage["sync_type"] for stage in response["stages"]} == {st.DEVICES}
+
+    endpoint_runtimes = response["endpoint_runtimes"]
+    assert len(endpoint_runtimes) == 2
+    assert {entry["endpoint_id"] for entry in endpoint_runtimes} == {1, 2}
+    assert response["runtime_summary"]["endpoint_count"] == 2
+
+    for entry in endpoint_runtimes:
+        labels = [phase["label"] for phase in entry["phases"]]
+        assert labels[:4] == [
+            "Cluster/node sync",
+            "Firewall sync",
+            "SDN sync",
+            "Datacenter sync",
+        ]
+        assert st.DEVICES in labels
+        assert entry["runtime_seconds"] > 0
+
+
 def test_proxbox_sync_job_run_targets_single_vm_route_when_requested(
     monkeypatch, proxbox_sync_job_module
 ):

--- a/tests/test_sdn_models.py
+++ b/tests/test_sdn_models.py
@@ -312,3 +312,5 @@ def test_sync_sdn_service_has_result_dataclass():
     assert "fabrics_created" in content
     assert "route_maps_created" in content
     assert "prefix_lists_created" in content
+    assert "per_endpoint" in content
+    assert "runtime_seconds" in content

--- a/tests/test_services_sync_firewall.py
+++ b/tests/test_services_sync_firewall.py
@@ -375,6 +375,9 @@ def test_happy_path_calls_upsert_for_all_object_types(sync_fw_module, monkeypatc
 
     assert result.success is True
     assert result.endpoints_processed == 1
+    assert result.per_endpoint[0]["endpoint_id"] == 1
+    assert "runtime_seconds" in result.per_endpoint[0]
+    assert result.per_endpoint[0]["runtime_seconds"] >= 0
     # 1 security group
     assert result.security_groups_created == 1
     # 1 datacenter rule + 1 security group rule


### PR DESCRIPTION
Closes #529. Adds a whole-job runtime summary, per-endpoint runtime cards, and per-phase endpoint timing metadata for Proxbox sync jobs. Testing: uv run python -m compileall netbox_proxbox tests; rtk ruff check .; rtk ty check proxbox_cli; uv run --extra test pytest tests/.