### PR TITLE
feat: add optional Proxmox SDN sync inventory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,13 @@ Three modes per type (global and per-endpoint — endpoint takes priority):
 - **`bootstrap_only`** — create once, tag with `bootstrap-only`, never patch/delete again
 - **`disabled`** — skip entirely, leave existing objects untouched
 
-Eight resource types: `sync_mode_vm`, `sync_mode_vm_template`, `sync_mode_vm_interface`, `sync_mode_mac`, `sync_mode_cluster`, `sync_mode_node`, `sync_mode_storage`, `sync_mode_ip_address`.
+Nine resource types: `sync_mode_vm`, `sync_mode_vm_template`, `sync_mode_vm_interface`, `sync_mode_mac`, `sync_mode_cluster`, `sync_mode_node`, `sync_mode_storage`, `sync_mode_ip_address`, `sync_mode_sdn`.
+
+`sync_mode_sdn` defaults to `disabled`. The **All** sync choice includes the SDN
+stage after VM interface/IP-address stages, but stage gating skips it until the
+effective SDN mode is enabled. SDN sync is read-only against Proxmox and writes
+only NetBox L2VPN/L2VPNTermination/RouteTarget/Prefix objects plus Proxbox
+plugin SDN metadata.
 
 Effective sync modes resolve through a parent-to-child cascade before stage gating and backend query forwarding. A resource is effectively `disabled` when its own mode is `disabled` or any ancestor is effectively `disabled`; child modes never affect parent modes. The hierarchy is:
 
@@ -71,11 +77,13 @@ vm + vm_template (both disabled only)
 └── vm_interface
     ├── ip_address
     └── mac
+
+sdn
 ```
 
 **VM templates** are stored in `ProxmoxVMTemplate` (not `VirtualMachine`). The model has optional FKs to `VirtualMachine` (`source_vm` and M2M `cloned_vms`), `ProxmoxCluster`, and `ProxmoxNode`.
 
-Key files: `choices.py` (SyncModeChoices), `constants.py` (SYNC_MODE_FIELDS), `models/plugin_settings.py` (global fields), `models/proxmox_endpoint.py` (per-endpoint fields + `effective_sync_mode()`), `models/vm_template.py` (ProxmoxVMTemplate), `sync_stages.py` (gating helpers), `netbox_bootstrap.py` (bootstrap-only tag creation), `services/sync_vm_template.py` (template sync service), `docs/configuration/sync-modes.md` (user docs).
+Key files: `choices.py` (SyncModeChoices), `constants.py` (SYNC_MODE_FIELDS), `models/plugin_settings.py` (global fields), `models/proxmox_endpoint.py` (per-endpoint fields + `effective_sync_mode()`), `models/vm_template.py` (ProxmoxVMTemplate), `models/sdn_inventory.py` (SDN metadata), `sync_stages.py` (gating helpers), `netbox_bootstrap.py` (bootstrap-only tag creation), `services/sync_vm_template.py` (template sync service), `docs/configuration/sync-modes.md` (user docs).
 
 ## Release Procedure (summary)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ The current plugin config lives in [`netbox_proxbox/__init__.py`](./netbox_proxb
 - VM lifecycle models: `ProxmoxVMTemplate` (VM template inventory with optional FK to `VirtualMachine`), `ProxmoxVMCloudInit` (cloud-init config), `CloudImageTemplate` (Firecracker/image factory catalog), `ProxmoxApplyJob` (intent apply job), `DeletionRequest` (auditable delete-request workflow).
 - Datacenter config: `ProxmoxDatacenterCpuModel` (custom CPU models synced from PVE).
 - Firewall inventory (6 models, read-only): `ProxmoxFirewallSecurityGroup`, `ProxmoxFirewallRule`, `ProxmoxFirewallIPSet`, `ProxmoxFirewallIPSetEntry`, `ProxmoxFirewallAlias`, `ProxmoxFirewallOptions`.
-- SDN inventory (3 models, PVE 9.2+): `ProxmoxSdnFabric`, `ProxmoxSdnRouteMap`, `ProxmoxSdnPrefixList`.
+- SDN inventory (PVE 9.2+): controllers, zones, VNets, subnets, bindings, fabrics, route maps, and prefix lists.
 - Firecracker Cloud uses separate `FirecrackerHostPool`, `FirecrackerHost`, `FirecrackerImageTemplate`, and `FirecrackerMicroVM` models. A micro-VM is not a NetBox core `VirtualMachine`; API clients identify it with `kind="firecracker"` and `instance_ref="firecracker:<id>"`.
 - `ProxmoxEndpoint.allowed_tenants` is the tenant allow-list for NMS Cloud endpoint visibility. Empty means default/global visibility. Non-empty pins the endpoint to those tenants. The paired backend must hide the default/global pool for a tenant as soon as any explicit endpoint grant matches that tenant.
 - `ProxboxPluginSettings` includes sync mode fields `sync_mode_vm_interface` and `sync_mode_mac` (migration 0051) and interface-batch tunables `interface_batch_size` (default 5) and `interface_batch_delay_ms` (default 100).
@@ -90,7 +90,7 @@ The current plugin config lives in [`netbox_proxbox/__init__.py`](./netbox_proxb
 - **When a job looks “stuck”:** **pending** usually means **no RQ worker** is running (or it does not listen to **`default`**). **running** for a long time usually means proxbox-api is still syncing or the stream is slow/buffered; **errored** with **`JobTimeoutException`** means RQ’s wall-clock limit was hit—increase `job_timeout` or `PROXBOX_SYNC_JOB_TIMEOUT`. Inspect the job **log** and **error** fields before changing code.
 - **Cancel on Job detail:** For Proxbox Sync rows in **pending**, **scheduled**, or **running** state, the plugin adds **Cancel job** (POST to `proxbox-cancel`). It requires **delete** permission on the core **Job** model, cancels or stops the linked RQ job when possible, then marks the NetBox job **failed** with a “Cancelled by user.” message. Stopping a **running** job is best-effort (RQ stop + long HTTP reads may not abort instantly).
 - **Run now on Job detail:** Shown only when the job is in a **terminal** state (**completed**, **errored**, or **failed**), including after **Cancel** (failed). It is **not** shown for **pending**, **scheduled**, or **running**—use **Cancel** first if a queued run should be abandoned, then **Run now** on the finished row to queue a new sync with the same parameters.
-- **Full update (UI vs jobs):** The plugin home may still use non-streaming helpers such as [`sync_full_update_resource`](./netbox_proxbox/services/backend_proxy.py) for JSON/redirect flows. Scheduled or immediate **Proxbox Sync** jobs use **`full-update/stream`** on proxbox-api and execute the full stage chain in one stream: devices, storage, virtual machines, virtual disks, backups, snapshots, network interfaces, IP addresses, VM interfaces, backup routines, and replications.
+- **Full update (UI vs jobs):** The plugin home may still use non-streaming helpers such as [`sync_full_update_resource`](./netbox_proxbox/services/backend_proxy.py) for JSON/redirect flows. Scheduled or immediate **Proxbox Sync** jobs expand selected sync types in [`sync_types.py`](./netbox_proxbox/sync_types.py) and call one backend `/stream` path per stage: devices, storage, virtual machines, task history, virtual disks, backups, snapshots, network interfaces, VM interfaces, IP addresses, SDN, replications, and backup routines. The SDN stage is included by **All** but skipped by default while `sync_mode_sdn=disabled`.
 
 ### SSL Certificate Verification
 
@@ -145,7 +145,18 @@ reflected into NetBox. Three modes are available:
 - **`bootstrap_only`** — sync the object once on first discovery, tag it with `bootstrap-only` in NetBox, and leave it completely untouched on all subsequent runs.
 - **`disabled`** — skip this resource type entirely; existing objects are not modified or removed.
 
-Controlled resource types: `sync_mode_vm`, `sync_mode_vm_template`, `sync_mode_vm_interface`, `sync_mode_mac`, `sync_mode_cluster`, `sync_mode_node`, `sync_mode_storage`, `sync_mode_ip_address`.
+Controlled resource types: `sync_mode_vm`, `sync_mode_vm_template`, `sync_mode_vm_interface`, `sync_mode_mac`, `sync_mode_cluster`, `sync_mode_node`, `sync_mode_storage`, `sync_mode_ip_address`, `sync_mode_sdn`.
+
+`sync_mode_sdn` defaults to `disabled` globally and per endpoint. The **All**
+sync option includes the SDN stage after VM interface/IP-address stages, but
+that stage is skipped until the effective SDN mode is enabled. SDN sync is
+read-only against Proxmox: it reflects controllers, zones, VNets, subnets,
+fabrics, route maps, prefix lists, and runtime bindings into NetBox plugin
+metadata, and it maps EVPN/VXLAN VNets into NetBox built-ins (`vpn.L2VPN`,
+`vpn.L2VPNTermination`, `ipam.RouteTarget`, `ipam.Prefix`) when enough source
+data is available.
+Unsupported older Proxmox clusters are counted as skipped warnings, not failed
+syncs.
 
 Resolution priority: **endpoint-level setting takes priority over the global default**. An endpoint field set to null inherits the global `ProxboxPluginSettings` value.
 
@@ -191,6 +202,8 @@ The `bootstrap-only` tag (slug `bootstrap-only`) is auto-created by `netbox_prox
 - `netbox_proxbox/models/vm_template.py` — `ProxmoxVMTemplate` model
 - `netbox_proxbox/migrations/0046_sync_modes.py` — migration for sync mode fields
 - `netbox_proxbox/migrations/0047_proxmox_vm_template.py` — migration for ProxmoxVMTemplate table
+- `netbox_proxbox/migrations/0054_sdn_sync_controls_and_inventory.py` — SDN sync mode and SDN inventory tables
+- `netbox_proxbox/models/sdn_inventory.py` — Proxmox SDN controller/zone/VNet/subnet/binding metadata
 - `netbox_proxbox/sync_stages.py` — `_has_bootstrap_only_tag()`, `_bootstrap_only_should_skip_existing()`, `_add_bootstrap_only_tag()`
 - `netbox_proxbox/netbox_bootstrap.py` — `ensure_proxbox_tags()`, `ensure_bootstrap_only_tag()`
 - `netbox_proxbox/services/sync_vm_template.py` — `sync_vm_templates()` service

--- a/docs/configuration/sync-modes.md
+++ b/docs/configuration/sync-modes.md
@@ -32,7 +32,7 @@ the object alone.
 
 ## Resource Types
 
-Eight resource types can be controlled:
+Nine resource types can be controlled:
 
 | Setting field | Resource |
 |---------------|----------|
@@ -44,6 +44,12 @@ Eight resource types can be controlled:
 | `sync_mode_node` | Proxmox node rows (DCIM devices) |
 | `sync_mode_storage` | Proxmox storage pools |
 | `sync_mode_ip_address` | IP addresses discovered from VM interfaces |
+| `sync_mode_sdn` | Read-only Proxmox SDN inventory and EVPN/VXLAN NetBox mapping |
+
+`sync_mode_sdn` is the exception to the normal default: it defaults to
+`disabled`. Choosing **All** still includes the SDN stage in the dependency
+order, but the stage is skipped until the effective SDN mode is `always` or
+`bootstrap_only`.
 
 ---
 
@@ -82,6 +88,8 @@ vm + vm_template (both disabled only)
 └── vm_interface
     ├── ip_address
     └── mac
+
+sdn
 ```
 
 The VM parent is a special case for network descendants: `vm_interface`,
@@ -119,7 +127,7 @@ to every endpoint that does not override the setting.
 ### Per-endpoint settings
 
 Navigate to an existing **ProxmoxEndpoint** and open its **Settings** tab.
-The same eight sync-mode dropdowns appear, but these fields are optional. Leave
+The same nine sync-mode dropdowns appear, but these fields are optional. Leave
 them blank to inherit the global setting; choose a value to override it.
 
 ---
@@ -136,6 +144,7 @@ them blank to inherit the global setting; choose a value to override it.
 | Node | `disabled` | `always` | _(blank)_ | `always` | `disabled` |
 | Storage | `always` | _(blank)_ | _(blank)_ | `always` | `always` |
 | IP address | `always` | _(blank)_ | `disabled` | `always` | `disabled` |
+| SDN | `disabled` | `always` | _(blank)_ | `always` | `disabled` |
 
 ---
 
@@ -153,7 +162,30 @@ ep.effective_sync_mode("cluster")     # → "disabled"
 ```
 
 Valid `resource_type` values: `vm`, `vm_template`, `vm_interface`, `mac`,
-`cluster`, `node`, `storage`, `ip_address`.
+`cluster`, `node`, `storage`, `ip_address`, `sdn`.
+
+---
+
+## SDN behavior
+
+SDN sync is read-only against Proxmox. When enabled, Proxbox calls the backend
+`GET /proxmox/sdn/create/stream` stage after VM interfaces and VM IP addresses.
+The stage collects controllers, zones, VNets, VNet subnets, fabrics, route
+maps, prefix lists, node zone content, bridges, MAC-VRF, and IP-VRF rows.
+Older Proxmox clusters that do not expose the SDN API are reported as skipped
+warnings rather than failed jobs.
+
+EVPN and VXLAN VNets are mapped to NetBox `vpn.L2VPN` records. EVPN
+`rt-import` values create/update `ipam.RouteTarget` records and are assigned as
+L2VPN import targets. Valid Proxmox subnet CIDRs create/update NetBox
+`ipam.Prefix` records. When runtime rows expose an explicit NetBox target or
+an unambiguous VLAN id, Proxbox creates `vpn.L2VPNTermination` records. If that
+target already belongs to a different L2VPN, Proxbox records the conflict in an
+SDN binding row and does not overwrite the manual assignment.
+
+Proxmox-specific metadata, raw payloads, and bindings are stored in plugin SDN
+inventory tables so operators can inspect unsupported or ambiguous rows without
+Proxmox writes.
 
 ---
 

--- a/docs/developer/architecture-overview.md
+++ b/docs/developer/architecture-overview.md
@@ -21,7 +21,7 @@ flowchart TB
 
     subgraph Backend["proxbox-api\n(FastAPI)"]
         Routes["Route handlers"]
-        SyncSvc["Sync services\n(12 stages)"]
+        SyncSvc["Sync services\n(13 scheduled stages)"]
         Transform["proxmox_to_netbox\n(Pydantic schemas)"]
         AuthMW["APIKeyAuthMiddleware"]
         SQLite["SQLite\n(endpoints, API keys)"]
@@ -39,7 +39,7 @@ flowchart TB
 
     UI -->|"HTTP / SSE / WebSocket"| Views
     Views -->|"requests / StreamingHttpResponse"| Services
-    Services -->|"GET /full-update/stream\n(SSE)"| Routes
+        Services -->|"GET /<stage>/stream\n(SSE)"| Routes
     Jobs -->|"run_sync_stream()"| Routes
     Routes --> SyncSvc
     SyncSvc --> Transform
@@ -94,7 +94,7 @@ flowchart LR
 | Component | Repository | Primary Stack | Responsibility |
 |---|---|---|---|
 | **netbox-proxbox** | `netbox-proxbox/` | Python, Django, NetBox plugin framework | NetBox plugin: UI, models, API, background jobs, backend proxy |
-| **proxbox-api** | `proxbox-api/` | Python, FastAPI, SQLite | Sync orchestrator: 12-stage pipeline, SSE streaming, endpoint management |
+| **proxbox-api** | `proxbox-api/` | Python, FastAPI, SQLite | Sync services, per-stage SSE streaming, endpoint management |
 | **netbox-sdk** | `netbox-sdk/` | Python, aiohttp | Async NetBox REST API client with typed models and caching |
 | **proxmox-openapi** | `proxmox-sdk/` | Python, aiohttp | Async Proxmox VE API client (646 endpoints, mock/real modes) |
 
@@ -107,8 +107,9 @@ A sync triggered from the NetBox UI follows this high-level path:
 1. **Browser** sends a form POST to a NetBox plugin view
 2. The **plugin view** enqueues a `ProxboxSyncJob` on the RQ `default` queue
 3. An **RQ worker** picks up the job and calls `run_sync_stream()` in the services layer
-4. The services layer opens a **streaming GET** to `proxbox-api/full-update/stream`
-5. **proxbox-api** runs the 12-stage sync pipeline, emitting SSE progress events
+4. The services layer opens one or more **streaming GET** calls to the stage
+   paths in `netbox_proxbox/sync_types.py`
+5. **proxbox-api** runs each requested stage, emitting SSE progress events
 6. Each stage fetches data from **Proxmox VE** via the proxmox-openapi SDK, transforms it, and writes to **NetBox** via netbox-sdk
 7. SSE events flow back through the plugin and are attached to the NetBox **Job** record
 8. The browser polls the Job detail page to see live log output
@@ -117,7 +118,7 @@ A sync triggered from the NetBox UI follows this high-level path:
 
 !!! tip "Where to go next"
     - [Component Deep Dive](component-deep-dive.md) — internal architecture of each repository
-    - [Sync Pipeline](sync-pipeline.md) — the 12-stage full-update sequence
+    - [Sync Pipeline](sync-pipeline.md) — the 13-stage scheduled full-update sequence
     - [Data Flow](data-flow.md) — Proxmox payload → NetBox object transformation
     - [Backend Integration](backend-integration.md) — plugin ↔ proxbox-api communication
     - [Streaming Protocol](streaming-protocol.md) — SSE and WebSocket protocol specification

--- a/docs/developer/component-deep-dive.md
+++ b/docs/developer/component-deep-dive.md
@@ -64,7 +64,7 @@ This page documents the internal architecture of each of the four Proxbox reposi
 
         def run(self, *args, **kwargs):
             ...
-            result, status = run_sync_stream("full-update/stream", ...)
+            result, status = run_sync_stream(_sync_stream_path(sync_type), ...)
     ```
 
 === "Template extensions"

--- a/docs/developer/data-model.md
+++ b/docs/developer/data-model.md
@@ -282,9 +282,19 @@ Six read-only models persist Proxmox VE firewall objects synced from proxbox-api
 
 | Model | Purpose |
 |---|---|
+| `ProxmoxSdnController` | SDN controller metadata and raw Proxmox payload |
+| `ProxmoxSdnZone` | SDN zone metadata including controller, RT import, IPAM, and state |
+| `ProxmoxSdnVNet` | SDN VNet metadata linked to NetBox `vpn.L2VPN` when EVPN/VXLAN mapping applies |
+| `ProxmoxSdnSubnet` | SDN subnet metadata linked to NetBox `ipam.Prefix` for valid CIDR payloads |
+| `ProxmoxSdnBinding` | Runtime binding/status rows and links back to generated NetBox objects |
 | `ProxmoxSdnFabric` | SDN fabric definition synced from Proxmox |
 | `ProxmoxSdnRouteMap` | SDN route-map definition |
 | `ProxmoxSdnPrefixList` | SDN prefix-list definition |
+
+The sync uses NetBox built-ins first for portable network semantics:
+`vpn.L2VPN`, `vpn.L2VPNTermination`, `ipam.RouteTarget`, and `ipam.Prefix`.
+Plugin SDN models keep Proxmox-specific fields, unsupported zone types, raw
+payloads, skipped reasons, termination conflicts, and generated-object bindings.
 
 ### Operational Models
 

--- a/docs/developer/endpoint-sync.md
+++ b/docs/developer/endpoint-sync.md
@@ -47,7 +47,7 @@ flowchart TB
 
     subgraph SyncJob["ProxboxSyncJob (RQ worker)"]
         Preflight["_ensure_backend_endpoints()\npreflight push"]
-        Stages["SSE sync stages\n(12 stages)"]
+        Stages["SSE sync stages\n(13 stages)"]
     end
 
     NB_EP -- "post_save signal\nsync_netbox_endpoint_to_backend()" --> BE_NB

--- a/docs/developer/streaming-protocol.md
+++ b/docs/developer/streaming-protocol.md
@@ -7,7 +7,7 @@ Proxbox uses **Server-Sent Events (SSE)** as the primary transport for real-time
 ## Two Sync Transport Modes
 
 === "SSE Streaming (primary)"
-    The plugin opens a long-lived HTTP GET to `proxbox-api/full-update/stream`. The response is `text/event-stream` and carries SSE frames for every stage and every object processed. The plugin proxies this stream to the browser via a Django `StreamingHttpResponse`.
+    The plugin opens long-lived HTTP GET calls to backend stage paths such as `proxbox-api/dcim/devices/create/stream` or `proxbox-api/proxmox/sdn/create/stream`. The response is `text/event-stream` and carries SSE frames for each stage and object processed. Scheduled jobs call one backend `/stream` path per selected stage; browser proxy views may still stream a single backend path directly.
 
     - **Used by**: `ProxboxSyncJob.run()` via `run_sync_stream()`, browser-facing `StreamingHttpResponse` proxy views
     - **Advantages**: real-time per-object progress, no polling needed, works through proxies with `X-Accel-Buffering: no`
@@ -36,21 +36,21 @@ data: <json_payload>
 
 ### `discovery`
 
-Emitted once at the start of a full-update stream. Lists all stages that will be processed.
+Emitted once at the start of a scheduled full-update job or legacy full-update stream. Lists all stages that will be processed.
 
 ```json
 {
   "event": "discovery",
   "phase": "full-update",
   "status": "discovered",
-  "message": "Discovered 12 sync stage(s) for full update",
-  "count": 12,
+  "message": "Discovered 13 sync stage(s) for full update",
+  "count": 13,
   "items": [
     {"name": "devices", "type": "stage"},
     {"name": "storage", "type": "stage"},
     ...
   ],
-  "progress": {"current": 0, "total": 12, "percent": 0},
+  "progress": {"current": 0, "total": 13, "percent": 0},
   "metadata": {"operation_id": "550e8400-e29b-41d4-a716-446655440000"}
 }
 ```
@@ -141,12 +141,12 @@ sequenceDiagram
 
     Browser->>NB: GET /proxbox/sync/stream/
     NB->>NB: Create StreamingHttpResponse
-    NB->>API: GET /full-update/stream (via iter_backend_sse_lines)
+    NB->>API: GET /<stage>/stream (via iter_backend_sse_lines)
     API-->>NB: SSE frames (chunked)
     NB-->>Browser: SSE frames (proxied)
 
     note over RQ,API: Background job path (separate)
-    RQ->>API: GET /full-update/stream (via run_sync_stream)
+    RQ->>API: GET /<stage>/stream (via run_sync_stream)
     API-->>RQ: SSE frames consumed by on_frame callback
     RQ->>RQ: Write progress to Job.log
 ```
@@ -203,7 +203,7 @@ sync_vms = await vms_task                # collect result
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Connected: GET /full-update/stream
+    [*] --> Connected: GET /<stage>/stream
 
     Connected --> Discovering: event:discovery
 

--- a/docs/developer/sync-pipeline.md
+++ b/docs/developer/sync-pipeline.md
@@ -1,6 +1,9 @@
 # Sync Pipeline
 
-The Proxbox full-update sync is a **12-stage sequential pipeline** executed by `proxbox-api`. Each stage fetches data from Proxmox, transforms it, and creates or updates the corresponding NetBox objects. Stages run in a fixed order because later stages depend on objects created by earlier ones.
+The scheduled Proxbox full-update sync is a **13-stage sequential pipeline**.
+Each stage fetches data from Proxmox through `proxbox-api`, transforms it, and
+creates or updates the corresponding NetBox objects. Stages run in a fixed
+order because later stages depend on objects created by earlier ones.
 
 ---
 
@@ -17,8 +20,9 @@ flowchart LR
     S7 --> S8["8\nNode\nInterfaces"]
     S8 --> S9["9\nVM\nInterfaces"]
     S9 --> S10["10\nVM IP\nAddresses"]
-    S10 --> S11["11\nReplications"]
-    S11 --> S12["12\nBackup\nRoutines"]
+    S10 --> S11["11\nSDN"]
+    S11 --> S12["12\nReplications"]
+    S12 --> S13["13\nBackup\nRoutines"]
 
     style S1 fill:#1565c0,color:#fff
     style S2 fill:#1565c0,color:#fff
@@ -30,8 +34,9 @@ flowchart LR
     style S8 fill:#6a1b9a,color:#fff
     style S9 fill:#6a1b9a,color:#fff
     style S10 fill:#6a1b9a,color:#fff
-    style S11 fill:#e65100,color:#fff
+    style S11 fill:#6a1b9a,color:#fff
     style S12 fill:#e65100,color:#fff
+    style S13 fill:#e65100,color:#fff
 ```
 
 **Legend:** blue = infrastructure, green = VM data, purple = networking, orange = operational
@@ -52,8 +57,9 @@ flowchart LR
 | 8 | **Node Interfaces** | `create_all_device_interfaces()` | `Interface` (on Device) | `/nodes/{node}/network` |
 | 9 | **VM Interfaces** | `create_only_vm_interfaces()` | `VMInterface` (on VirtualMachine) | VM config `net*` keys |
 | 10 | **VM IP Addresses** | `create_only_vm_ip_addresses()` | `IPAddress`, assigned to `VMInterface` | QEMU guest agent or config |
-| 11 | **Replications** | `sync_all_replications()` | `Replication` (plugin model) | `/cluster/replication` |
-| 12 | **Backup Routines** | `sync_all_backup_routines()` | `BackupRoutine` (plugin model) | `/cluster/backup` |
+| 11 | **SDN** | `sync_sdn_to_netbox()` | `L2VPN`, `RouteTarget`, `Prefix`, SDN plugin metadata | `/cluster/sdn/*`, `/nodes/{node}/sdn/*` |
+| 12 | **Replications** | `sync_all_replications()` | `Replication` (plugin model) | `/cluster/replication` |
+| 13 | **Backup Routines** | `sync_all_backup_routines()` | `BackupRoutine` (plugin model) | `/cluster/backup` |
 
 ---
 
@@ -67,17 +73,27 @@ The sequential order is not arbitrary — each stage depends on objects created 
 - **Stage 1 → 8**: Devices must exist before their network interfaces can be created
 - **Stage 3 → 9**: VMs must exist before their VM interfaces can be created
 - **Stage 9 → 10**: VM interfaces must exist before IP addresses can be assigned to them
+- **Stages 8–10 → 11**: SDN metadata runs after node/VM networking so generated
+  L2VPN, RouteTarget, Prefix, and binding rows can reference already-discovered
+  NetBox network objects when resolvable
 
 For upgraded installs, Stage 10 also depends on the `proxmox_vm_id` custom
 field that Stage 3 writes to each NetBox VM. VMs created by affected backend
 versions before the VM config fix may need one Full Update on a fixed
 `proxbox-api` build before the IP-address stage can match them reliably.
 
+The SDN stage is optional and defaults to skipped because `sync_mode_sdn`
+defaults to `disabled`. Choosing **All** includes the stage, but
+`sync_stages.py` records a skipped stage until the effective SDN mode allows
+it. Unsupported older Proxmox clusters are also counted as skipped warnings,
+not failed syncs.
+
 ---
 
 ## SSE Stream Mode
 
-The `/full-update/stream` endpoint emits **Server-Sent Events** during the pipeline. Each stage:
+The scheduled stage runner opens each backend stage's `/stream` endpoint and
+emits **Server-Sent Events** during the pipeline. Each stage:
 
 1. Emits a `step` event with `status: "started"`
 2. Creates a `WebSocketSSEBridge` and runs the sync function as an `asyncio.Task`
@@ -126,7 +142,10 @@ flowchart TD
 
 ## Non-Streaming (JSON) Mode
 
-The `/full-update` route runs the same 12 stages but waits for all of them to complete before returning a single JSON response. It is used by the plugin's `sync_full_update_resource()` helper for synchronous workflows.
+The backend `/full-update` route remains the synchronous JSON workflow for
+legacy helper calls. Scheduled NetBox jobs use the explicit per-stage stream
+paths in `netbox_proxbox/sync_types.py`, including
+`proxmox/sdn/create/stream` for the optional SDN stage.
 
 ---
 
@@ -151,7 +170,7 @@ Long syncs can be tuned via environment variables on the `proxbox-api` host:
 
 ## Individual Stage Sync
 
-Besides the full 12-stage pipeline, individual objects can be synced on-demand through targeted endpoints. The plugin exposes "Sync Now" buttons on cluster, node, storage, and VM detail pages that call individual sync routes in `proxbox_api/routes/sync/individual/`. These are handled by `netbox_proxbox/services/individual_sync.py` on the plugin side.
+Besides the full 13-stage scheduled pipeline, individual objects can be synced on-demand through targeted endpoints. The plugin exposes "Sync Now" buttons on cluster, node, storage, and VM detail pages that call individual sync routes in `proxbox_api/routes/sync/individual/`. These are handled by `netbox_proxbox/services/individual_sync.py` on the plugin side.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,10 +72,10 @@ The current codebase includes NetBox models for:
 - Replications (Proxmox storage replication metadata)
 - VM backups, VM snapshots, and VM task history
 - Proxmox VE firewall inventory: `ProxmoxFirewallSecurityGroup`, `ProxmoxFirewallRule`, `ProxmoxFirewallIPSet`, `ProxmoxFirewallIPSetEntry`, `ProxmoxFirewallAlias`, `ProxmoxFirewallOptions` (read-only, synced from proxbox-api)
-- SDN inventory (PVE 9.2+): `ProxmoxSdnFabric`, `ProxmoxSdnRouteMap`, `ProxmoxSdnPrefixList`
+- SDN inventory (PVE 9.2+): controllers, zones, VNets, subnets, bindings, fabrics, route maps, and prefix lists
 - Firecracker Cloud inventory: `FirecrackerHostPool`, `FirecrackerHost`, `FirecrackerImageTemplate`, `FirecrackerMicroVM`
 - Operational models: `ProxmoxApplyJob`, `DeletionRequest`
-- Plugin-wide settings (`ProxboxPluginSettings`), including sync mode controls for interfaces and MACs (migration 0051) and interface-batch tunables
+- Plugin-wide settings (`ProxboxPluginSettings`), including sync mode controls for VM, infrastructure, network, and SDN stages plus interface-batch tunables
 
 The plugin UI exposes sync actions for:
 

--- a/netbox_proxbox/api/serializers/__init__.py
+++ b/netbox_proxbox/api/serializers/__init__.py
@@ -56,9 +56,14 @@ from netbox_proxbox.api.serializers.datacenter import (
     ProxmoxDatacenterCpuModelSerializer,
 )
 from netbox_proxbox.api.serializers.sdn import (
+    ProxmoxSdnBindingSerializer,
+    ProxmoxSdnControllerSerializer,
     ProxmoxSdnFabricSerializer,
     ProxmoxSdnPrefixListSerializer,
     ProxmoxSdnRouteMapSerializer,
+    ProxmoxSdnSubnetSerializer,
+    ProxmoxSdnVNetSerializer,
+    ProxmoxSdnZoneSerializer,
 )
 from netbox_proxbox.api.serializers.replication import ReplicationSerializer
 from netbox_proxbox.api.serializers.settings import ProxboxPluginSettingsSerializer

--- a/netbox_proxbox/api/serializers/sdn.py
+++ b/netbox_proxbox/api/serializers/sdn.py
@@ -7,9 +7,14 @@ from netbox.api.serializers import NetBoxModelSerializer
 
 from netbox_proxbox.choices import FirewallSyncStatusChoices, SdnFabricTypeChoices
 from netbox_proxbox.models import (
+    ProxmoxSdnBinding,
+    ProxmoxSdnController,
     ProxmoxSdnFabric,
     ProxmoxSdnPrefixList,
     ProxmoxSdnRouteMap,
+    ProxmoxSdnSubnet,
+    ProxmoxSdnVNet,
+    ProxmoxSdnZone,
 )
 
 
@@ -33,6 +38,145 @@ class ProxmoxSdnFabricSerializer(NetBoxModelSerializer):
             "vrf_vxlan",
             "peers",
             "status",
+            "raw_config",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+
+
+class ProxmoxSdnControllerSerializer(NetBoxModelSerializer):
+    status = ChoiceField(choices=FirewallSyncStatusChoices, required=False)
+
+    class Meta:
+        model = ProxmoxSdnController
+        fields = (
+            "id",
+            "url",
+            "display",
+            "endpoint",
+            "cluster_name",
+            "controller_name",
+            "controller_type",
+            "asn",
+            "peers",
+            "nodes",
+            "loopback",
+            "state",
+            "status",
+            "raw_config",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+
+
+class ProxmoxSdnZoneSerializer(NetBoxModelSerializer):
+    status = ChoiceField(choices=FirewallSyncStatusChoices, required=False)
+
+    class Meta:
+        model = ProxmoxSdnZone
+        fields = (
+            "id",
+            "url",
+            "display",
+            "endpoint",
+            "cluster_name",
+            "zone_name",
+            "zone_type",
+            "controller",
+            "vrf_vxlan",
+            "tag",
+            "mtu",
+            "dns",
+            "ipam",
+            "rt_import",
+            "state",
+            "status",
+            "raw_config",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+
+
+class ProxmoxSdnVNetSerializer(NetBoxModelSerializer):
+    status = ChoiceField(choices=FirewallSyncStatusChoices, required=False)
+
+    class Meta:
+        model = ProxmoxSdnVNet
+        fields = (
+            "id",
+            "url",
+            "display",
+            "endpoint",
+            "cluster_name",
+            "zone_name",
+            "vnet_name",
+            "vnet_type",
+            "tag",
+            "alias",
+            "vlanaware",
+            "state",
+            "l2vpn",
+            "status",
+            "raw_config",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+
+
+class ProxmoxSdnSubnetSerializer(NetBoxModelSerializer):
+    status = ChoiceField(choices=FirewallSyncStatusChoices, required=False)
+
+    class Meta:
+        model = ProxmoxSdnSubnet
+        fields = (
+            "id",
+            "url",
+            "display",
+            "endpoint",
+            "cluster_name",
+            "zone_name",
+            "vnet_name",
+            "subnet",
+            "subnet_type",
+            "gateway",
+            "snat",
+            "prefix",
+            "skip_reason",
+            "status",
+            "raw_config",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+
+
+class ProxmoxSdnBindingSerializer(NetBoxModelSerializer):
+    class Meta:
+        model = ProxmoxSdnBinding
+        fields = (
+            "id",
+            "url",
+            "display",
+            "endpoint",
+            "cluster_name",
+            "source_type",
+            "source_name",
+            "node",
+            "zone_name",
+            "vnet_name",
+            "target_type",
+            "target_id",
+            "status",
+            "conflict_reason",
             "raw_config",
             "tags",
             "custom_fields",

--- a/netbox_proxbox/api/urls.py
+++ b/netbox_proxbox/api/urls.py
@@ -130,6 +130,31 @@ router.register(
     basename="proxmoxsdnfabric",
 )
 router.register(
+    "sdn-controllers",
+    views.ProxmoxSdnControllerViewSet,
+    basename="proxmoxsdncontroller",
+)
+router.register(
+    "sdn-zones",
+    views.ProxmoxSdnZoneViewSet,
+    basename="proxmoxsdnzone",
+)
+router.register(
+    "sdn-vnets",
+    views.ProxmoxSdnVNetViewSet,
+    basename="proxmoxsdnvnet",
+)
+router.register(
+    "sdn-subnets",
+    views.ProxmoxSdnSubnetViewSet,
+    basename="proxmoxsdnsubnet",
+)
+router.register(
+    "sdn-bindings",
+    views.ProxmoxSdnBindingViewSet,
+    basename="proxmoxsdnbinding",
+)
+router.register(
     "sdn-route-maps",
     views.ProxmoxSdnRouteMapViewSet,
     basename="proxmoxsdnroutemap",

--- a/netbox_proxbox/api/views.py
+++ b/netbox_proxbox/api/views.py
@@ -51,9 +51,14 @@ from .serializers import (
     ProxmoxFirewallSecurityGroupSerializer,
     ProxmoxDatacenterCpuModelSerializer,
     ProxmoxNodeSerializer,
+    ProxmoxSdnBindingSerializer,
+    ProxmoxSdnControllerSerializer,
     ProxmoxSdnFabricSerializer,
     ProxmoxSdnPrefixListSerializer,
     ProxmoxSdnRouteMapSerializer,
+    ProxmoxSdnSubnetSerializer,
+    ProxmoxSdnVNetSerializer,
+    ProxmoxSdnZoneSerializer,
     ProxmoxStorageSerializer,
     ProxmoxVMCloudInitSerializer,
     ProxmoxVMTemplateSerializer,
@@ -1609,6 +1614,46 @@ class ProxmoxSdnFabricViewSet(NetBoxModelViewSet):
     queryset = models.ProxmoxSdnFabric.objects.select_related("endpoint")
     serializer_class = ProxmoxSdnFabricSerializer
     filterset_class = filtersets.ProxmoxSdnFabricFilterSet
+
+
+class ProxmoxSdnControllerViewSet(NetBoxModelViewSet):
+    """REST API for Proxmox SDN controllers."""
+
+    queryset = models.ProxmoxSdnController.objects.select_related("endpoint")
+    serializer_class = ProxmoxSdnControllerSerializer
+    filterset_class = filtersets.ProxmoxSdnControllerFilterSet
+
+
+class ProxmoxSdnZoneViewSet(NetBoxModelViewSet):
+    """REST API for Proxmox SDN zones."""
+
+    queryset = models.ProxmoxSdnZone.objects.select_related("endpoint")
+    serializer_class = ProxmoxSdnZoneSerializer
+    filterset_class = filtersets.ProxmoxSdnZoneFilterSet
+
+
+class ProxmoxSdnVNetViewSet(NetBoxModelViewSet):
+    """REST API for Proxmox SDN VNets."""
+
+    queryset = models.ProxmoxSdnVNet.objects.select_related("endpoint", "l2vpn")
+    serializer_class = ProxmoxSdnVNetSerializer
+    filterset_class = filtersets.ProxmoxSdnVNetFilterSet
+
+
+class ProxmoxSdnSubnetViewSet(NetBoxModelViewSet):
+    """REST API for Proxmox SDN subnets."""
+
+    queryset = models.ProxmoxSdnSubnet.objects.select_related("endpoint", "prefix")
+    serializer_class = ProxmoxSdnSubnetSerializer
+    filterset_class = filtersets.ProxmoxSdnSubnetFilterSet
+
+
+class ProxmoxSdnBindingViewSet(NetBoxModelViewSet):
+    """REST API for Proxmox SDN binding/status records."""
+
+    queryset = models.ProxmoxSdnBinding.objects.select_related("endpoint")
+    serializer_class = ProxmoxSdnBindingSerializer
+    filterset_class = filtersets.ProxmoxSdnBindingFilterSet
 
 
 class ProxmoxSdnRouteMapViewSet(NetBoxModelViewSet):

--- a/netbox_proxbox/choices.py
+++ b/netbox_proxbox/choices.py
@@ -59,6 +59,7 @@ class SyncTypeChoices(ChoiceSet):
     NETWORK_INTERFACES = "network-interfaces"
     VM_INTERFACES = "vm-interfaces"
     IP_ADDRESSES = "ip-addresses"
+    SDN = "sdn"
     BACKUP_ROUTINES = "backup-routines"
     REPLICATIONS = "replications"
     TASK_HISTORY = "task-history"
@@ -74,6 +75,7 @@ class SyncTypeChoices(ChoiceSet):
         (NETWORK_INTERFACES, _("Network Interfaces"), "indigo"),
         (VM_INTERFACES, _("VM Interfaces"), "indigo"),
         (IP_ADDRESSES, _("IP Addresses"), "violet"),
+        (SDN, _("SDN"), "lime"),
         (BACKUP_ROUTINES, _("Backup Routines"), "yellow"),
         (REPLICATIONS, _("Replications"), "teal"),
         (TASK_HISTORY, _("Task History"), "amber"),

--- a/netbox_proxbox/constants.py
+++ b/netbox_proxbox/constants.py
@@ -24,6 +24,7 @@ SYNC_MODE_FIELD_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
             "sync_mode_cluster",
             "sync_mode_node",
             "sync_mode_storage",
+            "sync_mode_sdn",
         ),
     ),
 )

--- a/netbox_proxbox/filtersets.py
+++ b/netbox_proxbox/filtersets.py
@@ -34,9 +34,14 @@ from .models import (
     ProxmoxFirewallOptions,
     ProxmoxFirewallRule,
     ProxmoxFirewallSecurityGroup,
+    ProxmoxSdnBinding,
+    ProxmoxSdnController,
     ProxmoxSdnFabric,
     ProxmoxSdnRouteMap,
     ProxmoxSdnPrefixList,
+    ProxmoxSdnSubnet,
+    ProxmoxSdnVNet,
+    ProxmoxSdnZone,
     ProxmoxDatacenterCpuModel,
     ProxmoxNode,
     ProxmoxStorage,
@@ -880,6 +885,124 @@ class ProxmoxSdnFabricFilterSet(ProxboxModelFilterSet):
             return queryset
         return queryset.filter(
             Q(fabric_name__icontains=value) | Q(cluster_name__icontains=value)
+        )
+
+
+@register_filterset
+class ProxmoxSdnControllerFilterSet(ProxboxModelFilterSet):
+    """Filter Proxmox SDN controllers."""
+
+    class Meta:
+        model = ProxmoxSdnController
+        fields = (
+            "id",
+            "endpoint",
+            "cluster_name",
+            "controller_name",
+            "controller_type",
+            "status",
+        )
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(controller_name__icontains=value) | Q(cluster_name__icontains=value)
+        )
+
+
+@register_filterset
+class ProxmoxSdnZoneFilterSet(ProxboxModelFilterSet):
+    """Filter Proxmox SDN zones."""
+
+    class Meta:
+        model = ProxmoxSdnZone
+        fields = ("id", "endpoint", "cluster_name", "zone_name", "zone_type", "status")
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(zone_name__icontains=value) | Q(cluster_name__icontains=value)
+        )
+
+
+@register_filterset
+class ProxmoxSdnVNetFilterSet(ProxboxModelFilterSet):
+    """Filter Proxmox SDN VNets."""
+
+    class Meta:
+        model = ProxmoxSdnVNet
+        fields = (
+            "id",
+            "endpoint",
+            "cluster_name",
+            "zone_name",
+            "vnet_name",
+            "vnet_type",
+            "tag",
+            "status",
+        )
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(vnet_name__icontains=value)
+            | Q(zone_name__icontains=value)
+            | Q(cluster_name__icontains=value)
+        )
+
+
+@register_filterset
+class ProxmoxSdnSubnetFilterSet(ProxboxModelFilterSet):
+    """Filter Proxmox SDN subnets."""
+
+    class Meta:
+        model = ProxmoxSdnSubnet
+        fields = (
+            "id",
+            "endpoint",
+            "cluster_name",
+            "zone_name",
+            "vnet_name",
+            "subnet",
+            "status",
+        )
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(subnet__icontains=value)
+            | Q(vnet_name__icontains=value)
+            | Q(cluster_name__icontains=value)
+        )
+
+
+@register_filterset
+class ProxmoxSdnBindingFilterSet(ProxboxModelFilterSet):
+    """Filter Proxmox SDN binding/status rows."""
+
+    class Meta:
+        model = ProxmoxSdnBinding
+        fields = (
+            "id",
+            "endpoint",
+            "cluster_name",
+            "source_type",
+            "source_name",
+            "target_type",
+            "status",
+        )
+
+    def search(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        if not value.strip():
+            return queryset
+        return queryset.filter(
+            Q(source_name__icontains=value)
+            | Q(target_type__icontains=value)
+            | Q(cluster_name__icontains=value)
         )
 
 

--- a/netbox_proxbox/forms/__init__.py
+++ b/netbox_proxbox/forms/__init__.py
@@ -16,12 +16,22 @@ from .firewall import (
     ProxmoxFirewallSecurityGroupForm,
 )
 from .sdn import (
+    ProxmoxSdnBindingFilterForm,
+    ProxmoxSdnBindingForm,
+    ProxmoxSdnControllerFilterForm,
+    ProxmoxSdnControllerForm,
     ProxmoxSdnFabricFilterForm,
     ProxmoxSdnFabricForm,
     ProxmoxSdnPrefixListFilterForm,
     ProxmoxSdnPrefixListForm,
     ProxmoxSdnRouteMapFilterForm,
     ProxmoxSdnRouteMapForm,
+    ProxmoxSdnSubnetFilterForm,
+    ProxmoxSdnSubnetForm,
+    ProxmoxSdnVNetFilterForm,
+    ProxmoxSdnVNetForm,
+    ProxmoxSdnZoneFilterForm,
+    ProxmoxSdnZoneForm,
 )
 from .datacenter import (
     ProxmoxDatacenterCpuModelFilterForm,

--- a/netbox_proxbox/forms/proxmox.py
+++ b/netbox_proxbox/forms/proxmox.py
@@ -266,6 +266,7 @@ class ProxmoxEndpointSettingsForm(NetBoxModelForm):
             "sync_mode_cluster": "Cluster sync mode",
             "sync_mode_node": "Node sync mode",
             "sync_mode_storage": "Storage sync mode",
+            "sync_mode_sdn": "SDN sync mode",
             "sync_mode_ip_address": "IP address sync mode",
         }
         for name in SYNC_MODE_FIELDS:

--- a/netbox_proxbox/forms/sdn.py
+++ b/netbox_proxbox/forms/sdn.py
@@ -50,6 +50,131 @@ class ProxmoxSdnFabricFilterForm(_SdnEndpointMixin, NetBoxModelFilterSetForm):
     status = forms.ChoiceField(choices=_STATUS_CHOICES, required=False)
 
 
+class ProxmoxSdnControllerForm(_SdnEndpointMixin, NetBoxModelForm):
+    class Meta:
+        model = models.ProxmoxSdnController
+        fields = (
+            "endpoint",
+            "cluster_name",
+            "controller_name",
+            "controller_type",
+            "asn",
+            "peers",
+            "nodes",
+            "loopback",
+            "state",
+            "status",
+            "raw_config",
+            "tags",
+        )
+
+
+class ProxmoxSdnControllerFilterForm(_SdnEndpointMixin, NetBoxModelFilterSetForm):
+    model = models.ProxmoxSdnController
+    status = forms.ChoiceField(choices=_STATUS_CHOICES, required=False)
+
+
+class ProxmoxSdnZoneForm(_SdnEndpointMixin, NetBoxModelForm):
+    class Meta:
+        model = models.ProxmoxSdnZone
+        fields = (
+            "endpoint",
+            "cluster_name",
+            "zone_name",
+            "zone_type",
+            "controller",
+            "vrf_vxlan",
+            "tag",
+            "mtu",
+            "dns",
+            "ipam",
+            "rt_import",
+            "state",
+            "status",
+            "raw_config",
+            "tags",
+        )
+
+
+class ProxmoxSdnZoneFilterForm(_SdnEndpointMixin, NetBoxModelFilterSetForm):
+    model = models.ProxmoxSdnZone
+    status = forms.ChoiceField(choices=_STATUS_CHOICES, required=False)
+
+
+class ProxmoxSdnVNetForm(_SdnEndpointMixin, NetBoxModelForm):
+    class Meta:
+        model = models.ProxmoxSdnVNet
+        fields = (
+            "endpoint",
+            "cluster_name",
+            "zone_name",
+            "vnet_name",
+            "vnet_type",
+            "tag",
+            "alias",
+            "vlanaware",
+            "state",
+            "l2vpn",
+            "status",
+            "raw_config",
+            "tags",
+        )
+
+
+class ProxmoxSdnVNetFilterForm(_SdnEndpointMixin, NetBoxModelFilterSetForm):
+    model = models.ProxmoxSdnVNet
+    status = forms.ChoiceField(choices=_STATUS_CHOICES, required=False)
+
+
+class ProxmoxSdnSubnetForm(_SdnEndpointMixin, NetBoxModelForm):
+    class Meta:
+        model = models.ProxmoxSdnSubnet
+        fields = (
+            "endpoint",
+            "cluster_name",
+            "zone_name",
+            "vnet_name",
+            "subnet",
+            "subnet_type",
+            "gateway",
+            "snat",
+            "prefix",
+            "skip_reason",
+            "status",
+            "raw_config",
+            "tags",
+        )
+
+
+class ProxmoxSdnSubnetFilterForm(_SdnEndpointMixin, NetBoxModelFilterSetForm):
+    model = models.ProxmoxSdnSubnet
+    status = forms.ChoiceField(choices=_STATUS_CHOICES, required=False)
+
+
+class ProxmoxSdnBindingForm(_SdnEndpointMixin, NetBoxModelForm):
+    class Meta:
+        model = models.ProxmoxSdnBinding
+        fields = (
+            "endpoint",
+            "cluster_name",
+            "source_type",
+            "source_name",
+            "node",
+            "zone_name",
+            "vnet_name",
+            "target_type",
+            "target_id",
+            "status",
+            "conflict_reason",
+            "raw_config",
+            "tags",
+        )
+
+
+class ProxmoxSdnBindingFilterForm(_SdnEndpointMixin, NetBoxModelFilterSetForm):
+    model = models.ProxmoxSdnBinding
+
+
 class ProxmoxSdnRouteMapForm(_SdnEndpointMixin, NetBoxModelForm):
     class Meta:
         model = models.ProxmoxSdnRouteMap

--- a/netbox_proxbox/forms/settings.py
+++ b/netbox_proxbox/forms/settings.py
@@ -607,6 +607,7 @@ class ProxboxPluginSettingsForm(forms.Form):
             "sync_mode_cluster": "Cluster sync mode",
             "sync_mode_node": "Node sync mode",
             "sync_mode_storage": "Storage sync mode",
+            "sync_mode_sdn": "SDN sync mode",
             "sync_mode_ip_address": "IP address sync mode",
         }
         sync_mode_help = {
@@ -617,13 +618,18 @@ class ProxboxPluginSettingsForm(forms.Form):
             "sync_mode_cluster": "Controls Proxmox cluster tracking sync.",
             "sync_mode_node": "Controls Proxmox node tracking sync.",
             "sync_mode_storage": "Controls Proxmox storage sync.",
+            "sync_mode_sdn": "Controls read-only Proxmox SDN inventory and NetBox L2VPN sync.",
             "sync_mode_ip_address": "Controls IP address sync from VM interfaces.",
         }
         for name in SYNC_MODE_FIELDS:
             self.fields[name] = forms.ChoiceField(
                 required=True,
                 choices=_sync_mode_choice_options(),
-                initial=SyncModeChoices.ALWAYS,
+                initial=(
+                    SyncModeChoices.DISABLED
+                    if name == "sync_mode_sdn"
+                    else SyncModeChoices.ALWAYS
+                ),
                 label=sync_mode_labels[name],
                 help_text=sync_mode_help[name],
             )

--- a/netbox_proxbox/jobs.py
+++ b/netbox_proxbox/jobs.py
@@ -790,30 +790,6 @@ class ProxboxSyncJob(JobRunner):
                 )
             )
 
-            # Sync SDN objects (fabrics, route maps, prefix lists).
-            from netbox_proxbox.services.sync_sdn import sync_sdn  # noqa: PLC0415
-
-            self.logger.info("Syncing SDN objects from proxbox-api")
-            sdn_result = sync_sdn()
-            if sdn_result.success:
-                self.logger.info(
-                    f"SDN sync complete: {sdn_result.endpoints_processed} endpoint(s), "
-                    f"fabrics={sdn_result.fabrics_created}/{sdn_result.fabrics_updated}, "
-                    f"route_maps={sdn_result.route_maps_created}/{sdn_result.route_maps_updated}, "
-                    f"prefix_lists={sdn_result.prefix_lists_created}/{sdn_result.prefix_lists_updated}"
-                )
-            else:
-                self.logger.warning(
-                    f"SDN sync failed or partially failed: {sdn_result.error or 'see per_endpoint log'}"
-                )
-            endpoint_runtime_phases.extend(
-                _phases_from_service_result(
-                    sdn_result,
-                    kind="sdn",
-                    label="SDN sync",
-                )
-            )
-
             # Sync datacenter CPU models.
             from netbox_proxbox.services.sync_datacenter import sync_datacenter  # noqa: PLC0415
 

--- a/netbox_proxbox/migrations/0054_sdn_sync_controls_and_inventory.py
+++ b/netbox_proxbox/migrations/0054_sdn_sync_controls_and_inventory.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import django.db.models.deletion
+import taggit.managers
+import utilities.json
+from django.db import migrations, models
+
+from netbox_proxbox.migrations._idempotent_ops import (
+    add_field_idempotent,
+    create_model_idempotent,
+)
+
+
+SYNC_MODE_CHOICES = [
+    ("always", "Always"),
+    ("bootstrap_only", "Bootstrap only"),
+    ("disabled", "Disabled"),
+]
+
+SYNC_STATUS_CHOICES = [
+    ("active", "Active"),
+    ("stale", "Stale"),
+]
+
+
+def _netbox_model_fields():
+    return [
+        (
+            "id",
+            models.BigAutoField(auto_created=True, primary_key=True, serialize=False),
+        ),
+        ("created", models.DateTimeField(auto_now_add=True, null=True)),
+        ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+        (
+            "custom_field_data",
+            models.JSONField(
+                blank=True,
+                default=dict,
+                encoder=utilities.json.CustomFieldJSONEncoder,
+            ),
+        ),
+        (
+            "tags",
+            taggit.managers.TaggableManager(
+                through="extras.TaggedItem",
+                to="extras.Tag",
+            ),
+        ),
+    ]
+
+
+def _endpoint_field(related_name: str):
+    return models.ForeignKey(
+        blank=True,
+        null=True,
+        on_delete=django.db.models.deletion.CASCADE,
+        related_name=related_name,
+        to="netbox_proxbox.proxmoxendpoint",
+        verbose_name="Proxmox endpoint",
+    )
+
+
+def _status_field():
+    return models.CharField(
+        choices=SYNC_STATUS_CHOICES,
+        default="active",
+        max_length=20,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extras", "0134_owner"),
+        ("ipam", "0089_default_ordering_indexes"),
+        ("netbox_proxbox", "0053_tenant_from_cluster"),
+        ("vpn", "0012_default_ordering_indexes"),
+    ]
+
+    operations = [
+        add_field_idempotent(
+            model_name="proxboxpluginsettings",
+            field_name="sync_mode_sdn",
+            field=models.CharField(
+                choices=SYNC_MODE_CHOICES,
+                default="disabled",
+                max_length=16,
+            ),
+        ),
+        add_field_idempotent(
+            model_name="proxmoxendpoint",
+            field_name="sync_mode_sdn",
+            field=models.CharField(
+                blank=True,
+                choices=SYNC_MODE_CHOICES,
+                max_length=16,
+                null=True,
+            ),
+        ),
+        create_model_idempotent(
+            name="ProxmoxSdnController",
+            fields=[
+                *_netbox_model_fields(),
+                ("endpoint", _endpoint_field("sdn_controllers")),
+                ("cluster_name", models.CharField(max_length=255)),
+                ("controller_name", models.CharField(max_length=255)),
+                ("controller_type", models.CharField(blank=True, max_length=32)),
+                ("asn", models.IntegerField(blank=True, null=True)),
+                ("peers", models.JSONField(blank=True, default=list)),
+                ("nodes", models.JSONField(blank=True, default=list)),
+                ("loopback", models.CharField(blank=True, max_length=255)),
+                ("state", models.CharField(blank=True, max_length=32)),
+                ("status", _status_field()),
+                ("raw_config", models.JSONField(blank=True, default=dict)),
+            ],
+            options={
+                "verbose_name": "SDN Controller",
+                "verbose_name_plural": "SDN Controllers",
+                "ordering": ("endpoint", "cluster_name", "controller_name"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=["endpoint", "cluster_name", "controller_name"],
+                        name="nbpx_sdncontroller_unique_endpoint_cluster_name",
+                    )
+                ],
+            },
+        ),
+        create_model_idempotent(
+            name="ProxmoxSdnZone",
+            fields=[
+                *_netbox_model_fields(),
+                ("endpoint", _endpoint_field("sdn_zones")),
+                ("cluster_name", models.CharField(max_length=255)),
+                ("zone_name", models.CharField(max_length=255)),
+                ("zone_type", models.CharField(blank=True, max_length=32)),
+                ("controller", models.CharField(blank=True, max_length=255)),
+                ("vrf_vxlan", models.IntegerField(blank=True, null=True)),
+                ("tag", models.IntegerField(blank=True, null=True)),
+                ("mtu", models.IntegerField(blank=True, null=True)),
+                ("dns", models.CharField(blank=True, max_length=255)),
+                ("ipam", models.CharField(blank=True, max_length=255)),
+                ("rt_import", models.JSONField(blank=True, default=list)),
+                ("state", models.CharField(blank=True, max_length=32)),
+                ("status", _status_field()),
+                ("raw_config", models.JSONField(blank=True, default=dict)),
+            ],
+            options={
+                "verbose_name": "SDN Zone",
+                "verbose_name_plural": "SDN Zones",
+                "ordering": ("endpoint", "cluster_name", "zone_name"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=["endpoint", "cluster_name", "zone_name"],
+                        name="nbpx_sdnzone_unique_endpoint_cluster_name",
+                    )
+                ],
+            },
+        ),
+        create_model_idempotent(
+            name="ProxmoxSdnVNet",
+            fields=[
+                *_netbox_model_fields(),
+                ("endpoint", _endpoint_field("sdn_vnets")),
+                ("cluster_name", models.CharField(max_length=255)),
+                ("zone_name", models.CharField(blank=True, max_length=255)),
+                ("vnet_name", models.CharField(max_length=255)),
+                ("vnet_type", models.CharField(blank=True, max_length=32)),
+                ("tag", models.IntegerField(blank=True, null=True)),
+                ("alias", models.CharField(blank=True, max_length=255)),
+                ("vlanaware", models.BooleanField(default=False)),
+                ("state", models.CharField(blank=True, max_length=32)),
+                (
+                    "l2vpn",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="vpn.l2vpn",
+                        verbose_name="NetBox L2VPN",
+                    ),
+                ),
+                ("status", _status_field()),
+                ("raw_config", models.JSONField(blank=True, default=dict)),
+            ],
+            options={
+                "verbose_name": "SDN VNet",
+                "verbose_name_plural": "SDN VNets",
+                "ordering": ("endpoint", "cluster_name", "zone_name", "vnet_name"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=["endpoint", "cluster_name", "vnet_name"],
+                        name="nbpx_sdnvnet_unique_endpoint_cluster_name",
+                    )
+                ],
+            },
+        ),
+        create_model_idempotent(
+            name="ProxmoxSdnSubnet",
+            fields=[
+                *_netbox_model_fields(),
+                ("endpoint", _endpoint_field("sdn_subnets")),
+                ("cluster_name", models.CharField(max_length=255)),
+                ("zone_name", models.CharField(blank=True, max_length=255)),
+                ("vnet_name", models.CharField(max_length=255)),
+                ("subnet", models.CharField(max_length=128)),
+                ("subnet_type", models.CharField(blank=True, max_length=32)),
+                ("gateway", models.CharField(blank=True, max_length=128)),
+                ("snat", models.BooleanField(default=False)),
+                (
+                    "prefix",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="ipam.prefix",
+                        verbose_name="NetBox prefix",
+                    ),
+                ),
+                ("skip_reason", models.TextField(blank=True)),
+                ("status", _status_field()),
+                ("raw_config", models.JSONField(blank=True, default=dict)),
+            ],
+            options={
+                "verbose_name": "SDN Subnet",
+                "verbose_name_plural": "SDN Subnets",
+                "ordering": ("endpoint", "cluster_name", "vnet_name", "subnet"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=["endpoint", "cluster_name", "vnet_name", "subnet"],
+                        name="nbpx_sdnsubnet_unique_endpoint_cluster_vnet_subnet",
+                    )
+                ],
+            },
+        ),
+        create_model_idempotent(
+            name="ProxmoxSdnBinding",
+            fields=[
+                *_netbox_model_fields(),
+                ("endpoint", _endpoint_field("sdn_bindings")),
+                ("cluster_name", models.CharField(max_length=255)),
+                ("source_type", models.CharField(max_length=64)),
+                ("source_name", models.CharField(max_length=512)),
+                ("node", models.CharField(blank=True, max_length=255)),
+                ("zone_name", models.CharField(blank=True, max_length=255)),
+                ("vnet_name", models.CharField(blank=True, max_length=255)),
+                ("target_type", models.CharField(blank=True, max_length=64)),
+                ("target_id", models.PositiveBigIntegerField(blank=True, null=True)),
+                ("status", models.CharField(default="active", max_length=64)),
+                ("conflict_reason", models.TextField(blank=True)),
+                ("raw_config", models.JSONField(blank=True, default=dict)),
+            ],
+            options={
+                "verbose_name": "SDN Binding",
+                "verbose_name_plural": "SDN Bindings",
+                "ordering": ("endpoint", "cluster_name", "source_type", "source_name"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=[
+                            "endpoint",
+                            "cluster_name",
+                            "source_type",
+                            "source_name",
+                        ],
+                        name="nbpx_sdnbinding_unique_endpoint_cluster_source",
+                    )
+                ],
+            },
+        ),
+    ]

--- a/netbox_proxbox/models/__init__.py
+++ b/netbox_proxbox/models/__init__.py
@@ -10,6 +10,13 @@ from netbox_proxbox.models.firewall_options import ProxmoxFirewallOptions
 from netbox_proxbox.models.firewall_rule import ProxmoxFirewallRule
 from netbox_proxbox.models.firewall_security_group import ProxmoxFirewallSecurityGroup
 from netbox_proxbox.models.sdn_fabric import ProxmoxSdnFabric
+from netbox_proxbox.models.sdn_inventory import (
+    ProxmoxSdnBinding,
+    ProxmoxSdnController,
+    ProxmoxSdnSubnet,
+    ProxmoxSdnVNet,
+    ProxmoxSdnZone,
+)
 from netbox_proxbox.models.sdn_route_map import ProxmoxSdnRouteMap
 from netbox_proxbox.models.sdn_prefix_list import ProxmoxSdnPrefixList
 from netbox_proxbox.models.datacenter_cpu_model import ProxmoxDatacenterCpuModel
@@ -50,6 +57,11 @@ __all__ = (
     "ProxmoxFirewallRule",
     "ProxmoxFirewallSecurityGroup",
     "ProxmoxSdnFabric",
+    "ProxmoxSdnBinding",
+    "ProxmoxSdnController",
+    "ProxmoxSdnSubnet",
+    "ProxmoxSdnVNet",
+    "ProxmoxSdnZone",
     "ProxmoxSdnRouteMap",
     "ProxmoxSdnPrefixList",
     "ProxmoxDatacenterCpuModel",

--- a/netbox_proxbox/models/plugin_settings.py
+++ b/netbox_proxbox/models/plugin_settings.py
@@ -151,6 +151,16 @@ class ProxboxPluginSettings(NetBoxModel):
         verbose_name=_("Storage sync mode"),
         help_text=_("Controls synchronization of Proxmox storage inventory."),
     )
+    sync_mode_sdn = models.CharField(
+        max_length=16,
+        choices=SyncModeChoices,
+        default=SyncModeChoices.DISABLED,
+        verbose_name=_("SDN sync mode"),
+        help_text=_(
+            "Controls read-only Proxmox SDN inventory and NetBox L2VPN sync. "
+            "Disabled by default because older clusters may not expose SDN APIs."
+        ),
+    )
     sync_mode_ip_address = models.CharField(
         max_length=16,
         choices=SyncModeChoices,

--- a/netbox_proxbox/models/proxmox_endpoint.py
+++ b/netbox_proxbox/models/proxmox_endpoint.py
@@ -217,6 +217,16 @@ class ProxmoxEndpoint(EndpointBase):
             "Per-endpoint override for Proxmox storage sync. Leave blank to inherit."
         ),
     )
+    sync_mode_sdn = models.CharField(
+        max_length=16,
+        choices=SyncModeChoices,
+        null=True,
+        blank=True,
+        verbose_name=_("SDN sync mode"),
+        help_text=_(
+            "Per-endpoint override for read-only Proxmox SDN sync. Leave blank to inherit."
+        ),
+    )
     sync_mode_ip_address = models.CharField(
         max_length=16,
         choices=SyncModeChoices,

--- a/netbox_proxbox/models/sdn_inventory.py
+++ b/netbox_proxbox/models/sdn_inventory.py
@@ -1,0 +1,249 @@
+"""Additional Proxmox SDN inventory models."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from netbox.models import NetBoxModel
+
+from netbox_proxbox.choices import FirewallSyncStatusChoices
+
+
+class ProxmoxSdnController(NetBoxModel):
+    """Proxmox SDN controller metadata."""
+
+    endpoint = models.ForeignKey(
+        to="netbox_proxbox.ProxmoxEndpoint",
+        on_delete=models.CASCADE,
+        related_name="sdn_controllers",
+        null=True,
+        blank=True,
+        verbose_name=_("Proxmox endpoint"),
+    )
+    cluster_name = models.CharField(max_length=255)
+    controller_name = models.CharField(max_length=255)
+    controller_type = models.CharField(max_length=32, blank=True)
+    asn = models.IntegerField(null=True, blank=True)
+    peers = models.JSONField(default=list, blank=True)
+    nodes = models.JSONField(default=list, blank=True)
+    loopback = models.CharField(max_length=255, blank=True)
+    state = models.CharField(max_length=32, blank=True)
+    status = models.CharField(
+        max_length=20,
+        choices=FirewallSyncStatusChoices,
+        default=FirewallSyncStatusChoices.ACTIVE,
+    )
+    raw_config = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        verbose_name = _("SDN Controller")
+        verbose_name_plural = _("SDN Controllers")
+        ordering = ("endpoint", "cluster_name", "controller_name")
+        constraints = [
+            models.UniqueConstraint(
+                fields=["endpoint", "cluster_name", "controller_name"],
+                name="nbpx_sdncontroller_unique_endpoint_cluster_name",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.cluster_name} / {self.controller_name}"
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_proxbox:proxmoxsdncontroller", args=[self.pk])
+
+
+class ProxmoxSdnZone(NetBoxModel):
+    """Proxmox SDN zone metadata."""
+
+    endpoint = models.ForeignKey(
+        to="netbox_proxbox.ProxmoxEndpoint",
+        on_delete=models.CASCADE,
+        related_name="sdn_zones",
+        null=True,
+        blank=True,
+        verbose_name=_("Proxmox endpoint"),
+    )
+    cluster_name = models.CharField(max_length=255)
+    zone_name = models.CharField(max_length=255)
+    zone_type = models.CharField(max_length=32, blank=True)
+    controller = models.CharField(max_length=255, blank=True)
+    vrf_vxlan = models.IntegerField(null=True, blank=True)
+    tag = models.IntegerField(null=True, blank=True)
+    mtu = models.IntegerField(null=True, blank=True)
+    dns = models.CharField(max_length=255, blank=True)
+    ipam = models.CharField(max_length=255, blank=True)
+    rt_import = models.JSONField(default=list, blank=True)
+    state = models.CharField(max_length=32, blank=True)
+    status = models.CharField(
+        max_length=20,
+        choices=FirewallSyncStatusChoices,
+        default=FirewallSyncStatusChoices.ACTIVE,
+    )
+    raw_config = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        verbose_name = _("SDN Zone")
+        verbose_name_plural = _("SDN Zones")
+        ordering = ("endpoint", "cluster_name", "zone_name")
+        constraints = [
+            models.UniqueConstraint(
+                fields=["endpoint", "cluster_name", "zone_name"],
+                name="nbpx_sdnzone_unique_endpoint_cluster_name",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.cluster_name} / {self.zone_name}"
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_proxbox:proxmoxsdnzone", args=[self.pk])
+
+
+class ProxmoxSdnVNet(NetBoxModel):
+    """Proxmox SDN VNet metadata linked to NetBox L2VPN when managed."""
+
+    endpoint = models.ForeignKey(
+        to="netbox_proxbox.ProxmoxEndpoint",
+        on_delete=models.CASCADE,
+        related_name="sdn_vnets",
+        null=True,
+        blank=True,
+        verbose_name=_("Proxmox endpoint"),
+    )
+    cluster_name = models.CharField(max_length=255)
+    zone_name = models.CharField(max_length=255, blank=True)
+    vnet_name = models.CharField(max_length=255)
+    vnet_type = models.CharField(max_length=32, blank=True)
+    tag = models.IntegerField(null=True, blank=True)
+    alias = models.CharField(max_length=255, blank=True)
+    vlanaware = models.BooleanField(default=False)
+    state = models.CharField(max_length=32, blank=True)
+    l2vpn = models.ForeignKey(
+        to="vpn.L2VPN",
+        on_delete=models.SET_NULL,
+        related_name="+",
+        null=True,
+        blank=True,
+        verbose_name=_("NetBox L2VPN"),
+    )
+    status = models.CharField(
+        max_length=20,
+        choices=FirewallSyncStatusChoices,
+        default=FirewallSyncStatusChoices.ACTIVE,
+    )
+    raw_config = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        verbose_name = _("SDN VNet")
+        verbose_name_plural = _("SDN VNets")
+        ordering = ("endpoint", "cluster_name", "zone_name", "vnet_name")
+        constraints = [
+            models.UniqueConstraint(
+                fields=["endpoint", "cluster_name", "vnet_name"],
+                name="nbpx_sdnvnet_unique_endpoint_cluster_name",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.cluster_name} / {self.zone_name} / {self.vnet_name}"
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_proxbox:proxmoxsdnvnet", args=[self.pk])
+
+
+class ProxmoxSdnSubnet(NetBoxModel):
+    """Proxmox SDN subnet metadata linked to NetBox Prefix when valid."""
+
+    endpoint = models.ForeignKey(
+        to="netbox_proxbox.ProxmoxEndpoint",
+        on_delete=models.CASCADE,
+        related_name="sdn_subnets",
+        null=True,
+        blank=True,
+        verbose_name=_("Proxmox endpoint"),
+    )
+    cluster_name = models.CharField(max_length=255)
+    zone_name = models.CharField(max_length=255, blank=True)
+    vnet_name = models.CharField(max_length=255)
+    subnet = models.CharField(max_length=128)
+    subnet_type = models.CharField(max_length=32, blank=True)
+    gateway = models.CharField(max_length=128, blank=True)
+    snat = models.BooleanField(default=False)
+    prefix = models.ForeignKey(
+        to="ipam.Prefix",
+        on_delete=models.SET_NULL,
+        related_name="+",
+        null=True,
+        blank=True,
+        verbose_name=_("NetBox prefix"),
+    )
+    skip_reason = models.TextField(blank=True)
+    status = models.CharField(
+        max_length=20,
+        choices=FirewallSyncStatusChoices,
+        default=FirewallSyncStatusChoices.ACTIVE,
+    )
+    raw_config = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        verbose_name = _("SDN Subnet")
+        verbose_name_plural = _("SDN Subnets")
+        ordering = ("endpoint", "cluster_name", "vnet_name", "subnet")
+        constraints = [
+            models.UniqueConstraint(
+                fields=["endpoint", "cluster_name", "vnet_name", "subnet"],
+                name="nbpx_sdnsubnet_unique_endpoint_cluster_vnet_subnet",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.cluster_name} / {self.vnet_name} / {self.subnet}"
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_proxbox:proxmoxsdnsubnet", args=[self.pk])
+
+
+class ProxmoxSdnBinding(NetBoxModel):
+    """SDN sync binding/status record for runtime rows and NetBox object links."""
+
+    endpoint = models.ForeignKey(
+        to="netbox_proxbox.ProxmoxEndpoint",
+        on_delete=models.CASCADE,
+        related_name="sdn_bindings",
+        null=True,
+        blank=True,
+        verbose_name=_("Proxmox endpoint"),
+    )
+    cluster_name = models.CharField(max_length=255)
+    source_type = models.CharField(max_length=64)
+    source_name = models.CharField(max_length=512)
+    node = models.CharField(max_length=255, blank=True)
+    zone_name = models.CharField(max_length=255, blank=True)
+    vnet_name = models.CharField(max_length=255, blank=True)
+    target_type = models.CharField(max_length=64, blank=True)
+    target_id = models.PositiveBigIntegerField(null=True, blank=True)
+    status = models.CharField(
+        max_length=64,
+        default=FirewallSyncStatusChoices.ACTIVE,
+    )
+    conflict_reason = models.TextField(blank=True)
+    raw_config = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        verbose_name = _("SDN Binding")
+        verbose_name_plural = _("SDN Bindings")
+        ordering = ("endpoint", "cluster_name", "source_type", "source_name")
+        constraints = [
+            models.UniqueConstraint(
+                fields=["endpoint", "cluster_name", "source_type", "source_name"],
+                name="nbpx_sdnbinding_unique_endpoint_cluster_source",
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.cluster_name} / {self.source_type} / {self.source_name}"
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_proxbox:proxmoxsdnbinding", args=[self.pk])

--- a/netbox_proxbox/navigation.py
+++ b/netbox_proxbox/navigation.py
@@ -262,6 +262,59 @@ sdn_fabrics_item = PluginMenuItem(
     ),
 )
 
+sdn_controllers_item = PluginMenuItem(
+    link="plugins:netbox_proxbox:proxmoxsdncontroller_list",
+    link_text="Controllers",
+    buttons=(
+        PluginMenuButton(
+            "plugins:netbox_proxbox:proxmoxsdncontroller_add",
+            "Add Controller",
+            "mdi mdi-plus",
+        ),
+    ),
+)
+
+sdn_zones_item = PluginMenuItem(
+    link="plugins:netbox_proxbox:proxmoxsdnzone_list",
+    link_text="Zones",
+    buttons=(
+        PluginMenuButton(
+            "plugins:netbox_proxbox:proxmoxsdnzone_add",
+            "Add Zone",
+            "mdi mdi-plus",
+        ),
+    ),
+)
+
+sdn_vnets_item = PluginMenuItem(
+    link="plugins:netbox_proxbox:proxmoxsdnvnet_list",
+    link_text="VNets",
+    buttons=(
+        PluginMenuButton(
+            "plugins:netbox_proxbox:proxmoxsdnvnet_add",
+            "Add VNet",
+            "mdi mdi-plus",
+        ),
+    ),
+)
+
+sdn_subnets_item = PluginMenuItem(
+    link="plugins:netbox_proxbox:proxmoxsdnsubnet_list",
+    link_text="Subnets",
+    buttons=(
+        PluginMenuButton(
+            "plugins:netbox_proxbox:proxmoxsdnsubnet_add",
+            "Add Subnet",
+            "mdi mdi-plus",
+        ),
+    ),
+)
+
+sdn_bindings_item = PluginMenuItem(
+    link="plugins:netbox_proxbox:proxmoxsdnbinding_list",
+    link_text="Bindings",
+)
+
 sdn_route_maps_item = PluginMenuItem(
     link="plugins:netbox_proxbox:proxmoxsdnroutemap_list",
     link_text="Route Maps",
@@ -359,6 +412,11 @@ menu = PluginMenu(
             "SDN",
             (
                 sdn_fabrics_item,
+                sdn_controllers_item,
+                sdn_zones_item,
+                sdn_vnets_item,
+                sdn_subnets_item,
+                sdn_bindings_item,
                 sdn_route_maps_item,
                 sdn_prefix_lists_item,
             ),

--- a/netbox_proxbox/sync_params.py
+++ b/netbox_proxbox/sync_params.py
@@ -17,6 +17,7 @@ except ImportError:  # pragma: no cover - compatibility for focused import stubs
         "sync_mode_node",
         "sync_mode_storage",
         "sync_mode_ip_address",
+        "sync_mode_sdn",
     )
 from netbox_proxbox.sync_types import (
     _TARGETED_VM_JOB_NAME_RE,
@@ -168,16 +169,20 @@ def _global_overwrites() -> dict[str, bool]:
 
 def _global_sync_modes() -> dict[str, str]:
     """Return sync modes from the global plugin settings singleton."""
+
+    def default_for(name: str) -> str:
+        return "disabled" if name == "sync_mode_sdn" else "always"
+
     try:
         from netbox_proxbox.models import ProxboxPluginSettings
 
         settings = ProxboxPluginSettings.get_solo()
         return {
-            name: str(getattr(settings, name, "always") or "always")
+            name: str(getattr(settings, name, default_for(name)) or default_for(name))
             for name in SYNC_MODE_FIELDS
         }
     except (ImportError, RuntimeError, AttributeError):
-        return {name: "always" for name in SYNC_MODE_FIELDS}
+        return {name: default_for(name) for name in SYNC_MODE_FIELDS}
 
 
 def effective_overwrites_for_endpoint(

--- a/netbox_proxbox/sync_stages.py
+++ b/netbox_proxbox/sync_stages.py
@@ -31,6 +31,7 @@ except ImportError:  # pragma: no cover - compatibility for focused import stubs
         "sync_mode_node",
         "sync_mode_storage",
         "sync_mode_ip_address",
+        "sync_mode_sdn",
     )
 try:
     from netbox_proxbox.constants import SYNC_MODE_HIERARCHY
@@ -76,6 +77,7 @@ if TYPE_CHECKING:
 _HEARTBEAT_SECONDS = 20.0
 _STAGE_RETRY_MAX = 2
 _STAGE_RETRY_DELAY = 8.0
+_SDN_SYNC_TYPE = getattr(SyncTypeChoices, "SDN", "sdn")
 try:
     from netbox_proxbox.netbox_bootstrap import BOOTSTRAP_ONLY_TAG_SLUG
 except ImportError:  # pragma: no cover - compatibility for focused import stubs
@@ -89,6 +91,14 @@ sync_mode_cluster = SyncModeChoices.ALWAYS
 sync_mode_node = SyncModeChoices.ALWAYS
 sync_mode_storage = SyncModeChoices.ALWAYS
 sync_mode_ip_address = SyncModeChoices.ALWAYS
+sync_mode_sdn = SyncModeChoices.DISABLED
+
+
+def _default_sync_mode(field_name: str) -> str:
+    if field_name == "sync_mode_sdn":
+        return getattr(SyncModeChoices, "DISABLED", "disabled")
+    return getattr(SyncModeChoices, "ALWAYS", "always")
+
 
 # Stages that are supplementary/optional: a failure logs a warning and the sync
 # continues.  Required stages (devices, VMs, storage, interfaces, IPs) are NOT
@@ -98,6 +108,7 @@ _SKIPPABLE_STAGES: frozenset[str] = frozenset(
         SyncTypeChoices.VIRTUAL_MACHINES_BACKUPS,  # "vm-backups"
         SyncTypeChoices.VIRTUAL_MACHINES_SNAPSHOTS,  # "vm-snapshots"
         SyncTypeChoices.TASK_HISTORY,  # "task-history"
+        _SDN_SYNC_TYPE,  # read-only SDN inventory; old clusters may not support it
     }
 )
 
@@ -106,16 +117,14 @@ def _set_sync_mode_vars(modes: dict[str, str]) -> None:
     """Update module-level sync-mode vars for the active endpoint scope."""
     for field_name in SYNC_MODE_FIELDS:
         globals()[field_name] = str(
-            modes.get(field_name) or getattr(SyncModeChoices, "ALWAYS", "always")
+            modes.get(field_name) or _default_sync_mode(field_name)
         )
 
 
 def _active_sync_modes() -> dict[str, str]:
     """Return the current module-level sync modes after parent-child cascade."""
     raw_modes = {
-        field_name: str(
-            globals().get(field_name) or getattr(SyncModeChoices, "ALWAYS", "always")
-        )
+        field_name: str(globals().get(field_name) or _default_sync_mode(field_name))
         for field_name in SYNC_MODE_FIELDS
     }
     return _effective_sync_modes(raw_modes)
@@ -124,9 +133,7 @@ def _active_sync_modes() -> dict[str, str]:
 def _resource_mode(raw_modes: dict[str, str], resource_type: str) -> str:
     """Return a normalized raw mode value for a resource type."""
     field_name = f"sync_mode_{resource_type}"
-    return str(
-        raw_modes.get(field_name) or getattr(SyncModeChoices, "ALWAYS", "always")
-    )
+    return str(raw_modes.get(field_name) or _default_sync_mode(field_name))
 
 
 def _vm_parent_disabled(raw_modes: dict[str, str]) -> bool:
@@ -230,6 +237,7 @@ def _stage_skip_reason(sync_type: str) -> str | None:
         SyncTypeChoices.STORAGE: "storage",
         SyncTypeChoices.VM_INTERFACES: "vm_interface",
         SyncTypeChoices.IP_ADDRESSES: "ip_address",
+        _SDN_SYNC_TYPE: "sdn",
     }
     resource_type = stage_resource_map.get(sync_type)
     if resource_type and _sync_mode_for_resource(resource_type) == disabled:

--- a/netbox_proxbox/sync_types.py
+++ b/netbox_proxbox/sync_types.py
@@ -7,6 +7,8 @@ import re
 
 from netbox_proxbox.choices import SyncTypeChoices
 
+_SDN_SYNC_TYPE = getattr(SyncTypeChoices, "SDN", "sdn")
+
 _SYNC_STAGE_ORDER: tuple[str, ...] = (
     SyncTypeChoices.DEVICES,
     SyncTypeChoices.STORAGE,
@@ -18,6 +20,7 @@ _SYNC_STAGE_ORDER: tuple[str, ...] = (
     SyncTypeChoices.NETWORK_INTERFACES,
     SyncTypeChoices.VM_INTERFACES,
     SyncTypeChoices.IP_ADDRESSES,
+    _SDN_SYNC_TYPE,
     SyncTypeChoices.REPLICATIONS,
     SyncTypeChoices.BACKUP_ROUTINES,
 )
@@ -37,6 +40,7 @@ _SYNC_TYPE_PATH: dict[str, str] = {
     SyncTypeChoices.NETWORK_INTERFACES: "dcim/devices/interfaces/create",
     SyncTypeChoices.VM_INTERFACES: "virtualization/virtual-machines/interfaces/create",
     SyncTypeChoices.IP_ADDRESSES: "virtualization/virtual-machines/interfaces/ip-address/create",
+    _SDN_SYNC_TYPE: "proxmox/sdn/create",
     SyncTypeChoices.BACKUP_ROUTINES: "proxmox/cluster/backup",
 }
 

--- a/netbox_proxbox/tables/__init__.py
+++ b/netbox_proxbox/tables/__init__.py
@@ -26,9 +26,14 @@ from netbox_proxbox.tables.firewall import (
     ProxmoxFirewallSecurityGroupTable,
 )
 from netbox_proxbox.tables.sdn import (
+    ProxmoxSdnBindingTable,
+    ProxmoxSdnControllerTable,
     ProxmoxSdnFabricTable,
     ProxmoxSdnRouteMapTable,
     ProxmoxSdnPrefixListTable,
+    ProxmoxSdnSubnetTable,
+    ProxmoxSdnVNetTable,
+    ProxmoxSdnZoneTable,
 )
 from netbox_proxbox.tables.datacenter import ProxmoxDatacenterCpuModelTable
 from netbox_proxbox.tables.cloud_image_template import CloudImageTemplateTable

--- a/netbox_proxbox/tables/sdn.py
+++ b/netbox_proxbox/tables/sdn.py
@@ -39,6 +39,167 @@ class ProxmoxSdnFabricTable(NetBoxTable):
         )
 
 
+class ProxmoxSdnControllerTable(NetBoxTable):
+    controller_name = tables.Column(linkify=True)
+    endpoint = tables.Column(linkify=True)
+    status = columns.ChoiceFieldColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = models.ProxmoxSdnController
+        fields = (
+            "pk",
+            "id",
+            "controller_name",
+            "cluster_name",
+            "endpoint",
+            "controller_type",
+            "asn",
+            "status",
+            "tags",
+            "created",
+            "last_updated",
+        )
+        default_columns = (
+            "controller_name",
+            "cluster_name",
+            "endpoint",
+            "controller_type",
+            "asn",
+            "status",
+        )
+
+
+class ProxmoxSdnZoneTable(NetBoxTable):
+    zone_name = tables.Column(linkify=True)
+    endpoint = tables.Column(linkify=True)
+    status = columns.ChoiceFieldColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = models.ProxmoxSdnZone
+        fields = (
+            "pk",
+            "id",
+            "zone_name",
+            "cluster_name",
+            "endpoint",
+            "zone_type",
+            "controller",
+            "vrf_vxlan",
+            "status",
+            "tags",
+            "created",
+            "last_updated",
+        )
+        default_columns = (
+            "zone_name",
+            "cluster_name",
+            "endpoint",
+            "zone_type",
+            "controller",
+            "vrf_vxlan",
+            "status",
+        )
+
+
+class ProxmoxSdnVNetTable(NetBoxTable):
+    vnet_name = tables.Column(linkify=True)
+    endpoint = tables.Column(linkify=True)
+    l2vpn = tables.Column(linkify=True)
+    status = columns.ChoiceFieldColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = models.ProxmoxSdnVNet
+        fields = (
+            "pk",
+            "id",
+            "vnet_name",
+            "zone_name",
+            "cluster_name",
+            "endpoint",
+            "vnet_type",
+            "tag",
+            "l2vpn",
+            "status",
+            "tags",
+            "created",
+            "last_updated",
+        )
+        default_columns = (
+            "vnet_name",
+            "zone_name",
+            "cluster_name",
+            "endpoint",
+            "vnet_type",
+            "tag",
+            "l2vpn",
+            "status",
+        )
+
+
+class ProxmoxSdnSubnetTable(NetBoxTable):
+    subnet = tables.Column(linkify=True)
+    endpoint = tables.Column(linkify=True)
+    prefix = tables.Column(linkify=True)
+    status = columns.ChoiceFieldColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = models.ProxmoxSdnSubnet
+        fields = (
+            "pk",
+            "id",
+            "subnet",
+            "vnet_name",
+            "zone_name",
+            "cluster_name",
+            "endpoint",
+            "prefix",
+            "status",
+            "tags",
+            "created",
+            "last_updated",
+        )
+        default_columns = (
+            "subnet",
+            "vnet_name",
+            "zone_name",
+            "cluster_name",
+            "endpoint",
+            "prefix",
+            "status",
+        )
+
+
+class ProxmoxSdnBindingTable(NetBoxTable):
+    source_name = tables.Column(linkify=True)
+    endpoint = tables.Column(linkify=True)
+
+    class Meta(NetBoxTable.Meta):
+        model = models.ProxmoxSdnBinding
+        fields = (
+            "pk",
+            "id",
+            "source_type",
+            "source_name",
+            "cluster_name",
+            "endpoint",
+            "target_type",
+            "target_id",
+            "status",
+            "tags",
+            "created",
+            "last_updated",
+        )
+        default_columns = (
+            "source_type",
+            "source_name",
+            "cluster_name",
+            "endpoint",
+            "target_type",
+            "target_id",
+            "status",
+        )
+
+
 class ProxmoxSdnRouteMapTable(NetBoxTable):
     name = tables.Column(linkify=True)
     endpoint = tables.Column(linkify=True)

--- a/netbox_proxbox/urls.py
+++ b/netbox_proxbox/urls.py
@@ -214,6 +214,46 @@ urlpatterns = [
         include(get_model_urls("netbox_proxbox", "proxmoxsdnfabric", detail=False)),
     ),
     path(
+        "sdn/controllers/<int:pk>/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdncontroller")),
+    ),
+    path(
+        "sdn/controllers/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdncontroller", detail=False)),
+    ),
+    path(
+        "sdn/zones/<int:pk>/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdnzone")),
+    ),
+    path(
+        "sdn/zones/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdnzone", detail=False)),
+    ),
+    path(
+        "sdn/vnets/<int:pk>/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdnvnet")),
+    ),
+    path(
+        "sdn/vnets/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdnvnet", detail=False)),
+    ),
+    path(
+        "sdn/subnets/<int:pk>/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdnsubnet")),
+    ),
+    path(
+        "sdn/subnets/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdnsubnet", detail=False)),
+    ),
+    path(
+        "sdn/bindings/<int:pk>/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdnbinding")),
+    ),
+    path(
+        "sdn/bindings/",
+        include(get_model_urls("netbox_proxbox", "proxmoxsdnbinding", detail=False)),
+    ),
+    path(
         "sdn/route-maps/<int:pk>/",
         include(get_model_urls("netbox_proxbox", "proxmoxsdnroutemap")),
     ),
@@ -379,6 +419,7 @@ urlpatterns = [
 try:
     import netbox_pdm.views as _netbox_pdm_views  # noqa: F401 — triggers @register_model_view
     from netbox_proxbox.views.endpoints import pdm as _pdm_endpoint_views  # noqa: F401 — registers PDMEndpointView + PDMEndpointSyncNowView
+
     urlpatterns += [
         path(
             "pdm/endpoints/",

--- a/netbox_proxbox/views/__init__.py
+++ b/netbox_proxbox/views/__init__.py
@@ -55,6 +55,14 @@ from .firewall import (
     ProxmoxFirewallSecurityGroupView,
 )
 from .sdn import (
+    ProxmoxSdnBindingDeleteView,
+    ProxmoxSdnBindingEditView,
+    ProxmoxSdnBindingListView,
+    ProxmoxSdnBindingView,
+    ProxmoxSdnControllerDeleteView,
+    ProxmoxSdnControllerEditView,
+    ProxmoxSdnControllerListView,
+    ProxmoxSdnControllerView,
     ProxmoxSdnFabricDeleteView,
     ProxmoxSdnFabricEditView,
     ProxmoxSdnFabricListView,
@@ -67,6 +75,18 @@ from .sdn import (
     ProxmoxSdnRouteMapEditView,
     ProxmoxSdnRouteMapListView,
     ProxmoxSdnRouteMapView,
+    ProxmoxSdnSubnetDeleteView,
+    ProxmoxSdnSubnetEditView,
+    ProxmoxSdnSubnetListView,
+    ProxmoxSdnSubnetView,
+    ProxmoxSdnVNetDeleteView,
+    ProxmoxSdnVNetEditView,
+    ProxmoxSdnVNetListView,
+    ProxmoxSdnVNetView,
+    ProxmoxSdnZoneDeleteView,
+    ProxmoxSdnZoneEditView,
+    ProxmoxSdnZoneListView,
+    ProxmoxSdnZoneView,
 )
 from .datacenter import (
     ProxmoxDatacenterCpuModelDeleteView,

--- a/netbox_proxbox/views/endpoints/pdm.py
+++ b/netbox_proxbox/views/endpoints/pdm.py
@@ -1,4 +1,5 @@
 """PDMEndpoint detail and Sync Now views for netbox-proxbox."""
+
 from __future__ import annotations
 
 import logging
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 # "Discovered Remotes" table into the page context.
 # ---------------------------------------------------------------------------
 
+
 @register_model_view(PDMEndpoint)
 class PDMEndpointView(generic.ObjectView):
     """Detail view for a PDM endpoint with the Discovered Remotes table."""
@@ -52,6 +54,7 @@ class PDMEndpointView(generic.ObjectView):
 # ---------------------------------------------------------------------------
 # Sync Now — calls the PDM REST API directly and updates PDMRemote rows.
 # ---------------------------------------------------------------------------
+
 
 @register_model_view(PDMEndpoint, "sync_now", path="sync-now")
 class PDMEndpointSyncNowView(_ProxboxSyncViewBase):
@@ -101,7 +104,8 @@ class PDMEndpointSyncNowView(_ProxboxSyncViewBase):
                 request,
                 _(
                     "Synced %(count)d remote(s) from %(name)s with %(nerr)d error(s): %(errors)s"
-                ) % {
+                )
+                % {
                     "count": synced,
                     "name": endpoint.name or host,
                     "nerr": len(errors),
@@ -121,6 +125,7 @@ class PDMEndpointSyncNowView(_ProxboxSyncViewBase):
 # ---------------------------------------------------------------------------
 # Internal helpers — not views, not exported.
 # ---------------------------------------------------------------------------
+
 
 def _sync_pdm_remotes(endpoint: PDMEndpoint) -> tuple[int, list[str]]:
     """Call PDM /remotes, upsert PDMRemote rows, return (synced_count, errors)."""
@@ -158,9 +163,7 @@ def _sync_pdm_remotes(endpoint: PDMEndpoint) -> tuple[int, list[str]]:
             f"SSL error connecting to PDM at {host}:{port}: {exc}"
         ) from exc
     except requests.exceptions.ConnectionError as exc:
-        raise RuntimeError(
-            f"Cannot connect to PDM at {host}:{port}: {exc}"
-        ) from exc
+        raise RuntimeError(f"Cannot connect to PDM at {host}:{port}: {exc}") from exc
     except requests.exceptions.Timeout:
         raise RuntimeError(
             f"Timeout connecting to PDM at {host}:{port} after {timeout}s"
@@ -194,9 +197,7 @@ def _sync_pdm_remotes(endpoint: PDMEndpoint) -> tuple[int, list[str]]:
     return synced, errors
 
 
-def _upsert_pdm_remote(
-    endpoint: PDMEndpoint, data: dict, now: object
-) -> PDMRemote:
+def _upsert_pdm_remote(endpoint: PDMEndpoint, data: dict, now: object) -> PDMRemote:
     """Create or update one PDMRemote from raw PDM API data."""
     remote_name: str = data.get("id") or data.get("name") or ""
     remote_type: str = (data.get("type") or "pve").lower()
@@ -251,8 +252,7 @@ def _find_proxmox_endpoint(hostname: str):
     from netbox_proxbox.models import ProxmoxEndpoint
 
     return ProxmoxEndpoint.objects.filter(
-        Q(domain=hostname)
-        | Q(ip_address__address__startswith=hostname + "/")
+        Q(domain=hostname) | Q(ip_address__address__startswith=hostname + "/")
     ).first()
 
 
@@ -264,6 +264,5 @@ def _find_pbs_endpoint(hostname: str):
         return None
 
     return PBSEndpoint.objects.filter(
-        Q(domain=hostname)
-        | Q(ip_address__address__startswith=hostname + "/")
+        Q(domain=hostname) | Q(ip_address__address__startswith=hostname + "/")
     ).first()

--- a/netbox_proxbox/views/sdn.py
+++ b/netbox_proxbox/views/sdn.py
@@ -13,6 +13,11 @@ from utilities.views import register_model_view
 from netbox_proxbox import filtersets, forms, models, tables
 
 _FABRIC_QS = models.ProxmoxSdnFabric.objects.select_related("endpoint")
+_CONTROLLER_QS = models.ProxmoxSdnController.objects.select_related("endpoint")
+_ZONE_QS = models.ProxmoxSdnZone.objects.select_related("endpoint")
+_VNET_QS = models.ProxmoxSdnVNet.objects.select_related("endpoint", "l2vpn")
+_SUBNET_QS = models.ProxmoxSdnSubnet.objects.select_related("endpoint", "prefix")
+_BINDING_QS = models.ProxmoxSdnBinding.objects.select_related("endpoint")
 _ROUTEMAP_QS = models.ProxmoxSdnRouteMap.objects.select_related("endpoint")
 _PREFIXLIST_QS = models.ProxmoxSdnPrefixList.objects.select_related("endpoint")
 
@@ -44,6 +49,151 @@ class ProxmoxSdnFabricEditView(ObjectEditView):
 @register_model_view(models.ProxmoxSdnFabric, "delete")
 class ProxmoxSdnFabricDeleteView(ObjectDeleteView):
     queryset = _FABRIC_QS
+
+
+# ── ProxmoxSdnController ─────────────────────────────────────────────────────
+
+
+@register_model_view(models.ProxmoxSdnController, "list", path="", detail=False)
+class ProxmoxSdnControllerListView(ObjectListView):
+    queryset = _CONTROLLER_QS
+    table = tables.ProxmoxSdnControllerTable
+    filterset = filtersets.ProxmoxSdnControllerFilterSet
+    filterset_form = forms.ProxmoxSdnControllerFilterForm
+    actions = {}
+
+
+@register_model_view(models.ProxmoxSdnController)
+class ProxmoxSdnControllerView(ObjectView):
+    queryset = _CONTROLLER_QS
+
+
+@register_model_view(models.ProxmoxSdnController, "add", detail=False)
+@register_model_view(models.ProxmoxSdnController, "edit")
+class ProxmoxSdnControllerEditView(ObjectEditView):
+    queryset = _CONTROLLER_QS
+    form = forms.ProxmoxSdnControllerForm
+
+
+@register_model_view(models.ProxmoxSdnController, "delete")
+class ProxmoxSdnControllerDeleteView(ObjectDeleteView):
+    queryset = _CONTROLLER_QS
+
+
+# ── ProxmoxSdnZone ───────────────────────────────────────────────────────────
+
+
+@register_model_view(models.ProxmoxSdnZone, "list", path="", detail=False)
+class ProxmoxSdnZoneListView(ObjectListView):
+    queryset = _ZONE_QS
+    table = tables.ProxmoxSdnZoneTable
+    filterset = filtersets.ProxmoxSdnZoneFilterSet
+    filterset_form = forms.ProxmoxSdnZoneFilterForm
+    actions = {}
+
+
+@register_model_view(models.ProxmoxSdnZone)
+class ProxmoxSdnZoneView(ObjectView):
+    queryset = _ZONE_QS
+
+
+@register_model_view(models.ProxmoxSdnZone, "add", detail=False)
+@register_model_view(models.ProxmoxSdnZone, "edit")
+class ProxmoxSdnZoneEditView(ObjectEditView):
+    queryset = _ZONE_QS
+    form = forms.ProxmoxSdnZoneForm
+
+
+@register_model_view(models.ProxmoxSdnZone, "delete")
+class ProxmoxSdnZoneDeleteView(ObjectDeleteView):
+    queryset = _ZONE_QS
+
+
+# ── ProxmoxSdnVNet ───────────────────────────────────────────────────────────
+
+
+@register_model_view(models.ProxmoxSdnVNet, "list", path="", detail=False)
+class ProxmoxSdnVNetListView(ObjectListView):
+    queryset = _VNET_QS
+    table = tables.ProxmoxSdnVNetTable
+    filterset = filtersets.ProxmoxSdnVNetFilterSet
+    filterset_form = forms.ProxmoxSdnVNetFilterForm
+    actions = {}
+
+
+@register_model_view(models.ProxmoxSdnVNet)
+class ProxmoxSdnVNetView(ObjectView):
+    queryset = _VNET_QS
+
+
+@register_model_view(models.ProxmoxSdnVNet, "add", detail=False)
+@register_model_view(models.ProxmoxSdnVNet, "edit")
+class ProxmoxSdnVNetEditView(ObjectEditView):
+    queryset = _VNET_QS
+    form = forms.ProxmoxSdnVNetForm
+
+
+@register_model_view(models.ProxmoxSdnVNet, "delete")
+class ProxmoxSdnVNetDeleteView(ObjectDeleteView):
+    queryset = _VNET_QS
+
+
+# ── ProxmoxSdnSubnet ─────────────────────────────────────────────────────────
+
+
+@register_model_view(models.ProxmoxSdnSubnet, "list", path="", detail=False)
+class ProxmoxSdnSubnetListView(ObjectListView):
+    queryset = _SUBNET_QS
+    table = tables.ProxmoxSdnSubnetTable
+    filterset = filtersets.ProxmoxSdnSubnetFilterSet
+    filterset_form = forms.ProxmoxSdnSubnetFilterForm
+    actions = {}
+
+
+@register_model_view(models.ProxmoxSdnSubnet)
+class ProxmoxSdnSubnetView(ObjectView):
+    queryset = _SUBNET_QS
+
+
+@register_model_view(models.ProxmoxSdnSubnet, "add", detail=False)
+@register_model_view(models.ProxmoxSdnSubnet, "edit")
+class ProxmoxSdnSubnetEditView(ObjectEditView):
+    queryset = _SUBNET_QS
+    form = forms.ProxmoxSdnSubnetForm
+
+
+@register_model_view(models.ProxmoxSdnSubnet, "delete")
+class ProxmoxSdnSubnetDeleteView(ObjectDeleteView):
+    queryset = _SUBNET_QS
+
+
+# ── ProxmoxSdnBinding ────────────────────────────────────────────────────────
+
+
+@register_model_view(models.ProxmoxSdnBinding, "list", path="", detail=False)
+class ProxmoxSdnBindingListView(ObjectListView):
+    queryset = _BINDING_QS
+    table = tables.ProxmoxSdnBindingTable
+    filterset = filtersets.ProxmoxSdnBindingFilterSet
+    filterset_form = forms.ProxmoxSdnBindingFilterForm
+    actions = {}
+
+
+@register_model_view(models.ProxmoxSdnBinding)
+class ProxmoxSdnBindingView(ObjectView):
+    queryset = _BINDING_QS
+
+
+@register_model_view(models.ProxmoxSdnBinding, "add", detail=False)
+@register_model_view(models.ProxmoxSdnBinding, "edit")
+class ProxmoxSdnBindingEditView(ObjectEditView):
+    queryset = _BINDING_QS
+    form = forms.ProxmoxSdnBindingForm
+
+
+@register_model_view(models.ProxmoxSdnBinding, "delete")
+class ProxmoxSdnBindingDeleteView(ObjectDeleteView):
+    queryset = _BINDING_QS
 
 
 # ── ProxmoxSdnRouteMap ───────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -620,6 +620,7 @@ def load_plugin_module(
         NETWORK_INTERFACES = "network-interfaces"
         VM_INTERFACES = "vm-interfaces"
         IP_ADDRESSES = "ip-addresses"
+        SDN = "sdn"
         ALL = "all"
 
     nbp_choices.SyncTypeChoices = _SyncTypeChoices

--- a/tests/test_api_sdn.py
+++ b/tests/test_api_sdn.py
@@ -21,8 +21,13 @@ def test_sdn_serializer_file_exists():
     assert (REPO_ROOT / "netbox_proxbox/api/serializers/sdn.py").exists()
 
 
-def test_sdn_serializer_exports_all_three_classes():
+def test_sdn_serializer_exports_all_sdn_classes():
     content = _read("netbox_proxbox/api/serializers/sdn.py")
+    assert "class ProxmoxSdnControllerSerializer" in content
+    assert "class ProxmoxSdnZoneSerializer" in content
+    assert "class ProxmoxSdnVNetSerializer" in content
+    assert "class ProxmoxSdnSubnetSerializer" in content
+    assert "class ProxmoxSdnBindingSerializer" in content
     assert "class ProxmoxSdnFabricSerializer" in content
     assert "class ProxmoxSdnRouteMapSerializer" in content
     assert "class ProxmoxSdnPrefixListSerializer" in content
@@ -45,6 +50,11 @@ def test_sdn_serializer_includes_status_choice_field():
 
 def test_serializers_init_exports_sdn_serializers():
     content = _read("netbox_proxbox/api/serializers/__init__.py")
+    assert "ProxmoxSdnControllerSerializer" in content
+    assert "ProxmoxSdnZoneSerializer" in content
+    assert "ProxmoxSdnVNetSerializer" in content
+    assert "ProxmoxSdnSubnetSerializer" in content
+    assert "ProxmoxSdnBindingSerializer" in content
     assert "ProxmoxSdnFabricSerializer" in content
     assert "ProxmoxSdnRouteMapSerializer" in content
     assert "ProxmoxSdnPrefixListSerializer" in content
@@ -57,6 +67,11 @@ def test_serializers_init_exports_sdn_serializers():
 
 def test_sdn_viewsets_defined_in_views():
     content = _read("netbox_proxbox/api/views.py")
+    assert "ProxmoxSdnControllerViewSet" in content
+    assert "ProxmoxSdnZoneViewSet" in content
+    assert "ProxmoxSdnVNetViewSet" in content
+    assert "ProxmoxSdnSubnetViewSet" in content
+    assert "ProxmoxSdnBindingViewSet" in content
     assert "ProxmoxSdnFabricViewSet" in content
     assert "ProxmoxSdnRouteMapViewSet" in content
     assert "ProxmoxSdnPrefixListViewSet" in content
@@ -79,6 +94,11 @@ def test_sdn_viewsets_select_related_endpoint():
 
 def test_sdn_routes_registered_in_api_urls():
     content = _read("netbox_proxbox/api/urls.py")
+    assert "sdn-controllers" in content
+    assert "sdn-zones" in content
+    assert "sdn-vnets" in content
+    assert "sdn-subnets" in content
+    assert "sdn-bindings" in content
     assert "sdn-fabrics" in content
     assert "sdn-route-maps" in content
     assert "sdn-prefix-lists" in content
@@ -86,6 +106,11 @@ def test_sdn_routes_registered_in_api_urls():
 
 def test_sdn_router_basenames_correct():
     content = _read("netbox_proxbox/api/urls.py")
+    assert "proxmoxsdncontroller" in content
+    assert "proxmoxsdnzone" in content
+    assert "proxmoxsdnvnet" in content
+    assert "proxmoxsdnsubnet" in content
+    assert "proxmoxsdnbinding" in content
     assert "proxmoxsdnfabric" in content
     assert "proxmoxsdnroutemap" in content
     assert "proxmoxsdnprefixlist" in content

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1217,10 +1217,9 @@ def test_proxbox_sync_job_persists_endpoint_runtime_breakdown(
 
     for entry in endpoint_runtimes:
         labels = [phase["label"] for phase in entry["phases"]]
-        assert labels[:4] == [
+        assert labels[:3] == [
             "Cluster/node sync",
             "Firewall sync",
-            "SDN sync",
             "Datacenter sync",
         ]
         assert st.DEVICES in labels
@@ -1527,7 +1526,11 @@ def test_proxbox_sync_job_run_all_invokes_each_stage_stream(
     ProxboxSyncJob.run(job, sync_types=[st.ALL])
     assert calls == 12
     stages = job.job.data["proxbox_sync"]["response"]["stages"]
-    assert len(stages) == 12
+    assert len(stages) == 13
+    assert any(
+        stage["sync_type"] == "sdn" and stage["result_summary"].get("skipped") is True
+        for stage in stages
+    )
     assert {s["sync_type"] for s in stages} == {
         st.DEVICES,
         st.STORAGE,
@@ -1540,6 +1543,7 @@ def test_proxbox_sync_job_run_all_invokes_each_stage_stream(
         st.NETWORK_INTERFACES,
         st.VM_INTERFACES,
         st.IP_ADDRESSES,
+        "sdn",
         st.BACKUP_ROUTINES,
     }
 

--- a/tests/test_static_guardrails.py
+++ b/tests/test_static_guardrails.py
@@ -93,7 +93,7 @@ def test_deletion_request_viewset_is_read_only():
     # The viewset class for DeletionRequest must restrict http_method_names to
     # read-only methods (no POST, PUT, PATCH, DELETE allowed via REST API).
     assert 'http_method_names = ["get", "head", "options"]' in content, (
-        "DeletionRequest viewset must set http_method_names=[\"get\",\"head\",\"options\"] "
+        'DeletionRequest viewset must set http_method_names=["get","head","options"] '
         "to prevent REST-driven creation, update, or deletion"
     )
 
@@ -106,10 +106,14 @@ def test_deletion_request_viewset_is_read_only():
 def test_models_contain_no_exec():
     # Security assertion: scans source text to ensure exec() is absent.
     content = _read("netbox_proxbox/models/__init__.py")
-    assert "exec(" not in content, "netbox_proxbox/models/__init__.py must not use exec()"
+    assert "exec(" not in content, (
+        "netbox_proxbox/models/__init__.py must not use exec()"
+    )
 
 
 def test_views_contain_no_innerHTML():
     # Security assertion: scans source text to ensure XSS sink is absent.
     content = _read("netbox_proxbox/api/views.py")
-    assert "innerHTML" not in content, "netbox_proxbox/api/views.py must not use innerHTML"
+    assert "innerHTML" not in content, (
+        "netbox_proxbox/api/views.py must not use innerHTML"
+    )

--- a/tests/test_sync_modes.py
+++ b/tests/test_sync_modes.py
@@ -212,6 +212,7 @@ class TestSyncModeConstants:
             "node",
             "storage",
             "ip_address",
+            "sdn",
         }
         assert expected <= set(constants.SYNC_MODE_RESOURCE_TYPES)
 
@@ -226,6 +227,7 @@ class TestSyncModeConstants:
             "sync_mode_node",
             "sync_mode_storage",
             "sync_mode_ip_address",
+            "sync_mode_sdn",
         }
         assert expected <= set(constants.SYNC_MODE_FIELDS)
 
@@ -258,6 +260,14 @@ class TestSyncStagesDefaults:
     def test_sync_mode_ip_address_default_is_always(self, sync_stages_module):
         assert sync_stages_module.sync_mode_ip_address == "always"
 
+    def test_sync_mode_sdn_default_is_disabled(self, sync_stages_module):
+        assert sync_stages_module.sync_mode_sdn == "disabled"
+
+    def test_all_stages_include_sdn_after_ip_addresses(self, sync_stages_module):
+        stages = sync_stages_module.expanded_sync_stages(["all"])
+        assert "sdn" in stages
+        assert stages.index("ip-addresses") < stages.index("sdn")
+
 
 # ── VM whole-stage gating ──────────────────────────────────────────────────────
 
@@ -287,6 +297,15 @@ class TestVMStageSkipReason:
             m._stage_skip_reason(m.SyncTypeChoices.VIRTUAL_MACHINES)
             == "sync_mode_vm=disabled and sync_mode_vm_template=disabled"
         )
+
+    def test_sdn_stage_skipped_by_default(self, sync_stages_module):
+        m = sync_stages_module
+        assert m._stage_skip_reason("sdn") == "sync_mode_sdn=disabled"
+
+    def test_sdn_stage_runs_when_enabled(self, sync_stages_module):
+        m = sync_stages_module
+        m.sync_mode_sdn = "always"
+        assert m._stage_skip_reason("sdn") is None
 
 
 # ── Bootstrap-only helpers ─────────────────────────────────────────────────────

--- a/tests/test_tenant_name_regex.py
+++ b/tests/test_tenant_name_regex.py
@@ -209,9 +209,7 @@ def test_tenant_from_cluster_inherits_global(sync_params_module):
 
 def test_tenant_from_cluster_endpoint_override(sync_params_module):
     sync_params_module._stubs["global_cluster_enabled"] = True
-    sync_params_module._stubs["endpoints_by_pk"] = {
-        7: _endpoint(cluster_enable=False)
-    }
+    sync_params_module._stubs["endpoints_by_pk"] = {7: _endpoint(cluster_enable=False)}
 
     enabled = sync_params_module.effective_tenant_from_cluster_for_endpoint(7)
 

--- a/tests/test_vm_template_model.py
+++ b/tests/test_vm_template_model.py
@@ -228,6 +228,7 @@ class TestSyncModeFieldsOnModels:
         "sync_mode_node",
         "sync_mode_storage",
         "sync_mode_ip_address",
+        "sync_mode_sdn",
     ]
 
     def _load_model_file(self, monkeypatch, filename: str, class_name: str):


### PR DESCRIPTION
## Summary

Closes #594.

Adds optional, read-only Proxmox SDN sync support on the NetBox plugin side.

- Adds `sync_mode_sdn`, defaulting to `disabled`, with per-endpoint override support.
- Includes the SDN stage in `All` after VM interface/IP stages, but skips it until the effective SDN mode allows it.
- Removes the previous unconditional SDN refresh from the main job pre-stage path.
- Adds SDN inventory models, migration, serializers, API routes, UI routes, forms, tables, filters, navigation, and docs for controllers, zones, VNets, subnets, bindings, fabrics, route maps, and prefix lists.
- Documents the read-only NetBox mapping to `L2VPN`, `L2VPNTermination`, `RouteTarget`, and `Prefix` objects.

## Validation

- `uv run ruff check <touched files>`
- `uv run pytest tests/test_sync_modes.py tests/test_vm_template_model.py tests/test_api_sdn.py -q`
- `uv run pytest tests/test_jobs.py::test_proxbox_sync_job_run_all_invokes_each_stage_stream tests/test_sync_modes.py tests/test_sync_mode_forwarding.py tests/test_sync_mode_cascade.py tests/test_ip_sync_mode_gate.py -q`
- `uv run python -m compileall netbox_proxbox tests`
- `uv run ty check proxbox_cli`