### PR TITLE
Fix TypeError when adding dashboard widgets

### DIFF
--- a/netbox_proxbox/widgets.py
+++ b/netbox_proxbox/widgets.py
@@ -7,7 +7,6 @@ Each widget performs DB-only reads — no synchronous HTTP calls in ``render()``
 from __future__ import annotations
 
 from django.template.loader import render_to_string
-from django.utils.translation import gettext_lazy as _
 from extras.dashboard.utils import register_widget
 from extras.dashboard.widgets import DashboardWidget
 
@@ -36,8 +35,8 @@ def _safe_count(model, request):
 
 @register_widget
 class ProxboxSyncStatusWidget(DashboardWidget):
-    default_title = _("Proxbox Sync Status")
-    description = _("Last Proxbox sync job status and synced object summary.")
+    default_title = "Proxbox Sync Status"
+    description = "Last Proxbox sync job status and synced object summary."
     width = 6
     height = 4
 
@@ -83,8 +82,8 @@ class ProxboxSyncStatusWidget(DashboardWidget):
 
 @register_widget
 class ProxboxObjectCountsWidget(DashboardWidget):
-    default_title = _("Proxbox Object Counts")
-    description = _("Counts of all Proxbox plugin model objects.")
+    default_title = "Proxbox Object Counts"
+    description = "Counts of all Proxbox plugin model objects."
     width = 4
     height = 4
 
@@ -132,8 +131,8 @@ class ProxboxObjectCountsWidget(DashboardWidget):
 
 @register_widget
 class ProxboxEndpointStatusWidget(DashboardWidget):
-    default_title = _("Proxbox Endpoints")
-    description = _("Overview of configured Proxmox, NetBox, and FastAPI endpoints.")
+    default_title = "Proxbox Endpoints"
+    description = "Overview of configured Proxmox, NetBox, and FastAPI endpoints."
     width = 6
     height = 3
 


### PR DESCRIPTION
## Summary

- Replace `gettext_lazy` (`_()`) with plain strings for `default_title` and `description` on all three dashboard widget classes
- Remove unused `from django.utils.translation import gettext_lazy as _` import
- Fixes `TypeError: __str__ returned non-string (type __proxy__)` when selecting a widget type in the "Add Widget" modal on the NetBox home page

Closes #531

## Root Cause

`DashboardWidget.__str__` returns `self.title`, which inherits from `default_title`. When `default_title` is a `gettext_lazy` proxy object, Django 6.0.4's template rendering calls `str()` on it and gets back a `__proxy__` type instead of a string. NetBox's built-in widgets use plain strings for these attributes.

## Test plan

- [ ] Existing `tests/test_widgets.py` passes (11 AST-level structural tests)
- [ ] Navigate to NetBox home → Unlock Dashboard → Add Widget → verify all three Proxbox widgets appear in the dropdown without errors
- [ ] Add each widget type and confirm it renders correctly