### PR TITLE
fix: resolve 3 plugin–backend integration issues

### DIFF
--- a/netbox_proxbox/models/fastapi_endpoint.py
+++ b/netbox_proxbox/models/fastapi_endpoint.py
@@ -139,9 +139,24 @@ class FastAPIEndpoint(EndpointBase):
         is_new_token = not (self.token or "").strip()
         if is_new_token:
             self.token = secrets.token_urlsafe(48)
+
+        # Detect an explicit token change on an existing row so we can re-register.
+        token_explicitly_changed = False
+        if self.pk and not is_new_token:
+            try:
+                prior = type(self).objects.only("token").get(pk=self.pk)
+                token_explicitly_changed = bool(prior.token) and prior.token != self.token
+            except type(self).DoesNotExist:
+                pass
+
         super().save(*args, **kwargs)
         if is_new_token:
             self._register_key_with_backend()
+        elif token_explicitly_changed:
+            # Force-register the new token even though the backend already has keys.
+            # This handles the case where the backend key was rotated and the operator
+            # sets a fresh token value here to re-synchronise.
+            self._register_key_with_backend(skip_bootstrap_check=True)
 
     def _is_bootstrap_needed(self, base_url: str) -> bool:
         """Check whether the proxbox-api backend still needs its API key bootstrapped."""
@@ -159,8 +174,14 @@ class FastAPIEndpoint(EndpointBase):
             logger.debug("Could not check bootstrap status: %s", exc)
         return True
 
-    def _register_key_with_backend(self) -> None:
-        """Best-effort: register the auto-generated token with the proxbox-api backend."""
+    def _register_key_with_backend(self, skip_bootstrap_check: bool = False) -> None:
+        """Best-effort: register the current token with the proxbox-api backend.
+
+        Args:
+            skip_bootstrap_check: When True, register even if the backend already has
+                keys (used when the operator explicitly sets a new token value to
+                re-synchronise after a backend key rotation).
+        """
         from netbox_proxbox.utils import get_fastapi_url
 
         try:
@@ -170,7 +191,7 @@ class FastAPIEndpoint(EndpointBase):
                 logger.warning("No FastAPI URL configured, cannot register API key.")
                 return
 
-            if not self._is_bootstrap_needed(base_url):
+            if not skip_bootstrap_check and not self._is_bootstrap_needed(base_url):
                 logger.debug(
                     "proxbox-api already has API key configured; skipping registration."
                 )

--- a/netbox_proxbox/models/fastapi_endpoint.py
+++ b/netbox_proxbox/models/fastapi_endpoint.py
@@ -145,7 +145,9 @@ class FastAPIEndpoint(EndpointBase):
         if self.pk and not is_new_token:
             try:
                 prior = type(self).objects.only("token").get(pk=self.pk)
-                token_explicitly_changed = bool(prior.token) and prior.token != self.token
+                token_explicitly_changed = (
+                    bool(prior.token) and prior.token != self.token
+                )
             except type(self).DoesNotExist:
                 pass
 

--- a/netbox_proxbox/models/pbs_endpoint.py
+++ b/netbox_proxbox/models/pbs_endpoint.py
@@ -97,6 +97,26 @@ class PBSEndpoint(EndpointBase):
             ),
         )
 
+    @property
+    def host(self) -> str:
+        """Plain hostname string expected by proxbox-api's PBSEndpoint SQLite model.
+
+        proxbox-api stores endpoints with a single ``host`` field; the Django model
+        uses ``domain`` and ``ip_address`` from ``EndpointBase``. This property
+        provides a compatible value so sync code can use the same field name.
+        """
+        return self.domain or self.ip or ""
+
+    @property
+    def timeout_seconds(self) -> int:
+        """Timeout in seconds matching proxbox-api's ``PBSEndpoint.timeout_seconds`` field.
+
+        proxbox-api names the field ``timeout_seconds``; Django uses ``timeout``.
+        This property bridges the name difference so sync code can reference either
+        model interchangeably.
+        """
+        return self.timeout if self.timeout is not None else 30
+
     def get_absolute_url(self) -> str:
         """Plugin UI URL for this PBS endpoint detail view.
 

--- a/netbox_proxbox/models/pdm_endpoint.py
+++ b/netbox_proxbox/models/pdm_endpoint.py
@@ -124,6 +124,26 @@ class PDMEndpoint(EndpointBase):
             ),
         )
 
+    @property
+    def host(self) -> str:
+        """Plain hostname string expected by proxbox-api's PDMEndpoint SQLite model.
+
+        proxbox-api stores endpoints with a single ``host`` field; the Django model
+        uses ``domain`` and ``ip_address`` from ``EndpointBase``. This property
+        provides a compatible value so sync code can use the same field name.
+        """
+        return self.domain or self.ip or ""
+
+    @property
+    def timeout_seconds(self) -> int:
+        """Timeout in seconds matching proxbox-api's ``PDMEndpoint.timeout_seconds`` field.
+
+        proxbox-api names the field ``timeout_seconds``; Django uses ``timeout``.
+        This property bridges the name difference so sync code can reference either
+        model interchangeably.
+        """
+        return self.timeout if self.timeout is not None else 30
+
     def get_absolute_url(self) -> str:
         """Plugin UI URL for this PDM endpoint detail view.
 


### PR DESCRIPTION
## Summary

Fixes 3 issues found during a cross-repo database compatibility review between `netbox-proxbox develop` and `proxbox-api main`.

- **`FastAPIEndpoint` token drift after backend key rotation** — `save()` only registered the token with the backend when `self.token` was blank (new record). If the proxbox-api backend key was later rotated via its admin UI, the Django token became permanently stale: `_is_bootstrap_needed()` returns `False` once the backend has any keys, so re-registration was silently skipped, causing 401 on all subsequent plugin→backend calls with no recovery path. Now, when an operator explicitly sets a new token value on an existing row (detected by comparing `prior.token != self.token`), `_register_key_with_backend(skip_bootstrap_check=True)` is called to force-register the new token regardless of backend key state.
- **`PBSEndpoint.host` property** — proxbox-api's SQLite `PBSEndpoint` stores the address as a `host: str` field; the Django model uses `ip_address` (FK) and `domain` from `EndpointBase`. Added a `host` property that returns `domain or ip or ""`, bridging the field-name difference for future sync code.
- **`PBSEndpoint.timeout_seconds` / `PDMEndpoint.timeout_seconds` properties** — proxbox-api names the timeout field `timeout_seconds`; Django uses `timeout`. Added `timeout_seconds` properties to both models (returning `self.timeout or 30`) so sync code can reference the same name on both sides.
- Same `host` and `timeout_seconds` properties added to `PDMEndpoint`.

## Test plan

- [ ] `python3 -m py_compile netbox_proxbox/models/fastapi_endpoint.py netbox_proxbox/models/pbs_endpoint.py netbox_proxbox/models/pdm_endpoint.py` — no errors
- [ ] `ruff check netbox_proxbox/models/fastapi_endpoint.py netbox_proxbox/models/pbs_endpoint.py netbox_proxbox/models/pdm_endpoint.py` — passes
- [ ] Create a `FastAPIEndpoint`, confirm token registered. Then update the row with a new token value. Confirm `_register_key_with_backend(skip_bootstrap_check=True)` is called and new token is accepted by backend.
- [ ] Verify `PBSEndpoint().host` returns the domain if set, otherwise the IP string
- [ ] Verify `PBSEndpoint().timeout_seconds` returns the configured `timeout` value, or 30 when `timeout` is `None`