### PR TITLE
fix(nav): stop 'Homepage' menu item highlighting on every Proxbox page

### DIFF
--- a/netbox_proxbox/urls.py
+++ b/netbox_proxbox/urls.py
@@ -1,6 +1,7 @@
 """Register plugin UI routes for pages, models, sync actions, and status checks."""
 
 from django.urls import include, path
+from django.views.generic import RedirectView
 from utilities.urls import get_model_urls
 
 from netbox_proxbox import views
@@ -21,7 +22,21 @@ from netbox_proxbox.websocket_client import WebSocketView
 app_name = "netbox_proxbox"
 
 urlpatterns = [
-    path("", views.HomeView.as_view(), name="home"),
+    # Home lives at ``home/`` (not the bare plugin root) so its menu-item URL is
+    # not a prefix of every other Proxbox page URL. NetBox's sidenav active-link
+    # detection (utilities sidenav.ts ``getActiveLinks``) marks a menu item
+    # active when its href is a substring of the current URL, which made the
+    # "Homepage" entry highlight on every Proxbox page when it sat at the root.
+    # The bare root 302-redirects to ``home`` so bookmarks and inbound links to
+    # ``/plugins/proxbox/`` keep working.
+    path(
+        "",
+        RedirectView.as_view(
+            pattern_name="plugins:netbox_proxbox:home", permanent=False
+        ),
+        name="home_redirect",
+    ),
+    path("home/", views.HomeView.as_view(), name="home"),
     path(
         "quick-edit/<str:endpoint_type>/<int:pk>/",
         views.HomeQuickEditView.as_view(),

--- a/tests/e2e/page_coverage_check.py
+++ b/tests/e2e/page_coverage_check.py
@@ -26,7 +26,7 @@ _NETBOX_API_TOKEN = os.environ.get("NETBOX_API_TOKEN", "")
 # (label, path-relative-to-base)
 LIST_PAGES: list[tuple[str, str]] = [
     # Meta
-    ("home", "/plugins/proxbox/"),
+    ("home", "/plugins/proxbox/home/"),
     ("sitemap", "/plugins/proxbox/sitemap.txt"),
     ("dashboard", "/plugins/proxbox/dashboard/"),
     ("ha", "/plugins/proxbox/ha/"),

--- a/tests/e2e/stack_setup.py
+++ b/tests/e2e/stack_setup.py
@@ -421,7 +421,7 @@ def assert_plugin_routes(
 ) -> None:
     headers = {"Authorization": f"Token {netbox_token}"}
     route_checks = [
-        f"{netbox_base_url}/plugins/proxbox/",
+        f"{netbox_base_url}/plugins/proxbox/home/",
         f"{netbox_base_url}/plugins/proxbox/endpoints/proxmox/{endpoint_ids['proxmox_pk']}/",
         f"{netbox_base_url}/plugins/proxbox/endpoints/netbox/{endpoint_ids['netbox_pk']}/",
         f"{netbox_base_url}/plugins/proxbox/endpoints/fastapi/{endpoint_ids['fastapi_pk']}/",


### PR DESCRIPTION
## Summary

The Proxbox **Homepage** sidebar entry stayed highlighted on every plugin page, so any sub-page showed two active menu items at once (e.g. **Homepage** + **Settings**).

## Root cause

NetBox core's sidenav active-link detection (`utilities/.../sidenav.ts → getActiveLinks()`) marks a menu item active when its href is a **substring** of the current URL:

```js
const href = new RegExp(link.href, 'gi');
if (window.location.href.match(href)) yield menuitem;
```

The **Homepage** item lived at the bare plugin root `/plugins/proxbox/`, a prefix of every other Proxbox page URL, so it matched everywhere. Core menus avoid this because no core menu URL is a prefix of a sibling.

## Fix

Relocate `HomeView` to `/plugins/proxbox/home/` and 302-redirect the bare root to it. The `home` URL name is unchanged, so all `{% url %}` references and existing bookmarks (via redirect) keep working, and `/home/` is no longer a prefix of sibling pages.

Also updated the two e2e checks that hit the bare root to the new `/home/` path.

## Verification

- `python -m compileall`, `ruff check`, and the full `pytest` suite (1119 passed, 9 skipped) all pass.
- Live on NetBox 4.6.1 / netbox-proxbox 0.0.21:
  - `/plugins/proxbox/` → 302 → `/plugins/proxbox/home/`
  - Settings page active items: `["Settings"]` (was `["Homepage", "Settings"]`)
  - Home page active items: `["Homepage"]`



Fixes #591