### PR TITLE
Forward Proxmox endpoint tuning to backend

### DIFF
--- a/netbox_proxbox/views/CLAUDE.md
+++ b/netbox_proxbox/views/CLAUDE.md
@@ -5,7 +5,7 @@ This directory implements the plugin's NetBox UI behavior, including dashboard p
 ## Files And Ownership
 
 - [`__init__.py`](./__init__.py): top-level page views and re-exports for endpoint views, cluster views, dashboard pages, sync enqueue actions, status checks, settings/storage views, backup/replication views, snapshot/task views, and job integration helpers.
-- [`backend_sync.py`](./backend_sync.py): shared helper that ensures a Proxmox endpoint is synchronized to proxbox-api before live reads.
+- [`backend_sync.py`](./backend_sync.py): shared helper that ensures a Proxmox endpoint is synchronized to proxbox-api before live reads, including TLS verification and per-endpoint Proxmox request tuning fields.
 - [`dashboard_data.py`](./dashboard_data.py): assembles endpoint and cluster summary data for the dashboard page context.
 - [`mixins.py`](./mixins.py): shared view mixins used across multiple view modules.
 - [`resource_list_views.py`](./resource_list_views.py): list views for resource objects (nodes, VMs, LXC containers, interfaces, IP addresses).

--- a/netbox_proxbox/views/backend_sync.py
+++ b/netbox_proxbox/views/backend_sync.py
@@ -46,6 +46,24 @@ def _related_object_metadata(
     }
 
 
+def _int_or_none(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _float_or_none(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _proxmox_backend_payload(endpoint: ProxmoxEndpoint) -> dict[str, object]:
     """JSON body for POST/PUT ``/proxmox/endpoints`` from a ``ProxmoxEndpoint`` row."""
     return {
@@ -57,6 +75,9 @@ def _proxmox_backend_payload(endpoint: ProxmoxEndpoint) -> dict[str, object]:
         or "root@pam",
         "password": (getattr(endpoint, "password", "") or "").strip() or None,
         "verify_ssl": bool(getattr(endpoint, "verify_ssl", False)),
+        "timeout": _int_or_none(getattr(endpoint, "timeout", None)),
+        "max_retries": _int_or_none(getattr(endpoint, "max_retries", None)),
+        "retry_backoff": _float_or_none(getattr(endpoint, "retry_backoff", None)),
         "token_name": (getattr(endpoint, "token_name", "") or "").strip() or None,
         "token_value": (getattr(endpoint, "token_value", "") or "").strip() or None,
         **_related_object_metadata("site", getattr(endpoint, "site", None)),

--- a/tests/test_backend_sync_placement.py
+++ b/tests/test_backend_sync_placement.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 import types
+from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -63,6 +64,9 @@ def test_proxmox_backend_payload_includes_site_and_tenant_metadata(monkeypatch) 
         username="root@pam",
         password="secret",
         verify_ssl=False,
+        timeout=30,
+        max_retries=3,
+        retry_backoff=Decimal("1.25"),
         token_name=None,
         token_value=None,
         site=SimpleNamespace(pk=42, slug="dc1", name="DC 1"),
@@ -71,6 +75,10 @@ def test_proxmox_backend_payload_includes_site_and_tenant_metadata(monkeypatch) 
 
     payload = backend_sync._proxmox_backend_payload(endpoint)
 
+    assert payload["verify_ssl"] is False
+    assert payload["timeout"] == 30
+    assert payload["max_retries"] == 3
+    assert payload["retry_backoff"] == 1.25
     assert payload["site_id"] == 42
     assert payload["site_slug"] == "dc1"
     assert payload["site_name"] == "DC 1"


### PR DESCRIPTION
Refs emersonfelipesp/proxbox-api#211

## Summary
- Include Proxmox endpoint verify_ssl, timeout, max_retries, and retry_backoff in the payload sent to proxbox-api before live reads.
- Coerce numeric endpoint tuning values to JSON-safe int/float values.
- Document the backend_sync payload behavior in the scoped views guide.

## Tests
- uv run pytest tests/test_backend_sync_placement.py
- uv run ruff check netbox_proxbox/views/backend_sync.py tests/test_backend_sync_placement.py
- uv run ruff format --check netbox_proxbox/views/backend_sync.py tests/test_backend_sync_placement.py