### PR TITLE
ci: fix production deploy job (short plugin name + local-first)

### DIFF
--- a/.gitea/workflows/publish-gitea.yml
+++ b/.gitea/workflows/publish-gitea.yml
@@ -225,13 +225,21 @@ jobs:
       TAG: ${{ needs.validate-version.outputs.tag }}
     steps:
       - name: Deploy plugin
+        shell: bash
         run: |
           # Validate tag format defensively
           case "$TAG" in
             v[0-9]*.[0-9]*.[0-9]*) ;;
             *) echo "ERROR: Invalid tag format: $TAG"; exit 1 ;;
           esac
-          ssh -o StrictHostKeyChecking=accept-new \
-              -o ServerAliveInterval=30 \
-              -o ServerAliveCountMax=20 \
-              nmc-prod-207 -- deploy-plugin netbox-proxbox "$TAG"
+          # The deploy script's plugin whitelist uses the short name ("proxbox",
+          # not "netbox-proxbox"). Prefer the local script when the prod-deploy
+          # runner is on the prod host; fall back to ssh for a remote runner.
+          if [[ -x /opt/nmulticloud/deploy/bin/deploy-netbox-plugin ]]; then
+            /opt/nmulticloud/deploy/bin/deploy-netbox-plugin proxbox "$TAG"
+          else
+            ssh -o StrictHostKeyChecking=accept-new \
+                -o ServerAliveInterval=30 \
+                -o ServerAliveCountMax=20 \
+                nmc-prod-207 -- deploy-plugin proxbox "$TAG"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,8 +396,15 @@ What was done for v0.0.19:
 **Deploy job:**
 - Runs after `push-to-github` job completes (requires validated tag and GitHub Release created)
 - Condition: only for non-RC releases (`is_rc == false`)
-- Runs on `prod-deploy` runner with SSH access to production host
-- Executes: `ssh nmc-prod-207 -- deploy-plugin netbox-proxbox "$TAG"`
+- Runs on a `prod-deploy` runner (the repo's Gitea Actions runner must carry the
+  `prod-deploy:host` label in addition to `mirror-host:host`, or the deploy job
+  stays queued forever)
+- Executes the deploy with the **short** plugin name `proxbox` (the deploy
+  script's whitelist maps `proxbox` → module `netbox_proxbox` / package
+  `netbox-proxbox`; passing `netbox-proxbox` fails validation). It prefers the
+  local script when the runner is on the prod host, falling back to ssh for a
+  remote runner: `/opt/nmulticloud/deploy/bin/deploy-netbox-plugin proxbox "$TAG"`
+  else `ssh nmc-prod-207 -- deploy-plugin proxbox "$TAG"`
 
 **Security hardening:**
 - TAG is passed via environment variable, not direct GitHub Actions context interpolation
@@ -422,8 +429,8 @@ What was done for v0.0.19:
 
 **Manual deployment for hotfixes or rollbacks:**
 ```bash
-# Deploy a specific tag or branch
-ssh nmc-prod-207 -- deploy-plugin netbox-proxbox v0.0.19.post1
+# Deploy a specific tag or branch (short name "proxbox", not "netbox-proxbox")
+ssh nmc-prod-207 -- deploy-plugin proxbox v0.0.19.post1
 
 # List recent deploys (check system journal)
 ssh nmc-prod-207 -- journalctl -u netbox-production -n 50 --no-pager


### PR DESCRIPTION
## Problem
The `publish-gitea.yml` **deploy** job invoked `deploy-plugin netbox-proxbox "$TAG"`, but the deploy script (`/opt/nmulticloud/deploy/bin/deploy-netbox-plugin`) whitelists the **short** name `proxbox`. It would fail with `invalid netbox plugin 'netbox-proxbox'` even once a `prod-deploy` runner exists.

This is why `v0.0.20.post1` was published but never auto-deployed to netbox.nmulti.cloud (the deploy job was also stuck queued for lack of a `prod-deploy` runner — fixed separately by adding the label to the repo runner).

## Fix
- Use the short name `proxbox`.
- Adopt the **local-first-with-ssh-fallback** pattern from the sibling plugins' `deploy-production.yml`: run the deploy script directly when the `prod-deploy` runner is on the prod host, fall back to `ssh nmc-prod-207` for a remote runner (the alias isn't always resolvable from the runner's own shell).

No Python/code changes; CI lint/test/build unaffected.