### PR TITLE
fix: scope dashboard and status live reads to one endpoint by stable identity

### DIFF
--- a/netbox_proxbox/services/CLAUDE.md
+++ b/netbox_proxbox/services/CLAUDE.md
@@ -43,9 +43,13 @@ identity**, not its NetBox primary key:
   overwrite/sync-mode resolution but translates them to backend ids for the wire
   `proxmox_endpoint_ids` param via `_resolve_wire_endpoint_ids()`; an endpoint
   that does not resolve is skipped with a fail-loud `endpoint-scope` error stage.
-- Dashboards already scope live reads by `domain`/`ip_address` (endpoint-unique),
-  so they need no pk translation; `views/dashboard_data.py::build_local_node_rows`
-  bounds its name fallback to `proxmox_cluster__endpoint=<this endpoint>`.
+- Dashboard card, endpoint status, and dashboard per-endpoint live reads also
+  resolve the backend id via `resolve_backend_endpoint_id()` and send
+  `?proxmox_endpoint_ids=<backend_id>` to proxbox-api. They do **not** fall back
+  to `domain`/`ip_address` selectors, so duplicate Proxmox domains and stale
+  backend endpoint rows cannot bind reads to the first matching session.
+  `views/dashboard_data.py::build_local_node_rows` bounds its name fallback to
+  `proxmox_cluster__endpoint=<this endpoint>`.
 
 `schemas/proxmox_node.py::ProxmoxClusterStatusResponse` flattens the backend's
 nested `node_list` (one cluster object per session) into top-level node records,

--- a/netbox_proxbox/services/service_status.py
+++ b/netbox_proxbox/services/service_status.py
@@ -129,6 +129,28 @@ def sync_proxmox_endpoint_to_backend(
     )
 
 
+def resolve_backend_endpoint_id(
+    endpoint: ProxmoxEndpoint,
+    *,
+    base_url: str,
+    auth_headers: dict[str, str] | None = None,
+    backend_verify_ssl: bool = True,
+    timeout: int = 15,
+) -> tuple[int | None, str | None]:
+    """Compatibility wrapper for callers that patch this service module symbol."""
+    from netbox_proxbox.views.backend_sync import (  # noqa: PLC0415
+        resolve_backend_endpoint_id as _resolve,
+    )
+
+    return _resolve(
+        endpoint,
+        base_url=base_url,
+        auth_headers=auth_headers,
+        backend_verify_ssl=backend_verify_ssl,
+        timeout=timeout,
+    )
+
+
 def _maybe_update_proxmox_endpoint_mode(
     endpoint: ProxmoxEndpoint,
     base_url: str,
@@ -647,11 +669,29 @@ class ServiceStatus:
         authentication = "success"
 
         url = f"{base_url}/proxmox/version"
-        query_params = {"source": "database"}
-        if proxmox_domain:
-            query_params["domain"] = proxmox_domain
-        else:
-            query_params["ip_address"] = proxmox_ip_address
+        backend_endpoint_id, resolve_error = resolve_backend_endpoint_id(
+            proxmox_service_obj,
+            base_url=base_url,
+            auth_headers=request_headers,
+            backend_verify_ssl=backend_verify_ssl,
+            timeout=self.request_timeout,
+        )
+        if backend_endpoint_id is None:
+            self._set_error(
+                resolve_error
+                or "Failed to resolve Proxmox endpoint on ProxBox backend."
+            )
+            return status, ServiceCheckResult(
+                target_address=target_address,
+                target_port=target_port,
+                authentication=authentication,
+                api_access="error",
+                detail=self.last_error_detail,
+            )
+        query_params = {
+            "source": "database",
+            "proxmox_endpoint_ids": str(backend_endpoint_id),
+        }
 
         for attempt in range(max_retries):
             try:

--- a/netbox_proxbox/views/cards.py
+++ b/netbox_proxbox/views/cards.py
@@ -16,7 +16,10 @@ from netbox_proxbox.utils import (
     get_fastapi_url,
     get_ip_address_host,
 )
-from netbox_proxbox.views.backend_sync import sync_proxmox_endpoint_to_backend
+from netbox_proxbox.views.backend_sync import (
+    resolve_backend_endpoint_id,
+    sync_proxmox_endpoint_to_backend,
+)
 from netbox_proxbox.views.error_utils import (
     extract_proxmox_backend_error_detail,
     parse_requests_response_json,
@@ -109,11 +112,6 @@ class ProxboxProxmoxCardView(
         domain = (proxmox_object.domain or "").strip()
         ip_address = get_ip_address_host(proxmox_object.ip_address)
         proxmox_host = domain or ip_address
-        query_params = {"source": "database"}
-        if domain:
-            query_params["domain"] = domain
-        else:
-            query_params["ip_address"] = ip_address
 
         version_endpoint = f"{fastapi_url}/proxmox/version"
         cluster_endpoint = f"{fastapi_url}/proxmox/sessions"
@@ -148,6 +146,39 @@ class ProxboxProxmoxCardView(
             if sync_http_status is not None:
                 payload["http_status"] = sync_http_status
             return JsonResponse(payload)
+
+        backend_endpoint_id, resolve_error = resolve_backend_endpoint_id(
+            proxmox_object,
+            base_url=fastapi_url,
+            auth_headers=backend_headers,
+            backend_verify_ssl=backend_verify_ssl,
+            timeout=5,
+        )
+        if backend_endpoint_id is None:
+            return JsonResponse(
+                {
+                    "cluster_data": {},
+                    "object": {
+                        "pk": getattr(
+                            proxmox_object,
+                            "pk",
+                            getattr(proxmox_object, "id", None),
+                        ),
+                        "name": proxmox_object.name,
+                        "domain": proxmox_object.domain,
+                        "ip_address": str(proxmox_object.ip_address)
+                        if proxmox_object.ip_address
+                        else None,
+                    },
+                    "detail": resolve_error
+                    or "Failed to resolve Proxmox endpoint on ProxBox backend.",
+                }
+            )
+
+        query_params = {
+            "source": "database",
+            "proxmox_endpoint_ids": str(backend_endpoint_id),
+        }
 
         try:
             version_response = requests.get(

--- a/netbox_proxbox/views/dashboard.py
+++ b/netbox_proxbox/views/dashboard.py
@@ -13,7 +13,10 @@ from virtualization.models import Cluster
 import netbox_proxbox.views.dashboard_data as dashboard_data
 from netbox_proxbox.models import FastAPIEndpoint, ProxmoxEndpoint, ProxmoxNode
 from netbox_proxbox.utils import get_backend_auth_headers, get_fastapi_url
-from netbox_proxbox.views.backend_sync import sync_proxmox_endpoint_to_backend
+from netbox_proxbox.views.backend_sync import (
+    resolve_backend_endpoint_id,
+    sync_proxmox_endpoint_to_backend,
+)
 from netbox_proxbox.views.error_utils import (
     extract_proxmox_backend_error_detail,
     parse_requests_response_json,
@@ -47,13 +50,10 @@ class DashboardView(
     template_name = "netbox_proxbox/dashboard.html"
     request_timeout = 8
 
-    def _endpoint_query_params(self, endpoint: ProxmoxEndpoint) -> dict[str, str]:
-        domain = (endpoint.domain or "").strip()
-        if domain:
-            return {"source": "database", "domain": domain}
+    def _endpoint_query_params(self, backend_endpoint_id: int) -> dict[str, str]:
         return {
             "source": "database",
-            "ip_address": str(endpoint.ip_address).split("/")[0],
+            "proxmox_endpoint_ids": str(backend_endpoint_id),
         }
 
     def _fetch_json(
@@ -121,7 +121,22 @@ class DashboardView(
                 dashboards.append(dashboard)
                 continue
 
-            query_params = self._endpoint_query_params(endpoint)
+            backend_endpoint_id, resolve_error = resolve_backend_endpoint_id(
+                endpoint,
+                base_url=fastapi_url,
+                auth_headers=backend_headers,
+                backend_verify_ssl=backend_verify_ssl,
+                timeout=self.request_timeout,
+            )
+            if backend_endpoint_id is None:
+                dashboard["detail"] = (
+                    resolve_error
+                    or "Failed to resolve Proxmox endpoint on ProxBox backend."
+                )
+                dashboards.append(dashboard)
+                continue
+
+            query_params = self._endpoint_query_params(backend_endpoint_id)
 
             try:
                 cluster_payload, cluster_err = self._fetch_json(

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import requests
 
-from tests.conftest import ResponseStub, load_plugin_module
+from tests.conftest import ResponseStub, _make_model_class, load_plugin_module
 
 
 def test_get_proxmox_card_merges_cluster_and_version_payloads(
@@ -22,6 +22,11 @@ def test_get_proxmox_card_merges_cluster_and_version_payloads(
         module,
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
+    )
+    monkeypatch.setattr(
+        module,
+        "resolve_backend_endpoint_id",
+        lambda *args, **kwargs: (1, None),
     )
 
     calls = []
@@ -54,20 +59,20 @@ def test_get_proxmox_card_merges_cluster_and_version_payloads(
     assert calls == [
         (
             "https://proxbox.local:8800/proxmox/version",
-            {"source": "database", "domain": "pve.local"},
+            {"source": "database", "proxmox_endpoint_ids": "1"},
             {"Authorization": "Bearer backend-token"},
             True,
         ),
         (
             "https://proxbox.local:8800/proxmox/sessions",
-            {"source": "database", "domain": "pve.local"},
+            {"source": "database", "proxmox_endpoint_ids": "1"},
             {"Authorization": "Bearer backend-token"},
             True,
         ),
     ]
 
 
-def test_get_proxmox_card_uses_ip_query_when_domain_is_empty(
+def test_get_proxmox_card_uses_backend_endpoint_id_when_domain_is_empty(
     monkeypatch,
     fastapi_endpoint,
 ):
@@ -92,6 +97,11 @@ def test_get_proxmox_card_uses_ip_query_when_domain_is_empty(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    monkeypatch.setattr(
+        module,
+        "resolve_backend_endpoint_id",
+        lambda *args, **kwargs: (2, None),
+    )
 
     calls = []
 
@@ -103,7 +113,9 @@ def test_get_proxmox_card_uses_ip_query_when_domain_is_empty(
 
     response = module.get_proxmox_card(None, 1)
     assert response.payload["cluster_data"] == {}
-    assert calls[0][1] == {"source": "database", "ip_address": "10.0.30.139"}
+    assert calls[0][1] == {"source": "database", "proxmox_endpoint_ids": "2"}
+    assert "domain" not in calls[0][1]
+    assert "ip_address" not in calls[0][1]
 
 
 def test_get_proxmox_card_returns_error_detail_on_backend_failure(
@@ -121,6 +133,11 @@ def test_get_proxmox_card_returns_error_detail_on_backend_failure(
         module,
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
+    )
+    monkeypatch.setattr(
+        module,
+        "resolve_backend_endpoint_id",
+        lambda *args, **kwargs: (1, None),
     )
 
     class FailingResponse(ResponseStub):
@@ -160,11 +177,16 @@ def test_get_proxmox_card_normalizes_backend_connection_refused(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    monkeypatch.setattr(
+        module,
+        "resolve_backend_endpoint_id",
+        lambda *args, **kwargs: (1, None),
+    )
 
     def fake_get(url, timeout=None, params=None, headers=None, verify=None):
         raise requests.exceptions.ConnectionError(
             "HTTPConnectionPool(host='10.0.30.207', port=8000): Max retries exceeded "
-            "with url: /proxmox/version?source=database&ip_address=10.0.30.9 "
+            "with url: /proxmox/version?source=database&proxmox_endpoint_ids=1 "
             '(Caused by NewConnectionError("Failed to establish a new connection: '
             '[Errno 111] Connection refused"))'
         )
@@ -178,10 +200,81 @@ def test_get_proxmox_card_normalizes_backend_connection_refused(
         == "ProxBox backend could not connect to the configured Proxmox endpoint "
         "(pve.local:8006). Backend route: https://proxbox.local:8800/proxmox/version. "
         "Upstream error: HTTPConnectionPool(host='10.0.30.207', port=8000): Max "
-        "retries exceeded with url: /proxmox/version?source=database&ip_address=10.0.30.9 "
+        "retries exceeded with url: /proxmox/version?source=database&proxmox_endpoint_ids=1 "
         '(Caused by NewConnectionError("Failed to establish a new connection: '
         '[Errno 111] Connection refused"))'
     )
+
+
+def test_get_proxmox_card_scopes_duplicate_domain_by_backend_id(
+    monkeypatch,
+    fastapi_endpoint,
+):
+    proxmox_endpoint = type(
+        "Obj",
+        (),
+        {
+            "pk": 2,
+            "id": 2,
+            "name": "PVE",
+            "domain": "pve.local",
+            "ip_address": "10.0.30.139/24",
+            "port": 8006,
+        },
+    )()
+    module = load_plugin_module(
+        "netbox_proxbox.views.cards",
+        monkeypatch=monkeypatch,
+        fastapi_endpoint=fastapi_endpoint,
+        proxmox_endpoint=proxmox_endpoint,
+    )
+    module.ProxmoxEndpoint.objects = _make_model_class(
+        "ProxmoxEndpoint",
+        first=proxmox_endpoint,
+        objects_by_pk={2: proxmox_endpoint},
+    ).objects
+    monkeypatch.setattr(
+        module,
+        "sync_proxmox_endpoint_to_backend",
+        lambda *args, **kwargs: (True, None, None),
+    )
+
+    scoped_calls = []
+
+    def fake_get(url, timeout=None, params=None, headers=None, verify=None):
+        if url.endswith("/proxmox/endpoints"):
+            return ResponseStub(
+                [
+                    {"id": 1, "name": "PVE (nb:1)", "domain": "pve.local"},
+                    {"id": 2, "name": "PVE (nb:2)", "domain": "pve.local"},
+                ]
+            )
+        if "/proxmox/version" in url:
+            scoped_calls.append((url, params))
+            return ResponseStub([{"PVE": {"version": "8.3.0"}}])
+        if "/proxmox/sessions" in url:
+            scoped_calls.append((url, params))
+            return ResponseStub([{"name": "PVE", "mode": "cluster"}])
+        raise AssertionError(url)
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
+
+    response = module.get_proxmox_card(None, 2)
+
+    assert response.payload["cluster_data"]["name"] == "PVE"
+    assert scoped_calls == [
+        (
+            "https://proxbox.local:8800/proxmox/version",
+            {"source": "database", "proxmox_endpoint_ids": "2"},
+        ),
+        (
+            "https://proxbox.local:8800/proxmox/sessions",
+            {"source": "database", "proxmox_endpoint_ids": "2"},
+        ),
+    ]
+    for _, params in scoped_calls:
+        assert "domain" not in params
+        assert "ip_address" not in params
 
 
 def test_get_proxmox_card_returns_sync_error_without_requesting_backend(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -64,6 +64,94 @@ def _dashboard_request():
     )
 
 
+def _scope_dashboard_to_backend_id(monkeypatch, module, backend_id=1):
+    monkeypatch.setattr(
+        module,
+        "resolve_backend_endpoint_id",
+        lambda *args, **kwargs: (backend_id, None),
+    )
+
+
+def test_dashboard_live_reads_use_resolved_backend_endpoint_id(
+    monkeypatch,
+    fastapi_endpoint,
+    proxmox_endpoint,
+):
+    module = load_plugin_module(
+        "netbox_proxbox.views.dashboard",
+        monkeypatch=monkeypatch,
+        fastapi_endpoint=fastapi_endpoint,
+        proxmox_endpoint=proxmox_endpoint,
+    )
+    monkeypatch.setattr(
+        module,
+        "sync_proxmox_endpoint_to_backend",
+        lambda *args, **kwargs: (True, None, None),
+    )
+    _scope_dashboard_to_backend_id(monkeypatch, module, backend_id=2)
+    monkeypatch.setattr(module.ProxmoxNode, "objects", _NodeQuerySet(), raising=False)
+
+    scoped_calls = []
+
+    def fake_get(url, timeout=None, params=None, headers=None, verify=None):
+        scoped_calls.append((url, params))
+        if "/proxmox/cluster/status" in url:
+            return ResponseStub(
+                [
+                    {
+                        "type": "cluster",
+                        "name": "pve-cluster",
+                        "nodes": 1,
+                        "quorate": 1,
+                    },
+                    {"type": "node", "name": "pve-01", "status": "online", "online": 1},
+                ]
+            )
+        if "/proxmox/cluster/resources" in url:
+            return ResponseStub([])
+        if "/proxmox/nodes/" in url:
+            return ResponseStub(
+                [
+                    {
+                        "node": "pve-01",
+                        "status": "online",
+                        "uptime": 60,
+                        "cpu": 0.1,
+                        "maxcpu": 4,
+                        "loadavg": [0.0, 0.0, 0.0],
+                        "mem": 1 * 1024**3,
+                        "maxmem": 8 * 1024**3,
+                        "disk": 10 * 1024**3,
+                        "maxdisk": 50 * 1024**3,
+                    }
+                ]
+            )
+        raise AssertionError(url)
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
+
+    response = module.DashboardView.as_view()(_dashboard_request())
+
+    assert response["context"]["dashboards"][0]["detail"] is None
+    assert scoped_calls == [
+        (
+            "https://proxbox.local:8800/proxmox/cluster/status",
+            {"source": "database", "proxmox_endpoint_ids": "2"},
+        ),
+        (
+            "https://proxbox.local:8800/proxmox/cluster/resources",
+            {"source": "database", "proxmox_endpoint_ids": "2"},
+        ),
+        (
+            "https://proxbox.local:8800/proxmox/nodes/",
+            {"source": "database", "proxmox_endpoint_ids": "2"},
+        ),
+    ]
+    for _, params in scoped_calls:
+        assert "domain" not in params
+        assert "ip_address" not in params
+
+
 def test_dashboard_nodes_summary_uses_all_persisted_nodes(
     monkeypatch,
     fastapi_endpoint,
@@ -80,6 +168,7 @@ def test_dashboard_nodes_summary_uses_all_persisted_nodes(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    _scope_dashboard_to_backend_id(monkeypatch, module)
     monkeypatch.setattr(
         module.ProxmoxNode,
         "objects",
@@ -181,6 +270,7 @@ def test_dashboard_nodes_summary_falls_back_to_live_payload_when_needed(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    _scope_dashboard_to_backend_id(monkeypatch, module)
     monkeypatch.setattr(module.ProxmoxNode, "objects", _NodeQuerySet(), raising=False)
 
     def fake_get(url, timeout=None, params=None, headers=None, verify=None):
@@ -266,6 +356,7 @@ def test_dashboard_nodes_summary_includes_live_nodes_missing_from_database(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    _scope_dashboard_to_backend_id(monkeypatch, module)
     monkeypatch.setattr(
         module.ProxmoxNode,
         "objects",
@@ -371,6 +462,7 @@ def test_dashboard_nodes_summary_includes_cluster_sibling_nodes_from_database(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    _scope_dashboard_to_backend_id(monkeypatch, module)
 
     cluster = SimpleNamespace(name="pve-cluster")
     sibling_endpoint = SimpleNamespace(name="pve-02-endpoint")
@@ -482,6 +574,7 @@ def test_dashboard_includes_cluster_siblings_via_proxmox_cluster_endpoint(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    _scope_dashboard_to_backend_id(monkeypatch, module)
 
     # pve-01 is directly linked to the endpoint; pve-02 has its proxmox_cluster
     # owned by the same endpoint but its own endpoint FK is a sibling endpoint.
@@ -586,6 +679,7 @@ def test_dashboard_object_summaries_present_in_context(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    _scope_dashboard_to_backend_id(monkeypatch, module)
     monkeypatch.setattr(module.ProxmoxNode, "objects", _NodeQuerySet(), raising=False)
 
     def fake_get(url, timeout=None, params=None, headers=None, verify=None):
@@ -660,6 +754,7 @@ def test_dashboard_cluster_summary_preserves_api_totals_when_live_rows_truncated
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    _scope_dashboard_to_backend_id(monkeypatch, module)
     monkeypatch.setattr(module.ProxmoxNode, "objects", _NodeQuerySet(), raising=False)
 
     def fake_get(url, timeout=None, params=None, headers=None, verify=None):
@@ -739,6 +834,7 @@ def test_dashboard_nodes_include_placeholders_for_unsynced_cluster_members(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    _scope_dashboard_to_backend_id(monkeypatch, module)
     monkeypatch.setattr(module.ProxmoxNode, "objects", _NodeQuerySet(), raising=False)
 
     def fake_get(url, timeout=None, params=None, headers=None, verify=None):

--- a/tests/test_keepalive_status.py
+++ b/tests/test_keepalive_status.py
@@ -442,7 +442,7 @@ def test_extract_error_detail_rewrites_timeout_to_clear_backend_message(
     assert "Verify network reachability" in detail
 
 
-def test_proxmox_status_uses_domain_query_when_available(
+def test_proxmox_status_uses_backend_endpoint_id_query_when_domain_available(
     monkeypatch,
     fastapi_endpoint,
     proxmox_endpoint,
@@ -459,6 +459,11 @@ def test_proxmox_status_uses_domain_query_when_available(
         ss,
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
+    )
+    monkeypatch.setattr(
+        ss,
+        "resolve_backend_endpoint_id",
+        lambda *args, **kwargs: (11, None),
     )
     monkeypatch.setattr(ss, "_last_proxmox_mode_check", {})
     requested = []
@@ -482,20 +487,20 @@ def test_proxmox_status_uses_domain_query_when_available(
     assert requested == [
         (
             "https://proxbox.local:8800/proxmox/version",
-            {"source": "database", "domain": "pve.local"},
+            {"source": "database", "proxmox_endpoint_ids": "11"},
             {"Authorization": "Bearer backend-token"},
             True,
         ),
         (
             "https://proxbox.local:8800/proxmox/cluster/status",
-            {"source": "database", "domain": "pve.local"},
+            {"source": "database", "proxmox_endpoint_ids": "11"},
             {"Authorization": "Bearer backend-token"},
             True,
         ),
     ]
 
 
-def test_proxmox_status_uses_ip_query_when_domain_missing(
+def test_proxmox_status_uses_backend_endpoint_id_query_when_domain_missing(
     monkeypatch,
     fastapi_endpoint,
 ):
@@ -519,6 +524,11 @@ def test_proxmox_status_uses_ip_query_when_domain_missing(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    monkeypatch.setattr(
+        ss,
+        "resolve_backend_endpoint_id",
+        lambda *args, **kwargs: (12, None),
+    )
     monkeypatch.setattr(ss, "_last_proxmox_mode_check", {})
     requested = []
 
@@ -541,17 +551,94 @@ def test_proxmox_status_uses_ip_query_when_domain_missing(
     assert requested == [
         (
             "https://proxbox.local:8800/proxmox/version",
-            {"source": "database", "ip_address": "10.0.0.30"},
+            {"source": "database", "proxmox_endpoint_ids": "12"},
             {"Authorization": "Bearer backend-token"},
             False,
         ),
         (
             "https://proxbox.local:8800/proxmox/cluster/status",
-            {"source": "database", "ip_address": "10.0.0.30"},
+            {"source": "database", "proxmox_endpoint_ids": "12"},
             {"Authorization": "Bearer backend-token"},
             False,
         ),
     ]
+
+
+def test_proxmox_status_scopes_duplicate_domain_by_backend_id(
+    monkeypatch,
+    fastapi_endpoint,
+):
+    proxmox_endpoint = SimpleNamespace(
+        id=2,
+        pk=2,
+        name="PVE",
+        domain="pve.local",
+        ip_address="10.0.0.31/24",
+        port=8006,
+        verify_ssl=False,
+        mode="undefined",
+    )
+    load_plugin_module(
+        "netbox_proxbox.views.keepalive_status",
+        monkeypatch=monkeypatch,
+        fastapi_endpoint=fastapi_endpoint,
+        proxmox_endpoint=proxmox_endpoint,
+    )
+    ss = _service_status_module()
+    ss.ProxmoxEndpoint.objects = _make_model_class(
+        "ProxmoxEndpoint",
+        first=proxmox_endpoint,
+        objects_by_pk={2: proxmox_endpoint},
+    ).objects
+    monkeypatch.setattr(ss.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        ss,
+        "sync_proxmox_endpoint_to_backend",
+        lambda *args, **kwargs: (True, None, None),
+    )
+    monkeypatch.setattr(ss, "_last_proxmox_mode_check", {})
+    scoped_calls = []
+
+    def fake_get(url, verify=True, timeout=None, params=None, headers=None):
+        if url.endswith("/proxmox/endpoints"):
+            return ResponseStub(
+                [
+                    {"id": 1, "name": "PVE (nb:1)", "domain": "pve.local"},
+                    {"id": 2, "name": "PVE (nb:2)", "domain": "pve.local"},
+                ]
+            )
+        if url.endswith("/proxmox/version"):
+            scoped_calls.append((url, params))
+            return ResponseStub([{"PVE": {"version": "8.3.0"}}])
+        if url.endswith("/proxmox/cluster/status"):
+            scoped_calls.append((url, params))
+            return ResponseStub([{"type": "node", "name": "pve01"}])
+        raise AssertionError(url)
+
+    monkeypatch.setattr(ss.requests, "get", fake_get)
+
+    status, details = ss.ServiceStatus().proxmox_status(
+        2,
+        "https://proxbox.local:8800",
+        auth_headers={"Authorization": "Bearer backend-token"},
+        backend_verify_ssl=True,
+    )
+
+    assert status == "success"
+    assert details["api_access"] == "success"
+    assert scoped_calls == [
+        (
+            "https://proxbox.local:8800/proxmox/version",
+            {"source": "database", "proxmox_endpoint_ids": "2"},
+        ),
+        (
+            "https://proxbox.local:8800/proxmox/cluster/status",
+            {"source": "database", "proxmox_endpoint_ids": "2"},
+        ),
+    ]
+    for _, params in scoped_calls:
+        assert "domain" not in params
+        assert "ip_address" not in params
 
 
 def test_proxmox_status_normalizes_backend_connection_refused(
@@ -572,11 +659,16 @@ def test_proxmox_status_normalizes_backend_connection_refused(
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
+    monkeypatch.setattr(
+        ss,
+        "resolve_backend_endpoint_id",
+        lambda *args, **kwargs: (1, None),
+    )
 
     def fake_get(url, verify=True, timeout=None, params=None, headers=None):
         raise requests.exceptions.ConnectionError(
             "HTTPConnectionPool(host='10.0.30.207', port=8000): Max retries exceeded "
-            "with url: /proxmox/version?source=database&domain=pve.local "
+            "with url: /proxmox/version?source=database&proxmox_endpoint_ids=1 "
             '(Caused by NewConnectionError("Failed to establish a new connection: '
             '[Errno 111] Connection refused"))'
         )
@@ -599,7 +691,7 @@ def test_proxmox_status_normalizes_backend_connection_refused(
         == "ProxBox backend could not connect to the configured Proxmox endpoint "
         "(pve.local:8006). Backend route: https://proxbox.local:8800/proxmox/version. "
         "Upstream error: HTTPConnectionPool(host='10.0.30.207', port=8000): Max "
-        "retries exceeded with url: /proxmox/version?source=database&domain=pve.local "
+        "retries exceeded with url: /proxmox/version?source=database&proxmox_endpoint_ids=1 "
         '(Caused by NewConnectionError("Failed to establish a new connection: '
         '[Errno 111] Connection refused"))'
     )
@@ -810,6 +902,11 @@ def test_proxmox_mode_detected_on_successful_keepalive(
         ss,
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
+    )
+    monkeypatch.setattr(
+        ss,
+        "resolve_backend_endpoint_id",
+        lambda *args, **kwargs: (1, None),
     )
     monkeypatch.setattr(ss, "_last_proxmox_mode_check", {})
 


### PR DESCRIPTION
## Summary

Fixes the remaining read-side manifestation of #563 ("Issue with multiple proxmox endpoints").

With two or more Proxmox endpoints configured, the live dashboard/status reads bound to the **wrong** endpoint. The cluster/VM sync paths were already scoped to a single endpoint by its stable backend identity, but three live-read paths still selected the proxbox-api session by `domain`/`ip_address`:

- the per-endpoint dashboard **card** (`/proxmox/version`, `/proxmox/sessions`)
- the endpoint **status** health check (`/proxmox/version`, `/proxmox/cluster/status`)
- the operational **dashboard** (`/proxmox/cluster/status`, `/proxmox/cluster/resources`, `/proxmox/nodes/`)

proxbox-api returns the **first** session whose `domain`/`ip_address` matches. So when two endpoints share a Proxmox domain — or a stale backend endpoint row lingers after an endpoint is deleted and recreated — these reads attach to the wrong endpoint. Symptoms: "Cluster Nodes" shows the wrong cluster name/node counts, and data can't be retrieved for the intended endpoint even after the other one is removed.

## Fix

Resolve the proxbox-api backend endpoint id from the endpoint's stable `"(nb:<pk>)"` identity (the same translation already used by cluster/VM sync) and scope each live read with `?proxmox_endpoint_ids=<backend_id>` instead of `domain`/`ip_address`. Endpoints that can't be resolved on the backend now surface a clear error instead of silently falling back to an ambiguous selector.

## Test plan

- New regression tests reproduce the bug with **two endpoints that share a domain** and assert each read scopes by the resolved backend id (and sends no `domain`/`ip_address` selector) for the card, the status check, and the operational dashboard. They fail on pre-fix code.
- `ruff check .` / `ruff format --check` — clean
- `bandit -r netbox_proxbox proxbox_cli -ll` — no medium/high findings
- `python -m compileall netbox_proxbox tests` — clean
- Full mocked suite: `1034 passed, 4 skipped`

Closes #563
