### PR TITLE
fix(templates): render paginator instead of raw comment on plugin list pages

### DIFF
--- a/netbox_proxbox/templates/netbox_proxbox/inc/paginator.html
+++ b/netbox_proxbox/templates/netbox_proxbox/inc/paginator.html
@@ -1,13 +1,14 @@
 {% load proxbox_tags %}
 {% load i18n %}
-{# Reusable NetBox-style paginator for plugin list pages.
+{% comment %}
+Reusable NetBox-style paginator for plugin list pages.
 
-   Context:
-     page       - a django.core.paginator.Page (EnhancedPage) instance
-     paginator  - the EnhancedPaginator that produced ``page``
-     page_param - the query-string parameter that selects the page number
-                  (defaults to "page"; aggregate pages use "vm_page"/"node_page")
-#}
+Context:
+  page       - a django.core.paginator.Page (EnhancedPage) instance
+  paginator  - the EnhancedPaginator that produced ``page``
+  page_param - the query-string parameter that selects the page number
+               (defaults to "page"; aggregate pages use "vm_page"/"node_page")
+{% endcomment %}
 {% with page_param=page_param|default:"page" %}
 {% if page %}
   <div class="d-flex justify-content-between align-items-center border-top p-2">


### PR DESCRIPTION
## Summary

Plugin list pages (`virtual_machines`, `lxc_containers`, `devices`, `clusters`, `virtual_disks`) rendered the paginator template's header comment as literal text at the bottom of the page instead of pagination controls.

## Root cause

`netbox_proxbox/templates/netbox_proxbox/inc/paginator.html` opened with a multi-line `{# ... #}` comment. Django's `{# #}` comment syntax is **single-line only** — newlines between the delimiters are not permitted, so the parser does not strip it and emits the contents as page text.

## Fix

Switched the header to `{% comment %}...{% endcomment %}`, which is the correct multi-line comment form. No markup or logic changed. Since the paginator is a shared include, this fixes all five list pages at once.

## Validation

Patched the template into a running NetBox 4.6.1 container (netbox-proxbox 0.0.21) and confirmed the pagination controls now render correctly on the VM and LXC list pages, with the raw comment text gone.

Fixes #589