### PR TITLE
fix: replace multi-line {# #} template comment with {% comment %} block tag

### DIFF
--- a/netbox_proxbox/services/service_status.py
+++ b/netbox_proxbox/services/service_status.py
@@ -150,7 +150,10 @@ def _maybe_update_proxmox_endpoint_mode(
             return
 
         now = time.monotonic()
-        if now - _last_proxmox_mode_check.get(pk, 0.0) < _PROXMOX_MODE_CHECK_THROTTLE_SECONDS:
+        if (
+            now - _last_proxmox_mode_check.get(pk, 0.0)
+            < _PROXMOX_MODE_CHECK_THROTTLE_SECONDS
+        ):
             return
 
         from netbox_proxbox.schemas import ProxmoxClusterStatusResponse  # noqa: PLC0415

--- a/netbox_proxbox/templates/netbox_proxbox/home.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home.html
@@ -13,9 +13,9 @@
     {% if active_proxbox_job %}
         {% include "netbox_proxbox/inc/job_log_assets.html" %}
     {% endif %}
-    {# Dashboard hydration is inlined (issue #355) so logos, status badges,
+    {% comment %}Dashboard hydration is inlined (issue #355) so logos, status badges,
        and cluster cards render even when ``manage.py collectstatic`` was
-       not run after installing/upgrading the plugin. #}
+       not run after installing/upgrading the plugin.{% endcomment %}
     <script>{% inline_static_script 'netbox_proxbox/js/home_inline.js' %}</script>
     {% if quick_schedule_form %}
         <link rel="stylesheet" href="{% static 'netbox_proxbox/css/quick_schedule_home.css' %}">

--- a/netbox_proxbox/views/home_context.py
+++ b/netbox_proxbox/views/home_context.py
@@ -20,7 +20,11 @@ from netbox_proxbox.schedule_hints import (
     has_recurring_proxbox_sync_all,
     quick_schedule_home_form_kwargs,
 )
-from netbox_proxbox.tables import FastAPIEndpointTable, NetBoxEndpointTable, ProxmoxEndpointTable
+from netbox_proxbox.tables import (
+    FastAPIEndpointTable,
+    NetBoxEndpointTable,
+    ProxmoxEndpointTable,
+)
 from netbox_proxbox.utils import get_fastapi_url
 from netbox_proxbox.views.proxbox_access import permission_enqueue_proxbox_sync
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -505,6 +505,9 @@ def load_plugin_module(
         def __init__(self, *args, **kwargs):
             pass
 
+        def configure(self, request):
+            pass
+
     django_tables2_mod.Table = _StubTable
     for _col_name in ("Column", "LinkColumn", "TemplateColumn", "CheckBoxColumn"):
         setattr(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -495,6 +495,52 @@ def load_plugin_module(
 
     utils_module.resolve_vm_type = _resolve_vm_type_stub
 
+    # django_tables2 stub — needed by netbox_proxbox.tables which home_context imports.
+    django_tables2_mod = types.ModuleType("django_tables2")
+
+    class _StubTable:
+        class Meta:
+            pass
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    django_tables2_mod.Table = _StubTable
+    for _col_name in ("Column", "LinkColumn", "TemplateColumn", "CheckBoxColumn"):
+        setattr(
+            django_tables2_mod,
+            _col_name,
+            type(_col_name, (), {"__init__": lambda s, *a, **kw: None}),
+        )
+
+    netbox_tables_mod = types.ModuleType("netbox.tables")
+
+    class _StubNetBoxTable(_StubTable):
+        pass
+
+    netbox_tables_mod.NetBoxTable = _StubNetBoxTable
+    netbox_tables_mod.ChoiceFieldColumn = type(
+        "ChoiceFieldColumn", (), {"__init__": lambda s, *a, **kw: None}
+    )
+    netbox_tables_columns_mod = types.ModuleType("netbox.tables.columns")
+    netbox_tables_columns_mod.BooleanColumn = type(
+        "BooleanColumn", (), {"__init__": lambda s, *a, **kw: None}
+    )
+    netbox_tables_columns_mod.ColoredLabelColumn = type(
+        "ColoredLabelColumn", (), {"__init__": lambda s, *a, **kw: None}
+    )
+
+    nbp_tables_mod = types.ModuleType("netbox_proxbox.tables")
+    nbp_tables_mod.FastAPIEndpointTable = type(
+        "FastAPIEndpointTable", (_StubNetBoxTable,), {}
+    )
+    nbp_tables_mod.NetBoxEndpointTable = type(
+        "NetBoxEndpointTable", (_StubNetBoxTable,), {}
+    )
+    nbp_tables_mod.ProxmoxEndpointTable = type(
+        "ProxmoxEndpointTable", (_StubNetBoxTable,), {}
+    )
+
     stub_modules = {
         "django": django_module,
         "django.http": django_http,
@@ -530,6 +576,10 @@ def load_plugin_module(
         "netbox_proxbox.utils": utils_module,
         "utilities.permissions": utilities_permissions,
         "utilities.views": utilities_views,
+        "django_tables2": django_tables2_mod,
+        "netbox.tables": netbox_tables_mod,
+        "netbox.tables.columns": netbox_tables_columns_mod,
+        "netbox_proxbox.tables": nbp_tables_mod,
     }
 
     django_rq_mod = types.ModuleType("django_rq")

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -31,6 +31,24 @@ def test_runtime_code_no_longer_depends_on_django_htmx():
         assert "hx-" not in contents
 
 
+def test_home_template_comment_is_not_multiline_inline_syntax():
+    """Django's {# #} syntax only suppresses single-line comments; multi-line
+    {# ... #} blocks are not recognised as comments and the raw text is emitted
+    into the rendered HTML, which browsers can display visibly.  This test
+    ensures the issue-#355 explanation comment uses the correct block-comment
+    tag so it never leaks to the page.
+
+    See https://github.com/emersonfelipesp/netbox-proxbox/issues/541
+    """
+    contents = _read("netbox_proxbox/templates/netbox_proxbox/home.html")
+    # The comment text must NOT appear as a bare inline {# ... #} comment.
+    assert "{# Dashboard hydration is inlined" not in contents
+    # It must use the block comment tag that Django supports across multiple lines.
+    assert "{% comment %}" in contents
+    assert "Dashboard hydration is inlined" in contents
+    assert "{% endcomment %}" in contents
+
+
 def test_home_template_uses_plugin_vanilla_js_entrypoint():
     contents = _read("netbox_proxbox/templates/netbox_proxbox/home.html")
     assert "netbox_proxbox/home/quick_schedule_banner.html" in contents

--- a/tests/test_keepalive_status.py
+++ b/tests/test_keepalive_status.py
@@ -455,6 +455,9 @@ def test_proxmox_status_uses_domain_query_when_available(
     )
     ss = _service_status_module()
     monkeypatch.setattr(ss.time, "sleep", lambda seconds: None)
+    # Ensure the 5-minute throttle check never fires on freshly started CI runners
+    # where time.monotonic() may still be below the throttle threshold.
+    monkeypatch.setattr(ss.time, "monotonic", lambda: 1_000_000)
     monkeypatch.setattr(
         ss,
         "sync_proxmox_endpoint_to_backend",
@@ -514,6 +517,8 @@ def test_proxmox_status_uses_ip_query_when_domain_missing(
         proxmox_endpoint=proxmox_endpoint,
     )
     ss = _service_status_module()
+    # Ensure the 5-minute throttle check never fires on freshly started CI runners.
+    monkeypatch.setattr(ss.time, "monotonic", lambda: 1_000_000)
     monkeypatch.setattr(
         ss,
         "sync_proxmox_endpoint_to_backend",
@@ -806,6 +811,8 @@ def test_proxmox_mode_detected_on_successful_keepalive(
     )
     ss = _service_status_module()
     monkeypatch.setattr(ss.time, "sleep", lambda seconds: None)
+    # Ensure the 5-minute throttle check never fires on freshly started CI runners.
+    monkeypatch.setattr(ss.time, "monotonic", lambda: 1_000_000)
     monkeypatch.setattr(
         ss,
         "sync_proxmox_endpoint_to_backend",

--- a/tests/test_keepalive_status.py
+++ b/tests/test_keepalive_status.py
@@ -815,11 +815,13 @@ def test_proxmox_mode_detected_on_successful_keepalive(
 
     def fake_get(url, verify=True, timeout=None, params=None, headers=None):
         if url.endswith("/proxmox/cluster/status"):
-            return ResponseStub([
-                {"type": "cluster", "name": "pve-cluster"},
-                {"type": "node", "name": "pve01"},
-                {"type": "node", "name": "pve02"},
-            ])
+            return ResponseStub(
+                [
+                    {"type": "cluster", "name": "pve-cluster"},
+                    {"type": "node", "name": "pve01"},
+                    {"type": "node", "name": "pve02"},
+                ]
+            )
         return ResponseStub([{"pve01": {"version": "8.3.0"}}])
 
     monkeypatch.setattr(ss.requests, "get", fake_get)


### PR DESCRIPTION
## Summary

- Converts the three-line `{# ... #}` comment in `home.html` (lines 16-18) to `{% comment %}...{% endcomment %}`.
- Adds a regression test to `test_frontend_contracts.py` that asserts the old inline syntax is absent and the block comment tag is present.

## Root Cause

Django's inline comment tokenizer uses the regex `\{#.*?#\}` **without `re.DOTALL`**, so `.` cannot cross newlines. A comment that spans multiple lines is never matched — the raw `{# … #}` text is emitted into the rendered HTML as a text node. When the browser encounters that text inside `<head>`, it implicitly closes `<head>` and renders the fragment visibly in `<body>`.

The three-line issue-#355 explanation comment in `home.html` was hitting exactly this path. Users on version 0.0.18 saw the following text on the dashboard page:

> 355) so logos, status badges, and cluster cards render even when ``manage.py collectstatic`` was not run after installing/upgrading the plugin. #}

`{% comment %} … {% endcomment %}` is the correct multi-line comment construct in Django templates.

## Test Plan

- [x] `python3 -m pytest tests/test_frontend_contracts.py` — 44 passed, 0 failed
- [x] New `test_home_template_comment_is_not_multiline_inline_syntax` test passes and would have caught the regression

Closes #541