### PR TITLE
fix: replace multi-line {# #} template comment with {% comment %} block tag

### DIFF
--- a/netbox_proxbox/templates/netbox_proxbox/home.html
+++ b/netbox_proxbox/templates/netbox_proxbox/home.html
@@ -13,9 +13,9 @@
     {% if active_proxbox_job %}
         {% include "netbox_proxbox/inc/job_log_assets.html" %}
     {% endif %}
-    {# Dashboard hydration is inlined (issue #355) so logos, status badges,
+    {% comment %}Dashboard hydration is inlined (issue #355) so logos, status badges,
        and cluster cards render even when ``manage.py collectstatic`` was
-       not run after installing/upgrading the plugin. #}
+       not run after installing/upgrading the plugin.{% endcomment %}
     <script>{% inline_static_script 'netbox_proxbox/js/home_inline.js' %}</script>
     {% if quick_schedule_form %}
         <link rel="stylesheet" href="{% static 'netbox_proxbox/css/quick_schedule_home.css' %}">

--- a/tests/test_frontend_contracts.py
+++ b/tests/test_frontend_contracts.py
@@ -31,6 +31,24 @@ def test_runtime_code_no_longer_depends_on_django_htmx():
         assert "hx-" not in contents
 
 
+def test_home_template_comment_is_not_multiline_inline_syntax():
+    """Django's {# #} syntax only suppresses single-line comments; multi-line
+    {# ... #} blocks are not recognised as comments and the raw text is emitted
+    into the rendered HTML, which browsers can display visibly.  This test
+    ensures the issue-#355 explanation comment uses the correct block-comment
+    tag so it never leaks to the page.
+
+    See https://github.com/emersonfelipesp/netbox-proxbox/issues/541
+    """
+    contents = _read("netbox_proxbox/templates/netbox_proxbox/home.html")
+    # The comment text must NOT appear as a bare inline {# ... #} comment.
+    assert "{# Dashboard hydration is inlined" not in contents
+    # It must use the block comment tag that Django supports across multiple lines.
+    assert "{% comment %}" in contents
+    assert "Dashboard hydration is inlined" in contents
+    assert "{% endcomment %}" in contents
+
+
 def test_home_template_uses_plugin_vanilla_js_entrypoint():
     contents = _read("netbox_proxbox/templates/netbox_proxbox/home.html")
     assert "netbox_proxbox/home/quick_schedule_banner.html" in contents


### PR DESCRIPTION
## Summary

Converts the three-line `{# ... #}` comment in `home.html` (lines 16-18) to `{% comment %}...{% endcomment %}`, and adds a regression test.

## Root Cause

Django's inline comment tokenizer uses the regex `\{#.*?#\}` **without `re.DOTALL`**, so `.` cannot cross newlines. A comment that spans multiple lines is never matched — the raw `{# … #}` text is emitted into the rendered HTML as a text node.

When the browser encounters that raw text inside `<head>`, it implicitly closes `<head>` and renders the fragment visibly in `<body>`.

The three-line issue-#355 explanation comment in `home.html` was hitting this path exactly. Users on v0.0.18 saw the following on the dashboard page:

> 355) so logos, status badges, and cluster cards render even when ``manage.py collectstatic`` was not run after installing/upgrading the plugin. #}

`{% comment %} … {% endcomment %}` is the correct multi-line comment construct in Django templates.

## Test Plan

- [x] `python3 -m pytest tests/test_frontend_contracts.py` — 44 passed, 0 failed
- [x] New `test_home_template_comment_is_not_multiline_inline_syntax` test added

Closes #541