### PR TITLE
fix: set all dashboard widgets to width 4 for single-row layout

### DIFF
--- a/netbox_proxbox/widgets.py
+++ b/netbox_proxbox/widgets.py
@@ -37,7 +37,7 @@ def _safe_count(model, request):
 class ProxboxSyncStatusWidget(DashboardWidget):
     default_title = "Proxbox Sync Status"
     description = "Last Proxbox sync job status and synced object summary."
-    width = 6
+    width = 4
     height = 4
 
     def render(self, request):
@@ -133,7 +133,7 @@ class ProxboxObjectCountsWidget(DashboardWidget):
 class ProxboxEndpointStatusWidget(DashboardWidget):
     default_title = "Proxbox Endpoints"
     description = "Overview of configured Proxmox, NetBox, and FastAPI endpoints."
-    width = 6
+    width = 4
     height = 3
 
     def render(self, request):


### PR DESCRIPTION
Closes #533

## Summary
- Set `ProxboxSyncStatusWidget.width` from 6 → 4
- Set `ProxboxEndpointStatusWidget.width` from 6 → 4
- `ProxboxObjectCountsWidget` was already 4

All three widgets now total 12 columns (4+4+4), fitting exactly on one GridStack row.

## Test plan
- [x] Verified on `netbox.nmulti.cloud` — all three widgets render correctly at width 4
- [x] Inner Bootstrap grids (sync status tiles, object count list, endpoint status columns) are self-contained and unaffected by the narrower widget