### PR TITLE
Pass VM sync run IDs to proxbox-api

### DIFF
--- a/netbox_proxbox/jobs.py
+++ b/netbox_proxbox/jobs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import uuid
 from netbox.constants import RQ_QUEUE_DEFAULT
 from netbox.jobs import JobRunner
 
@@ -546,6 +547,7 @@ class ProxboxSyncJob(JobRunner):
             )
             batch_object_ids = _normalize_batch_object_ids(batch_object_ids)
             run_started = time.monotonic()
+            sync_run_id = str(uuid.uuid4())
             _sync_stage_settings()
 
             try:
@@ -597,6 +599,7 @@ class ProxboxSyncJob(JobRunner):
                 "batch_object_type": batch_object_type,
                 "batch_object_ids": batch_object_ids,
                 "fastapi_endpoint_id": fastapi_endpoint_id,
+                "run_id": sync_run_id,
             }
             self.job.data = {
                 "proxbox_sync": {

--- a/netbox_proxbox/schemas/sync_result.py
+++ b/netbox_proxbox/schemas/sync_result.py
@@ -16,6 +16,7 @@ class SyncJobParams(ProxboxBaseModel):
     netbox_vm_ids: list[str] = Field(default_factory=list)
     batch_object_type: str | None = None
     batch_object_ids: list[str] = Field(default_factory=list)
+    run_id: str | None = None
 
 
 class SyncJobData(ProxboxBaseModel):

--- a/netbox_proxbox/sync_params.py
+++ b/netbox_proxbox/sync_params.py
@@ -215,6 +215,7 @@ def _serialize_sync_params(
     batch_object_type: str | None = None,
     batch_object_ids: list[str] | None = None,
     fastapi_endpoint_id: int | None = None,
+    run_id: str | None = None,
 ) -> dict[str, object]:
     """Return a backward-compatible params block for Job.data."""
     if len(sync_types) == 1:
@@ -235,6 +236,8 @@ def _serialize_sync_params(
     }
     if fastapi_endpoint_id is not None:
         result["fastapi_endpoint_id"] = fastapi_endpoint_id
+    if run_id:
+        result["run_id"] = run_id
     return result
 
 

--- a/netbox_proxbox/sync_stages.py
+++ b/netbox_proxbox/sync_stages.py
@@ -227,6 +227,7 @@ def _build_stage_query_params(
     sync_type: str,
     target_vm_ids: list[str],
     disable_vm_network_on_vm_stage: bool = False,
+    run_id: str | None = None,
 ) -> dict[str, str]:
     """Build query parameters for a specific sync stage."""
     query_params = dict(base_query)
@@ -237,6 +238,8 @@ def _build_stage_query_params(
     if sync_type == SyncTypeChoices.VIRTUAL_MACHINES and disable_vm_network_on_vm_stage:
         # Full sync runs dedicated VM interface/IP stages; skip network work in VM stage.
         query_params["sync_vm_network"] = "false"
+    if sync_type == SyncTypeChoices.VIRTUAL_MACHINES and run_id:
+        query_params["run_id"] = run_id
     if target_vm_ids:
         query_params["netbox_vm_ids"] = ",".join(target_vm_ids)
     return query_params
@@ -392,6 +395,7 @@ def _run_all_stages_sync(
     target_vm_ids = [str(x) for x in list(params.get("netbox_vm_ids") or []) if str(x)]
     fastapi_endpoint_id = params.get("fastapi_endpoint_id")
     netbox_branch_schema_id = params.get("netbox_branch_schema_id")
+    sync_run_id = str(params.get("run_id") or "").strip() or None
     disable_vm_network_on_vm_stage = SyncTypeChoices.VIRTUAL_MACHINES in stages and (
         SyncTypeChoices.VM_INTERFACES in stages
         or SyncTypeChoices.IP_ADDRESSES in stages
@@ -416,6 +420,7 @@ def _run_all_stages_sync(
                 st,
                 target_vm_ids,
                 disable_vm_network_on_vm_stage=disable_vm_network_on_vm_stage,
+                run_id=sync_run_id,
             )
             stage_paths = _sync_stream_paths_for_stage(st, target_vm_ids)
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7,6 +7,7 @@ import importlib.util
 import logging
 import sys
 import types
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -978,11 +979,13 @@ def test_proxbox_sync_job_run_targets_each_requested_vm_route(
     monkeypatch, proxbox_sync_job_module
 ):
     paths: list[str] = []
+    captured_query_params: list[dict[str, object]] = []
 
     services_mod = types.ModuleType("netbox_proxbox.services")
 
     def run_sync_stream(path, query_params=None, **stream_kwargs):
         paths.append(path)
+        captured_query_params.append(dict(query_params or {}))
         return ({"stream": True, "response": {"ok": True}}, 200)
 
     services_mod.run_sync_stream = run_sync_stream
@@ -1005,6 +1008,9 @@ def test_proxbox_sync_job_run_targets_each_requested_vm_route(
         "virtualization/virtual-machines/512/create/stream",
         "virtualization/virtual-machines/777/create/stream",
     ]
+    run_ids = {str(qp["run_id"]) for qp in captured_query_params}
+    assert len(run_ids) == 1
+    assert str(uuid.UUID(next(iter(run_ids)))) == next(iter(run_ids))
 
 
 def test_proxbox_sync_job_query_flag_tracks_plugin_setting(
@@ -1128,6 +1134,14 @@ def test_full_sync_disables_vm_network_inside_virtual_machines_stage(
         if path == "virtualization/virtual-machines/create/stream"
     )
     assert vm_stage["sync_vm_network"] == "false"
+    vm_run_id = str(vm_stage["run_id"])
+    assert str(uuid.UUID(vm_run_id)) == vm_run_id
+    assert job.job.data["proxbox_sync"]["params"]["run_id"] == vm_run_id
+    assert all(
+        "run_id" not in qp
+        for path, qp in captured
+        if path != "virtualization/virtual-machines/create/stream"
+    )
 
 
 def test_vm_only_stage_keeps_default_vm_network_behavior(
@@ -1158,6 +1172,7 @@ def test_vm_only_stage_keeps_default_vm_network_behavior(
         if path == "virtualization/virtual-machines/create/stream"
     )
     assert "sync_vm_network" not in vm_stage
+    assert str(uuid.UUID(str(vm_stage["run_id"]))) == vm_stage["run_id"]
 
 
 def test_proxbox_sync_job_run_all_invokes_each_stage_stream(

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -146,13 +146,20 @@ def test_openapi_summary_rejects_non_object_payload():
 def test_sync_job_data_from_job_reads_nested_params():
     job = SimpleNamespace(
         data={
-            "proxbox_sync": {"params": {"sync_types": ["all"], "netbox_vm_ids": ["1"]}}
+            "proxbox_sync": {
+                "params": {
+                    "sync_types": ["all"],
+                    "netbox_vm_ids": ["1"],
+                    "run_id": "issue-519-run",
+                }
+            }
         }
     )
 
     data = SyncJobData.from_job(job)
     assert data.params.sync_types == ["all"]
     assert data.params.netbox_vm_ids == ["1"]
+    assert data.params.run_id == "issue-519-run"
 
 
 def test_backend_request_context_defaults_headers():


### PR DESCRIPTION
Closes #519.

## Summary
- Generate one VM sync `run_id` per Proxbox sync job.
- Persist the run ID in job data for inspection.
- Send the run ID to VM-stage SSE requests, including targeted per-VM routes.

## Tests
- `uv run ruff check netbox_proxbox/jobs.py netbox_proxbox/sync_stages.py netbox_proxbox/sync_params.py netbox_proxbox/schemas/sync_result.py tests/test_jobs.py tests/test_schemas.py`
- `uv run pytest tests/test_jobs.py tests/test_schemas.py tests/test_sync_params_flag_flattening.py tests/test_vm_sync_device_flag_enforcement.py -q`
- `uv run pytest -q`

## Note
This PR expects the companion backend PR in `emersonfelipesp/proxbox-api` to be merged/released so the forwarded `run_id` is consumed by `proxbox-api`.
