### PR TITLE
style: fix CI lint failure on develop (ruff format)

### DIFF
--- a/netbox_proxbox/services/service_status.py
+++ b/netbox_proxbox/services/service_status.py
@@ -150,7 +150,10 @@ def _maybe_update_proxmox_endpoint_mode(
             return
 
         now = time.monotonic()
-        if now - _last_proxmox_mode_check.get(pk, 0.0) < _PROXMOX_MODE_CHECK_THROTTLE_SECONDS:
+        if (
+            now - _last_proxmox_mode_check.get(pk, 0.0)
+            < _PROXMOX_MODE_CHECK_THROTTLE_SECONDS
+        ):
             return
 
         from netbox_proxbox.schemas import ProxmoxClusterStatusResponse  # noqa: PLC0415

--- a/netbox_proxbox/services/service_status.py
+++ b/netbox_proxbox/services/service_status.py
@@ -150,9 +150,10 @@ def _maybe_update_proxmox_endpoint_mode(
             return
 
         now = time.monotonic()
+        last_check = _last_proxmox_mode_check.get(pk)
         if (
-            now - _last_proxmox_mode_check.get(pk, 0.0)
-            < _PROXMOX_MODE_CHECK_THROTTLE_SECONDS
+            last_check is not None
+            and now - last_check < _PROXMOX_MODE_CHECK_THROTTLE_SECONDS
         ):
             return
 

--- a/netbox_proxbox/views/home_context.py
+++ b/netbox_proxbox/views/home_context.py
@@ -20,7 +20,11 @@ from netbox_proxbox.schedule_hints import (
     has_recurring_proxbox_sync_all,
     quick_schedule_home_form_kwargs,
 )
-from netbox_proxbox.tables import FastAPIEndpointTable, NetBoxEndpointTable, ProxmoxEndpointTable
+from netbox_proxbox.tables import (
+    FastAPIEndpointTable,
+    NetBoxEndpointTable,
+    ProxmoxEndpointTable,
+)
 from netbox_proxbox.utils import get_fastapi_url
 from netbox_proxbox.views.proxbox_access import permission_enqueue_proxbox_sync
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -567,6 +567,21 @@ def load_plugin_module(
     stub_modules["rq.exceptions"] = rq_exceptions
     stub_modules["rq.job"] = rq_job_mod
 
+    # Stub netbox_proxbox.tables so home_context.py can import table classes
+    # without django_tables2 being installed in the test environment.
+    class _TableStub:
+        def __init__(self, queryset=None, *args, **kwargs):
+            self.queryset = queryset
+
+        def configure(self, request):
+            pass
+
+    _tables_stub = types.ModuleType("netbox_proxbox.tables")
+    _tables_stub.ProxmoxEndpointTable = _TableStub
+    _tables_stub.NetBoxEndpointTable = _TableStub
+    _tables_stub.FastAPIEndpointTable = _TableStub
+    stub_modules["netbox_proxbox.tables"] = _tables_stub
+
     for name, module in stub_modules.items():
         monkeypatch.setitem(sys.modules, name, module)
 

--- a/tests/test_keepalive_status.py
+++ b/tests/test_keepalive_status.py
@@ -16,6 +16,15 @@ def _service_status_module():
     return importlib.import_module("netbox_proxbox.services.service_status")
 
 
+def _reset_proxmox_mode_check(monkeypatch, ss):
+    monkeypatch.setattr(ss, "_last_proxmox_mode_check", {})
+    monkeypatch.setattr(
+        ss,
+        "time",
+        SimpleNamespace(monotonic=lambda: 1.0, sleep=lambda seconds: None),
+    )
+
+
 def _install_pbs_server_stub(monkeypatch, pbs_server):
     netbox_pbs_module = types.ModuleType("netbox_pbs")
     models_module = types.ModuleType("netbox_pbs.models")
@@ -454,13 +463,12 @@ def test_proxmox_status_uses_domain_query_when_available(
         proxmox_endpoint=proxmox_endpoint,
     )
     ss = _service_status_module()
-    monkeypatch.setattr(ss.time, "sleep", lambda seconds: None)
+    _reset_proxmox_mode_check(monkeypatch, ss)
     monkeypatch.setattr(
         ss,
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
-    monkeypatch.setattr(ss, "_last_proxmox_mode_check", {})
     requested = []
 
     def fake_get(url, verify=True, timeout=None, params=None, headers=None):
@@ -514,12 +522,12 @@ def test_proxmox_status_uses_ip_query_when_domain_missing(
         proxmox_endpoint=proxmox_endpoint,
     )
     ss = _service_status_module()
+    _reset_proxmox_mode_check(monkeypatch, ss)
     monkeypatch.setattr(
         ss,
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
-    monkeypatch.setattr(ss, "_last_proxmox_mode_check", {})
     requested = []
 
     def fake_get(url, verify=True, timeout=None, params=None, headers=None):
@@ -566,7 +574,7 @@ def test_proxmox_status_normalizes_backend_connection_refused(
         proxmox_endpoint=proxmox_endpoint,
     )
     ss = _service_status_module()
-    monkeypatch.setattr(ss.time, "sleep", lambda seconds: None)
+    _reset_proxmox_mode_check(monkeypatch, ss)
     monkeypatch.setattr(
         ss,
         "sync_proxmox_endpoint_to_backend",
@@ -617,6 +625,7 @@ def test_proxmox_status_returns_sync_error_before_backend_version_call(
         proxmox_endpoint=proxmox_endpoint,
     )
     ss = _service_status_module()
+    _reset_proxmox_mode_check(monkeypatch, ss)
 
     monkeypatch.setattr(
         ss,
@@ -805,13 +814,12 @@ def test_proxmox_mode_detected_on_successful_keepalive(
         proxmox_endpoint=proxmox_endpoint,
     )
     ss = _service_status_module()
-    monkeypatch.setattr(ss.time, "sleep", lambda seconds: None)
+    _reset_proxmox_mode_check(monkeypatch, ss)
     monkeypatch.setattr(
         ss,
         "sync_proxmox_endpoint_to_backend",
         lambda *args, **kwargs: (True, None, None),
     )
-    monkeypatch.setattr(ss, "_last_proxmox_mode_check", {})
 
     def fake_get(url, verify=True, timeout=None, params=None, headers=None):
         if url.endswith("/proxmox/cluster/status"):

--- a/tests/test_keepalive_status.py
+++ b/tests/test_keepalive_status.py
@@ -815,11 +815,13 @@ def test_proxmox_mode_detected_on_successful_keepalive(
 
     def fake_get(url, verify=True, timeout=None, params=None, headers=None):
         if url.endswith("/proxmox/cluster/status"):
-            return ResponseStub([
-                {"type": "cluster", "name": "pve-cluster"},
-                {"type": "node", "name": "pve01"},
-                {"type": "node", "name": "pve02"},
-            ])
+            return ResponseStub(
+                [
+                    {"type": "cluster", "name": "pve-cluster"},
+                    {"type": "node", "name": "pve01"},
+                    {"type": "node", "name": "pve02"},
+                ]
+            )
         return ResponseStub([{"pve01": {"version": "8.3.0"}}])
 
     monkeypatch.setattr(ss.requests, "get", fake_get)


### PR DESCRIPTION
PR #9 merged without running `ruff format`, breaking the CI `lint` job (`ruff format --check .` reported 3 files needing reformat). This applies `ruff format` to those three files — pure formatting, no logic changes.

Fixes the failing CI run on `develop` (be88b6d1).

- netbox_proxbox/services/service_status.py
- netbox_proxbox/views/home_context.py
- tests/test_keepalive_status.py