### PR TITLE
Fix SDN migration dependencies for NetBox 4.5

### DIFF
--- a/netbox_proxbox/migrations/0055_sdn_sync_controls_and_inventory.py
+++ b/netbox_proxbox/migrations/0055_sdn_sync_controls_and_inventory.py
@@ -71,9 +71,9 @@ def _status_field():
 class Migration(migrations.Migration):
     dependencies = [
         ("extras", "0134_owner"),
-        ("ipam", "0089_default_ordering_indexes"),
+        ("ipam", "0086_gfk_indexes"),
         ("netbox_proxbox", "0054_proxmoxendpoint_ssh_credential_source"),
-        ("vpn", "0012_default_ordering_indexes"),
+        ("vpn", "0011_add_comments_to_organizationalmodel"),
     ]
 
     operations = [

--- a/tests/test_sdn_migration_compatibility.py
+++ b/tests/test_sdn_migration_compatibility.py
@@ -1,0 +1,36 @@
+"""Regression tests for SDN migration compatibility with supported NetBox versions."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SDN_MIGRATION = (
+    REPO_ROOT / "netbox_proxbox/migrations/0055_sdn_sync_controls_and_inventory.py"
+)
+
+
+def _migration_dependencies(path: Path) -> list[tuple[str, str]]:
+    module = ast.parse(path.read_text(encoding="utf-8"))
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "Migration":
+            for statement in node.body:
+                if not isinstance(statement, ast.Assign):
+                    continue
+                if any(
+                    isinstance(target, ast.Name) and target.id == "dependencies"
+                    for target in statement.targets
+                ):
+                    return ast.literal_eval(statement.value)
+    raise AssertionError(f"Migration.dependencies not found in {path}")
+
+
+def test_sdn_migration_uses_netbox_45_compatible_dependency_parents() -> None:
+    dependencies = _migration_dependencies(SDN_MIGRATION)
+
+    assert ("ipam", "0086_gfk_indexes") in dependencies
+    assert ("vpn", "0011_add_comments_to_organizationalmodel") in dependencies
+    assert ("ipam", "0089_default_ordering_indexes") not in dependencies
+    assert ("vpn", "0012_default_ordering_indexes") not in dependencies


### PR DESCRIPTION
## Summary
- Lower SDN migration dependencies to NetBox 4.5-compatible ipam/vpn parents.
- Add a regression test that rejects NetBox 4.6-only migration parents for the SDN migration.

## Verification
- uv run pytest tests/test_sdn_migration_compatibility.py -q
- uv run ruff check netbox_proxbox/migrations/0055_sdn_sync_controls_and_inventory.py tests/test_sdn_migration_compatibility.py
- uv run ruff format --check netbox_proxbox/migrations/0055_sdn_sync_controls_and_inventory.py tests/test_sdn_migration_compatibility.py
- Verified netboxcommunity/netbox:v4.5.8 contains ipam.0086_gfk_indexes and vpn.0011_add_comments_to_organizationalmodel, but not the newer default-ordering migrations.